### PR TITLE
refactor: upgrade Column._data to typed Variant storage

### DIFF
--- a/bison/column.mojo
+++ b/bison/column.mojo
@@ -1,4 +1,5 @@
 from python import Python, PythonObject
+from utils import Variant
 from .dtypes import (
     BisonDtype,
     int8, int16, int32, int64,
@@ -8,18 +9,34 @@ from .dtypes import (
     datetime64_ns, timedelta64_ns,
 )
 
+# One active arm per Column instance, selected by dtype:
+#   List[Int64]        — int8/16/32/64, uint8/16/32/64
+#   List[Float64]      — float32/float64
+#   List[Bool]         — bool
+#   List[String]       — string / pandas StringDtype
+#   List[PythonObject] — object, datetime64, timedelta64 (fallback)
+alias ColumnData = Variant[
+    List[Int64],
+    List[Float64],
+    List[Bool],
+    List[String],
+    List[PythonObject],
+]
+
 
 struct Column(Copyable, Movable):
     """A single typed array representing one column of a DataFrame or a Series.
 
-    Data is stored as a ``List[PythonObject]`` (one element per row).  The
-    ``dtype`` field records the pandas-compatible dtype string so that
-    round-trips through ``to_pandas`` preserve the original dtype.
+    Data is stored as a ``ColumnData`` Variant — one typed list per column,
+    selected by ``dtype``.  Only the arm matching the dtype is populated;
+    all other arms are empty.  The ``dtype`` field records the
+    pandas-compatible dtype string so that round-trips through ``to_pandas``
+    preserve the original dtype.
     """
 
     var name: String
     var dtype: BisonDtype
-    var _data: List[PythonObject]
+    var _data: ColumnData
 
     # ------------------------------------------------------------------
     # Constructors
@@ -29,21 +46,21 @@ struct Column(Copyable, Movable):
         """Empty column with object dtype — used as stub placeholder."""
         self.name  = ""
         self.dtype = object_
-        self._data = List[PythonObject]()
+        self._data = ColumnData(List[PythonObject]())
 
-    fn __init__(out self, name: String, owned data: List[PythonObject], dtype: BisonDtype = object_):
+    fn __init__(out self, name: String, owned data: ColumnData, dtype: BisonDtype):
         self.name  = name
         self.dtype = dtype
         self._data = data^
 
     # ------------------------------------------------------------------
-    # Traits
+    # Traits — Variant is Copyable so __copyinit__ is trivial
     # ------------------------------------------------------------------
 
     fn __copyinit__(out self, existing: Self):
         self.name  = existing.name
         self.dtype = existing.dtype
-        self._data = existing._data.copy()
+        self._data = existing._data
 
     fn __moveinit__(out self, deinit existing: Self):
         self.name  = existing.name^
@@ -51,20 +68,61 @@ struct Column(Copyable, Movable):
         self._data = existing._data^
 
     # ------------------------------------------------------------------
+    # Typed accessor helpers — the only sites that call isa/get
+    # ------------------------------------------------------------------
+
+    fn _int64_data(ref self) -> ref [self._data] List[Int64]:
+        return self._data[List[Int64]]
+
+    fn _float64_data(ref self) -> ref [self._data] List[Float64]:
+        return self._data[List[Float64]]
+
+    fn _bool_data(ref self) -> ref [self._data] List[Bool]:
+        return self._data[List[Bool]]
+
+    fn _str_data(ref self) -> ref [self._data] List[String]:
+        return self._data[List[String]]
+
+    fn _obj_data(ref self) -> ref [self._data] List[PythonObject]:
+        return self._data[List[PythonObject]]
+
+    # ------------------------------------------------------------------
     # Explicit copy helper (used by Series / DataFrame __copyinit__)
     # ------------------------------------------------------------------
 
     fn copy(self) -> Column:
         """Return an independent copy of this Column."""
-        var new_data = self._data.copy()
-        return Column(self.name, new_data^, self.dtype)
+        if self._data.isa[List[Int64]]():
+            var d = self._data[List[Int64]].copy()
+            return Column(self.name, ColumnData(d^), self.dtype)
+        elif self._data.isa[List[Float64]]():
+            var d = self._data[List[Float64]].copy()
+            return Column(self.name, ColumnData(d^), self.dtype)
+        elif self._data.isa[List[Bool]]():
+            var d = self._data[List[Bool]].copy()
+            return Column(self.name, ColumnData(d^), self.dtype)
+        elif self._data.isa[List[String]]():
+            var d = self._data[List[String]].copy()
+            return Column(self.name, ColumnData(d^), self.dtype)
+        else:
+            var d = self._data[List[PythonObject]].copy()
+            return Column(self.name, ColumnData(d^), self.dtype)
 
     # ------------------------------------------------------------------
     # Length
     # ------------------------------------------------------------------
 
     fn __len__(self) -> Int:
-        return len(self._data)
+        if self._data.isa[List[Int64]]():
+            return len(self._data[List[Int64]])
+        elif self._data.isa[List[Float64]]():
+            return len(self._data[List[Float64]])
+        elif self._data.isa[List[Bool]]():
+            return len(self._data[List[Bool]])
+        elif self._data.isa[List[String]]():
+            return len(self._data[List[String]])
+        else:
+            return len(self._data[List[PythonObject]])
 
     # ------------------------------------------------------------------
     # Pandas interop
@@ -96,15 +154,49 @@ struct Column(Copyable, Movable):
         else:
             bison_dtype = object_
 
-        var data = List[PythonObject]()
-        for i in range(n):
-            data.append(py_list[i])
-        return Column(name, data^, bison_dtype)
+        if bison_dtype == int64:
+            var data = List[Int64]()
+            for i in range(n):
+                data.append(Int64(Int(py=py_list[i])))
+            return Column(name, ColumnData(data^), bison_dtype)
+        elif bison_dtype == float64:
+            var data = List[Float64]()
+            for i in range(n):
+                data.append(Float64(String(py_list[i])))
+            return Column(name, ColumnData(data^), bison_dtype)
+        elif bison_dtype == bool_:
+            var data = List[Bool]()
+            for i in range(n):
+                data.append(Bool(py_list[i].__bool__()))
+            return Column(name, ColumnData(data^), bison_dtype)
+        elif dtype_str == "string":
+            var data = List[String]()
+            for i in range(n):
+                data.append(String(py_list[i]))
+            return Column(name, ColumnData(data^), object_)
+        else:
+            var data = List[PythonObject]()
+            for i in range(n):
+                data.append(py_list[i])
+            return Column(name, ColumnData(data^), bison_dtype)
 
     fn to_pandas(self) raises -> PythonObject:
         """Reconstruct a pandas Series from stored values."""
         var pd = Python.import_module("pandas")
         var py_list = Python.evaluate("[]")
-        for i in range(len(self._data)):
-            _ = py_list.append(self._data[i])
+        if self._data.isa[List[Int64]]():
+            for i in range(len(self._data[List[Int64]])):
+                _ = py_list.append(self._data[List[Int64]][i])
+        elif self._data.isa[List[Float64]]():
+            for i in range(len(self._data[List[Float64]])):
+                _ = py_list.append(self._data[List[Float64]][i])
+        elif self._data.isa[List[Bool]]():
+            for i in range(len(self._data[List[Bool]])):
+                _ = py_list.append(self._data[List[Bool]][i])
+        elif self._data.isa[List[String]]():
+            for i in range(len(self._data[List[String]])):
+                _ = py_list.append(self._data[List[String]][i])
+        else:
+            for i in range(len(self._data[List[PythonObject]])):
+                _ = py_list.append(self._data[List[PythonObject]][i])
         return pd.Series(py_list, name=self.name, dtype=self.dtype.name)

--- a/tests/test_interop.mojo
+++ b/tests/test_interop.mojo
@@ -1,7 +1,7 @@
 """Tests for from_pandas / to_pandas interop (these work at stub stage)."""
 from python import Python, PythonObject
 from testing import assert_equal, assert_true
-from bison import DataFrame, Series
+from bison import DataFrame, Series, Column
 
 
 def test_df_from_pandas_preserves_shape():
@@ -65,6 +65,35 @@ def test_quickstart_example():
     testing.assert_frame_equal(pd_df, original)
 
 
+def test_column_typed_storage():
+    """Verify from_pandas routes values into the correct Variant arm."""
+    var pd = Python.import_module("pandas")
+
+    # int64 column -> List[Int64] arm
+    var s_int = pd.Series(Python.evaluate("[1, 2, 3]"), dtype="int64", name="i")
+    var col_int = Column.from_pandas(s_int, "i")
+    assert_true(col_int._data.isa[List[Int64]](), "int column should use List[Int64]")
+    assert_equal(col_int.__len__(), 3)
+
+    # float64 column -> List[Float64] arm
+    var s_float = pd.Series(Python.evaluate("[1.1, 2.2]"), dtype="float64", name="f")
+    var col_float = Column.from_pandas(s_float, "f")
+    assert_true(col_float._data.isa[List[Float64]](), "float column should use List[Float64]")
+    assert_equal(col_float.__len__(), 2)
+
+    # bool column -> List[Bool] arm
+    var s_bool = pd.Series(Python.evaluate("[True, False]"), dtype="bool", name="b")
+    var col_bool = Column.from_pandas(s_bool, "b")
+    assert_true(col_bool._data.isa[List[Bool]](), "bool column should use List[Bool]")
+    assert_equal(col_bool.__len__(), 2)
+
+    # object column -> List[PythonObject] arm
+    var s_obj = pd.Series(Python.evaluate("['x', 'y']"), dtype="object", name="o")
+    var col_obj = Column.from_pandas(s_obj, "o")
+    assert_true(col_obj._data.isa[List[PythonObject]](), "object column should use List[PythonObject]")
+    assert_equal(col_obj.__len__(), 2)
+
+
 def main():
     test_df_from_pandas_preserves_shape()
     test_df_to_pandas_identity()
@@ -72,4 +101,5 @@ def main():
     test_series_to_pandas_identity()
     test_df_columns_match()
     test_quickstart_example()
+    test_column_typed_storage()
     print("test_interop: all tests passed")


### PR DESCRIPTION
## Summary

Implements #45.

Replaces `Column._data: List[PythonObject]` with a five-arm `Variant`:

```mojo
alias ColumnData = Variant[
    List[Int64],
    List[Float64],
    List[Bool],
    List[String],
    List[PythonObject],   # object / datetime / timedelta fallback
]
```

Only the arm matching the column dtype is populated; all other arms are empty.

## Coercion workarounds (MAX 26.1)

Direct `Int64(PythonObject)` / `Float64(PythonObject)` do not compile. The following patterns were confirmed by a spike script (`scripts/spike_coercion.mojo`):

| Target | Pattern |
|--------|---------|
| `Int64` | `Int64(Int(py=py_obj))` |
| `Float64` | `Float64(String(py_obj))` |
| `Bool` | `Bool(py_obj.__bool__())` |
| `String` | `String(py_obj)` |

> Note: `Float64(String(...))` round-trips through decimal repr and is lossy for extreme values. This is tracked in SESSION.md as a known limitation, pending a future `bitcast` fix.

## Changes

- `bison/column.mojo`: `ColumnData` alias, new constructor, typed accessor helpers (`_int64_data`, `_float64_data`, `_bool_data`, `_str_data`, `_obj_data`), updated `from_pandas`, `to_pandas`, `copy`, `__len__`
- `tests/test_interop.mojo`: added `test_column_typed_storage` asserting the correct Variant arm is active for int, float, bool, and object columns

## Test results

All 10 tests pass (`pixi run test`).