### PR TITLE
CI: amend commit when updating compatibility table

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,5 +46,7 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git add README.md
-          git diff --cached --quiet || git commit -m "chore: update compatibility table [skip ci]"
-          git push
+          if ! git diff --cached --quiet; then
+            git commit --amend --no-edit
+            git push --force-with-lease origin HEAD:main
+          fi


### PR DESCRIPTION
## Summary
- updates CI to amend the triggering main commit when README compatibility table changes
- avoids creating an extra follow-up bot commit on every main push
- uses force-with-lease for safe history update

Fixes #37