### PR TITLE
feat: implement Series.sum and DataFrame.sum natively (#43)

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,8 +80,8 @@ In CI it runs after the test suite and the result is committed back to the branc
 <!-- COMPAT_TABLE_START -->
 | Category | Stubs | Implemented |
 |----------|-------|-------------|
-| DataFrame | 101 | 0 |
-| Series | 73 | 0 |
+| DataFrame | 100 | 0 |
+| Series | 72 | 0 |
 | GroupBy (DataFrame) | 16 | 0 |
 | GroupBy (Series) | 15 | 0 |
 | String accessor | 18 | 0 |
@@ -89,7 +89,7 @@ In CI it runs after the test suite and the result is committed back to the branc
 | Index | 3 | 0 |
 | IO | 12 | 0 |
 | Reshape | 1 | 0 |
-| **Total** | **256** | **0** |
+| **Total** | **254** | **0** |
 <!-- COMPAT_TABLE_END -->
 
 ## Contributing

--- a/bison/column.mojo
+++ b/bison/column.mojo
@@ -145,6 +145,31 @@ struct Column(Copyable, Movable):
             return len(self._data[List[PythonObject]])
 
     # ------------------------------------------------------------------
+    # Aggregation
+    # ------------------------------------------------------------------
+
+    fn sum(self) raises -> Float64:
+        """Return the sum of all values as Float64. Raises for non-numeric types."""
+        if self._data.isa[List[Int64]]():
+            var total = Float64(0)
+            for i in range(len(self._data[List[Int64]])):
+                total += Float64(self._data[List[Int64]][i])
+            return total
+        elif self._data.isa[List[Float64]]():
+            var total = Float64(0)
+            for i in range(len(self._data[List[Float64]])):
+                total += self._data[List[Float64]][i]
+            return total
+        elif self._data.isa[List[Bool]]():
+            var total = Float64(0)
+            for i in range(len(self._data[List[Bool]])):
+                if self._data[List[Bool]][i]:
+                    total += 1.0
+            return total
+        else:
+            raise Error("sum: non-numeric column type")
+
+    # ------------------------------------------------------------------
     # Pandas interop
     # ------------------------------------------------------------------
 

--- a/bison/dataframe.mojo
+++ b/bison/dataframe.mojo
@@ -2,6 +2,7 @@ from python import Python, PythonObject
 from collections import Optional, Dict
 from ._errors import _not_implemented
 from .column import Column, ColumnData, DFScalar
+from .dtypes import float64 as _float64
 from .series import Series
 from .groupby import DataFrameGroupBy
 
@@ -148,8 +149,16 @@ struct DataFrame(Copyable, Movable):
     # ------------------------------------------------------------------
 
     fn sum(self, axis: Int = 0, skipna: Bool = True) raises -> Series:
-        _not_implemented("DataFrame.sum")
-        return Series()
+        # skipna is accepted but not enforced: Column has no null mask yet.
+        if axis != 0:
+            raise Error("DataFrame.sum: axis=1 not yet implemented")
+        var values = List[Float64]()
+        for i in range(len(self._cols)):
+            values.append(self._cols[i].sum())
+        var col_data = ColumnData(values^)
+        var dtype = Column._sniff_dtype(col_data)
+        var result_col = Column("", col_data^, dtype)
+        return Series(result_col^)
 
     fn mean(self, axis: Int = 0, skipna: Bool = True) raises -> Series:
         _not_implemented("DataFrame.mean")

--- a/bison/series.mojo
+++ b/bison/series.mojo
@@ -181,9 +181,9 @@ struct Series(Copyable, Movable):
     # Aggregation
     # ------------------------------------------------------------------
 
-    fn sum(self) raises -> Float64:
-        _not_implemented("Series.sum")
-        return Float64(0)
+    fn sum(self, skipna: Bool = True) raises -> Float64:
+        # skipna is accepted but not enforced: Column has no null mask yet.
+        return self._col.sum()
 
     fn mean(self) raises -> Float64:
         _not_implemented("Series.mean")

--- a/tests/test_aggregation.mojo
+++ b/tests/test_aggregation.mojo
@@ -1,4 +1,4 @@
-"""Tests that aggregation stubs raise 'not implemented'."""
+"""Tests aggregation methods (sum implemented; others are stubs)."""
 from python import Python
 from testing import assert_true
 from bison import DataFrame, Series
@@ -9,15 +9,32 @@ def _raises(name: String, raised: Bool):
         raise Error(name + " should have raised")
 
 
-def test_df_sum_stub():
+def test_series_sum_int():
     var pd = Python.import_module("pandas")
-    var df = DataFrame(pd.DataFrame(Python.evaluate("{'a': [1, 2, 3]}")))
-    var raised = False
-    try:
-        _ = df.sum()
-    except:
-        raised = True
-    _raises("DataFrame.sum", raised)
+    var s = Series(pd.Series(Python.evaluate("[1, 2, 3]")))
+    assert_true(s.sum() == 6.0)
+
+
+def test_series_sum_float():
+    var pd = Python.import_module("pandas")
+    var s = Series(pd.Series(Python.evaluate("[1.5, 2.5]")))
+    assert_true(s.sum() == 4.0)
+
+
+def test_series_sum_skipna_flag():
+    var pd = Python.import_module("pandas")
+    var s = Series(pd.Series(Python.evaluate("[1.0, 2.0]")))
+    # skipna flag is accepted; behaviour is identical until Column gains a null mask
+    assert_true(s.sum(skipna=False) == 3.0)
+
+
+def test_df_sum():
+    var pd = Python.import_module("pandas")
+    var pd_df = pd.DataFrame(Python.evaluate("{'a': [1, 2, 3], 'b': [1.5, 2.5, 3.5]}"))
+    var df = DataFrame(pd_df)
+    var result_pd = df.sum().to_pandas()
+    assert_true(Float64(String(result_pd.iloc[0])) == 6.0)
+    assert_true(Float64(String(result_pd.iloc[1])) == 7.5)
 
 
 def test_df_mean_stub():
@@ -65,7 +82,10 @@ def test_series_value_counts_stub():
 
 
 def main():
-    test_df_sum_stub()
+    test_series_sum_int()
+    test_series_sum_float()
+    test_series_sum_skipna_flag()
+    test_df_sum()
     test_df_mean_stub()
     test_df_describe_stub()
     test_series_mean_stub()

--- a/tests/test_series.mojo
+++ b/tests/test_series.mojo
@@ -45,17 +45,10 @@ def test_to_pandas_roundtrip():
     assert_equal(back.__len__(), 3)
 
 
-def test_stub_raises_sum():
-    """Stub methods must raise with 'not implemented'."""
+def test_sum():
     var pd = Python.import_module("pandas")
     var s = Series(pd.Series(Python.evaluate("[1, 2, 3]")))
-    var raised = False
-    try:
-        _ = s.sum()
-    except e:
-        raised = True
-        assert_true(String(e).__contains__("not implemented"))
-    assert_true(raised)
+    assert_true(s.sum() == 6.0)
 
 
 def test_stub_raises_head():
@@ -76,6 +69,6 @@ def main():
     test_empty_true()
     test_shape()
     test_to_pandas_roundtrip()
-    test_stub_raises_sum()
+    test_sum()
     test_stub_raises_head()
     print("test_series: all tests passed")


### PR DESCRIPTION
Closes #43

## What changed

- **`Column.sum()`** — new method with typed dispatch over `List[Int64]`, `List[Float64]`, `List[Bool]`; raises for non-numeric types.
- **`Series.sum(skipna)`** — delegates to `Column.sum()`. `skipna` parameter accepted (no-op until Column gains a null mask).
- **`DataFrame.sum(axis, skipna)`** — iterates columns, collects `Float64` sums, returns a `Series`. `axis=1` raises with a clear message.

## Tests

- `test_aggregation.mojo`: replaced stub-raise test with real assertions for `Series` (int, float, skipna flag) and `DataFrame` (multi-column).
- `test_series.mojo`: replaced `test_stub_raises_sum` with `test_sum` real assertion.
- All 10 tests pass (`pixi run test`).

## Notes

`skipna` is accepted and compiles correctly but behaves identically for both values — Column has no null bitmask yet. A comment in the code documents this.