### PR TITLE
refactor: update return types in DataFrame and Series methods to improve type consistency

### DIFF
--- a/bison/dataframe.mojo
+++ b/bison/dataframe.mojo
@@ -81,16 +81,16 @@ struct DataFrame(Copyable, Movable):
     fn ndim(self) -> Int:
         return 2
 
-    fn dtypes(self) raises -> PythonObject:
+    fn dtypes(self) raises -> Series:
         _not_implemented("DataFrame.dtypes")
-        return PythonObject(None)
+        return Series(PythonObject(None))
 
     fn info(self) raises:
         _not_implemented("DataFrame.info")
 
-    fn memory_usage(self, deep: Bool = False) raises -> PythonObject:
+    fn memory_usage(self, deep: Bool = False) raises -> Series:
         _not_implemented("DataFrame.memory_usage")
-        return PythonObject(None)
+        return Series(PythonObject(None))
 
     # ------------------------------------------------------------------
     # Selection / indexing
@@ -131,49 +131,49 @@ struct DataFrame(Copyable, Movable):
     # Aggregation
     # ------------------------------------------------------------------
 
-    fn sum(self, axis: Int = 0, skipna: Bool = True) raises -> PythonObject:
+    fn sum(self, axis: Int = 0, skipna: Bool = True) raises -> Series:
         _not_implemented("DataFrame.sum")
-        return PythonObject(None)
+        return Series(PythonObject(None))
 
-    fn mean(self, axis: Int = 0, skipna: Bool = True) raises -> PythonObject:
+    fn mean(self, axis: Int = 0, skipna: Bool = True) raises -> Series:
         _not_implemented("DataFrame.mean")
-        return PythonObject(None)
+        return Series(PythonObject(None))
 
-    fn median(self, axis: Int = 0, skipna: Bool = True) raises -> PythonObject:
+    fn median(self, axis: Int = 0, skipna: Bool = True) raises -> Series:
         _not_implemented("DataFrame.median")
-        return PythonObject(None)
+        return Series(PythonObject(None))
 
-    fn min(self, axis: Int = 0, skipna: Bool = True) raises -> PythonObject:
+    fn min(self, axis: Int = 0, skipna: Bool = True) raises -> Series:
         _not_implemented("DataFrame.min")
-        return PythonObject(None)
+        return Series(PythonObject(None))
 
-    fn max(self, axis: Int = 0, skipna: Bool = True) raises -> PythonObject:
+    fn max(self, axis: Int = 0, skipna: Bool = True) raises -> Series:
         _not_implemented("DataFrame.max")
-        return PythonObject(None)
+        return Series(PythonObject(None))
 
-    fn std(self, axis: Int = 0, ddof: Int = 1, skipna: Bool = True) raises -> PythonObject:
+    fn std(self, axis: Int = 0, ddof: Int = 1, skipna: Bool = True) raises -> Series:
         _not_implemented("DataFrame.std")
-        return PythonObject(None)
+        return Series(PythonObject(None))
 
-    fn var(self, axis: Int = 0, ddof: Int = 1, skipna: Bool = True) raises -> PythonObject:
+    fn var(self, axis: Int = 0, ddof: Int = 1, skipna: Bool = True) raises -> Series:
         _not_implemented("DataFrame.var")
-        return PythonObject(None)
+        return Series(PythonObject(None))
 
-    fn count(self, axis: Int = 0) raises -> PythonObject:
+    fn count(self, axis: Int = 0) raises -> Series:
         _not_implemented("DataFrame.count")
-        return PythonObject(None)
+        return Series(PythonObject(None))
 
-    fn nunique(self, axis: Int = 0) raises -> PythonObject:
+    fn nunique(self, axis: Int = 0) raises -> Series:
         _not_implemented("DataFrame.nunique")
-        return PythonObject(None)
+        return Series(PythonObject(None))
 
     fn describe(self, include: Optional[PythonObject] = None, exclude: Optional[PythonObject] = None) raises -> DataFrame:
         _not_implemented("DataFrame.describe")
         return DataFrame(self._pd_df)
 
-    fn quantile(self, q: Float64 = 0.5, axis: Int = 0) raises -> PythonObject:
+    fn quantile(self, q: Float64 = 0.5, axis: Int = 0) raises -> Series:
         _not_implemented("DataFrame.quantile")
-        return PythonObject(None)
+        return Series(PythonObject(None))
 
     fn abs(self) raises -> DataFrame:
         _not_implemented("DataFrame.abs")
@@ -195,17 +195,17 @@ struct DataFrame(Copyable, Movable):
         _not_implemented("DataFrame.cummax")
         return DataFrame(self._pd_df)
 
-    fn agg(self, func: PythonObject, axis: Int = 0) raises -> PythonObject:
+    fn agg(self, func: PythonObject, axis: Int = 0) raises -> Series:
         _not_implemented("DataFrame.agg")
-        return PythonObject(None)
+        return Series(PythonObject(None))
 
-    fn aggregate(self, func: PythonObject, axis: Int = 0) raises -> PythonObject:
+    fn aggregate(self, func: PythonObject, axis: Int = 0) raises -> Series:
         _not_implemented("DataFrame.aggregate")
-        return PythonObject(None)
+        return Series(PythonObject(None))
 
-    fn apply(self, func: PythonObject, axis: Int = 0) raises -> PythonObject:
+    fn apply(self, func: PythonObject, axis: Int = 0) raises -> DataFrame:
         _not_implemented("DataFrame.apply")
-        return PythonObject(None)
+        return DataFrame(self._pd_df)
 
     fn applymap(self, func: PythonObject) raises -> DataFrame:
         _not_implemented("DataFrame.applymap")
@@ -215,17 +215,17 @@ struct DataFrame(Copyable, Movable):
         _not_implemented("DataFrame.transform")
         return DataFrame(self._pd_df)
 
-    fn eval(self, expr: String) raises -> PythonObject:
+    fn eval(self, expr: String) raises -> Series:
         _not_implemented("DataFrame.eval")
-        return PythonObject(None)
+        return Series(PythonObject(None))
 
     fn query(self, expr: String) raises -> DataFrame:
         _not_implemented("DataFrame.query")
         return DataFrame(self._pd_df)
 
-    fn pipe(self, func: PythonObject) raises -> PythonObject:
+    fn pipe(self, func: PythonObject) raises -> DataFrame:
         _not_implemented("DataFrame.pipe")
-        return PythonObject(None)
+        return DataFrame(self._pd_df)
 
     # ------------------------------------------------------------------
     # Missing data
@@ -307,9 +307,9 @@ struct DataFrame(Copyable, Movable):
         _not_implemented("DataFrame.drop_duplicates")
         return DataFrame(self._pd_df)
 
-    fn duplicated(self, subset: Optional[PythonObject] = None, keep: String = "first") raises -> PythonObject:
+    fn duplicated(self, subset: Optional[PythonObject] = None, keep: String = "first") raises -> Series:
         _not_implemented("DataFrame.duplicated")
-        return PythonObject(None)
+        return Series(PythonObject(None))
 
     fn pivot(self, index: String = "", columns: String = "", values: String = "") raises -> DataFrame:
         _not_implemented("DataFrame.pivot")
@@ -323,13 +323,13 @@ struct DataFrame(Copyable, Movable):
         _not_implemented("DataFrame.melt")
         return DataFrame(self._pd_df)
 
-    fn stack(self, level: Int = -1) raises -> PythonObject:
+    fn stack(self, level: Int = -1) raises -> Series:
         _not_implemented("DataFrame.stack")
-        return PythonObject(None)
+        return Series(PythonObject(None))
 
-    fn unstack(self, level: Int = -1) raises -> PythonObject:
+    fn unstack(self, level: Int = -1) raises -> DataFrame:
         _not_implemented("DataFrame.unstack")
-        return PythonObject(None)
+        return DataFrame(self._pd_df)
 
     fn transpose(self) raises -> DataFrame:
         _not_implemented("DataFrame.transpose")
@@ -462,16 +462,16 @@ struct DataFrame(Copyable, Movable):
     # IO
     # ------------------------------------------------------------------
 
-    fn to_csv(self, path_or_buf: String = "", sep: String = ",", index: Bool = True) raises -> PythonObject:
+    fn to_csv(self, path_or_buf: String = "", sep: String = ",", index: Bool = True) raises -> String:
         _not_implemented("DataFrame.to_csv")
-        return PythonObject(None)
+        return String("")
 
     fn to_parquet(self, path: String, engine: String = "auto", compression: String = "snappy") raises:
         _not_implemented("DataFrame.to_parquet")
 
-    fn to_json(self, path_or_buf: String = "", orient: String = "") raises -> PythonObject:
+    fn to_json(self, path_or_buf: String = "", orient: String = "") raises -> String:
         _not_implemented("DataFrame.to_json")
-        return PythonObject(None)
+        return String("")
 
     fn to_excel(self, excel_writer: String, sheet_name: String = "Sheet1", index: Bool = True) raises:
         _not_implemented("DataFrame.to_excel")

--- a/bison/groupby.mojo
+++ b/bison/groupby.mojo
@@ -1,5 +1,6 @@
 from python import PythonObject
 from ._errors import _not_implemented
+from .series import Series
 
 
 struct DataFrameGroupBy:
@@ -83,62 +84,62 @@ struct SeriesGroupBy:
     fn __init__(out self, pd_gb: PythonObject):
         self._pd_gb = pd_gb
 
-    fn agg(self, func: PythonObject) raises -> PythonObject:
+    fn agg(self, func: PythonObject) raises -> Series:
         _not_implemented("SeriesGroupBy.agg")
-        return PythonObject(None)
+        return Series(PythonObject(None))
 
-    fn aggregate(self, func: PythonObject) raises -> PythonObject:
+    fn aggregate(self, func: PythonObject) raises -> Series:
         _not_implemented("SeriesGroupBy.aggregate")
-        return PythonObject(None)
+        return Series(PythonObject(None))
 
-    fn transform(self, func: PythonObject) raises -> PythonObject:
+    fn transform(self, func: PythonObject) raises -> Series:
         _not_implemented("SeriesGroupBy.transform")
-        return PythonObject(None)
+        return Series(PythonObject(None))
 
-    fn apply(self, func: PythonObject) raises -> PythonObject:
+    fn apply(self, func: PythonObject) raises -> Series:
         _not_implemented("SeriesGroupBy.apply")
-        return PythonObject(None)
+        return Series(PythonObject(None))
 
-    fn sum(self) raises -> PythonObject:
+    fn sum(self) raises -> Series:
         _not_implemented("SeriesGroupBy.sum")
-        return PythonObject(None)
+        return Series(PythonObject(None))
 
-    fn mean(self) raises -> PythonObject:
+    fn mean(self) raises -> Series:
         _not_implemented("SeriesGroupBy.mean")
-        return PythonObject(None)
+        return Series(PythonObject(None))
 
-    fn min(self) raises -> PythonObject:
+    fn min(self) raises -> Series:
         _not_implemented("SeriesGroupBy.min")
-        return PythonObject(None)
+        return Series(PythonObject(None))
 
-    fn max(self) raises -> PythonObject:
+    fn max(self) raises -> Series:
         _not_implemented("SeriesGroupBy.max")
-        return PythonObject(None)
+        return Series(PythonObject(None))
 
-    fn count(self) raises -> PythonObject:
+    fn count(self) raises -> Series:
         _not_implemented("SeriesGroupBy.count")
-        return PythonObject(None)
+        return Series(PythonObject(None))
 
-    fn nunique(self) raises -> PythonObject:
+    fn nunique(self) raises -> Series:
         _not_implemented("SeriesGroupBy.nunique")
-        return PythonObject(None)
+        return Series(PythonObject(None))
 
-    fn first(self) raises -> PythonObject:
+    fn first(self) raises -> Series:
         _not_implemented("SeriesGroupBy.first")
-        return PythonObject(None)
+        return Series(PythonObject(None))
 
-    fn last(self) raises -> PythonObject:
+    fn last(self) raises -> Series:
         _not_implemented("SeriesGroupBy.last")
-        return PythonObject(None)
+        return Series(PythonObject(None))
 
-    fn size(self) raises -> PythonObject:
+    fn size(self) raises -> Series:
         _not_implemented("SeriesGroupBy.size")
-        return PythonObject(None)
+        return Series(PythonObject(None))
 
-    fn std(self, ddof: Int = 1) raises -> PythonObject:
+    fn std(self, ddof: Int = 1) raises -> Series:
         _not_implemented("SeriesGroupBy.std")
-        return PythonObject(None)
+        return Series(PythonObject(None))
 
-    fn var(self, ddof: Int = 1) raises -> PythonObject:
+    fn var(self, ddof: Int = 1) raises -> Series:
         _not_implemented("SeriesGroupBy.var")
-        return PythonObject(None)
+        return Series(PythonObject(None))

--- a/bison/io/csv.mojo
+++ b/bison/io/csv.mojo
@@ -1,6 +1,7 @@
 from python import PythonObject
 from collections import Optional
 from .._errors import _not_implemented
+from ..dataframe import DataFrame
 
 
 fn read_csv(
@@ -15,10 +16,10 @@ fn read_csv(
     na_values: Optional[PythonObject] = None,
     encoding: String = "utf-8",
     parse_dates: Bool = False,
-) raises -> PythonObject:
+) raises -> DataFrame:
     """Read a CSV file into a DataFrame. STUB."""
     _not_implemented("read_csv")
-    return PythonObject(None)
+    return DataFrame(PythonObject(None))
 
 
 fn to_csv(
@@ -28,7 +29,7 @@ fn to_csv(
     index: Bool = True,
     header: Bool = True,
     encoding: String = "utf-8",
-) raises -> PythonObject:
+) raises -> String:
     """Write a DataFrame to CSV. STUB."""
     _not_implemented("DataFrame.to_csv")
-    return PythonObject(None)
+    return String("")

--- a/bison/io/excel.mojo
+++ b/bison/io/excel.mojo
@@ -1,6 +1,7 @@
 from python import PythonObject
 from collections import Optional
 from .._errors import _not_implemented
+from ..dataframe import DataFrame
 
 
 fn read_excel(
@@ -12,10 +13,10 @@ fn read_excel(
     dtype: Optional[PythonObject] = None,
     skiprows: Optional[PythonObject] = None,
     nrows: Optional[PythonObject] = None,
-) raises -> PythonObject:
+) raises -> DataFrame:
     """Read an Excel file into a DataFrame. STUB."""
     _not_implemented("read_excel")
-    return PythonObject(None)
+    return DataFrame(PythonObject(None))
 
 
 fn to_excel(

--- a/bison/io/json.mojo
+++ b/bison/io/json.mojo
@@ -1,6 +1,7 @@
 from python import PythonObject
 from collections import Optional
 from .._errors import _not_implemented
+from ..dataframe import DataFrame
 
 
 fn read_json(
@@ -8,10 +9,10 @@ fn read_json(
     orient: String = "",
     dtype: Optional[PythonObject] = None,
     lines: Bool = False,
-) raises -> PythonObject:
+) raises -> DataFrame:
     """Read a JSON file into a DataFrame. STUB."""
     _not_implemented("read_json")
-    return PythonObject(None)
+    return DataFrame(PythonObject(None))
 
 
 fn to_json(
@@ -20,7 +21,7 @@ fn to_json(
     orient: String = "",
     lines: Bool = False,
     indent: Int = 0,
-) raises -> PythonObject:
+) raises -> String:
     """Write a DataFrame to JSON. STUB."""
     _not_implemented("DataFrame.to_json")
-    return PythonObject(None)
+    return String("")

--- a/bison/io/parquet.mojo
+++ b/bison/io/parquet.mojo
@@ -1,6 +1,7 @@
 from python import PythonObject
 from collections import Optional
 from .._errors import _not_implemented
+from ..dataframe import DataFrame
 
 
 fn read_parquet(
@@ -8,10 +9,10 @@ fn read_parquet(
     engine: String = "auto",
     columns: Optional[PythonObject] = None,
     filters: Optional[PythonObject] = None,
-) raises -> PythonObject:
+) raises -> DataFrame:
     """Read a Parquet file into a DataFrame. STUB."""
     _not_implemented("read_parquet")
-    return PythonObject(None)
+    return DataFrame(PythonObject(None))
 
 
 fn to_parquet(

--- a/bison/reshape/concat.mojo
+++ b/bison/reshape/concat.mojo
@@ -1,5 +1,6 @@
 from python import PythonObject
 from .._errors import _not_implemented
+from ..dataframe import DataFrame
 
 
 fn concat(
@@ -9,7 +10,7 @@ fn concat(
     ignore_index: Bool = False,
     keys: PythonObject = PythonObject(None),
     sort: Bool = False,
-) raises -> PythonObject:
+) raises -> DataFrame:
     """Concatenate bison objects along an axis. STUB."""
     _not_implemented("concat")
-    return PythonObject(None)
+    return DataFrame(PythonObject(None))

--- a/bison/series.mojo
+++ b/bison/series.mojo
@@ -172,33 +172,33 @@ struct Series(Copyable, Movable):
     # Aggregation
     # ------------------------------------------------------------------
 
-    fn sum(self) raises -> PythonObject:
+    fn sum(self) raises -> Float64:
         _not_implemented("Series.sum")
-        return PythonObject(None)
+        return Float64(0)
 
-    fn mean(self) raises -> PythonObject:
+    fn mean(self) raises -> Float64:
         _not_implemented("Series.mean")
-        return PythonObject(None)
+        return Float64(0)
 
-    fn median(self) raises -> PythonObject:
+    fn median(self) raises -> Float64:
         _not_implemented("Series.median")
-        return PythonObject(None)
+        return Float64(0)
 
-    fn min(self) raises -> PythonObject:
+    fn min(self) raises -> Float64:
         _not_implemented("Series.min")
-        return PythonObject(None)
+        return Float64(0)
 
-    fn max(self) raises -> PythonObject:
+    fn max(self) raises -> Float64:
         _not_implemented("Series.max")
-        return PythonObject(None)
+        return Float64(0)
 
-    fn std(self, ddof: Int = 1) raises -> PythonObject:
+    fn std(self, ddof: Int = 1) raises -> Float64:
         _not_implemented("Series.std")
-        return PythonObject(None)
+        return Float64(0)
 
-    fn var(self, ddof: Int = 1) raises -> PythonObject:
+    fn var(self, ddof: Int = 1) raises -> Float64:
         _not_implemented("Series.var")
-        return PythonObject(None)
+        return Float64(0)
 
     fn count(self) raises -> Int:
         _not_implemented("Series.count")
@@ -216,9 +216,9 @@ struct Series(Copyable, Movable):
         _not_implemented("Series.value_counts")
         return Series(self._pd_s, self.name)
 
-    fn quantile(self, q: Float64 = 0.5) raises -> PythonObject:
+    fn quantile(self, q: Float64 = 0.5) raises -> Float64:
         _not_implemented("Series.quantile")
-        return PythonObject(None)
+        return Float64(0)
 
     fn cumsum(self) raises -> Series:
         _not_implemented("Series.cumsum")
@@ -332,9 +332,9 @@ struct Series(Copyable, Movable):
         _not_implemented("Series.round")
         return Series(self._pd_s, self.name)
 
-    fn unique(self) raises -> PythonObject:
+    fn unique(self) raises -> Series:
         _not_implemented("Series.unique")
-        return PythonObject(None)
+        return Series(self._pd_s, self.name)
 
     fn isin(self, values: PythonObject) raises -> Series:
         _not_implemented("Series.isin")
@@ -372,13 +372,13 @@ struct Series(Copyable, Movable):
         _not_implemented("Series.to_dict")
         return PythonObject(None)
 
-    fn to_csv(self, path: String = "") raises -> PythonObject:
+    fn to_csv(self, path: String = "") raises -> String:
         _not_implemented("Series.to_csv")
-        return PythonObject(None)
+        return String("")
 
-    fn to_json(self, path: String = "") raises -> PythonObject:
+    fn to_json(self, path: String = "") raises -> String:
         _not_implemented("Series.to_json")
-        return PythonObject(None)
+        return String("")
 
     # ------------------------------------------------------------------
     # String / Datetime accessors (return accessor structs)


### PR DESCRIPTION
## Summary

- Replace `PythonObject` return types with proper Mojo types (`Series`, `DataFrame`, `Float64`, `String`) across `DataFrame`, `Series`, `DataFrameGroupBy`, `SeriesGroupBy`, and IO/reshape stubs
- Updates `groupby.mojo`, `io/csv.mojo`, `io/excel.mojo`, `io/json.mojo`, `io/parquet.mojo`, and `reshape/concat.mojo` to import and return concrete types instead of raw `PythonObject(None)`
- Improves type safety and makes the stub layer more self-documenting about expected return shapes

## Test plan

- [ ] Run `pixi run test` — all existing tests should pass (stub methods still raise `_not_implemented`, tests assert on that)
- [ ] Run `pixi run check` — type-check should pass with updated signatures
- [ ] Run `pixi run update-compat` — compat table should remain consistent