### PR TITLE
fix: grant write permission and token for README auto-commit in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,8 +8,12 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Pixi
         run: |


### PR DESCRIPTION
## Summary

- Add `permissions: contents: write` to the CI job so `github-actions[bot]` can push
- Pass `secrets.GITHUB_TOKEN` to `actions/checkout` so the remote URL is authenticated

## Root cause

The default `GITHUB_TOKEN` only has read access unless explicitly granted write, causing the `git push` in the "Commit updated README" step to fail with a 403.