### PR TITLE
feat: implement DataFrame/Series basic aggregations

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,8 +80,8 @@ In CI it runs after the test suite and the result is committed back to the branc
 <!-- COMPAT_TABLE_START -->
 | Category | Stubs | Implemented |
 |----------|-------|-------------|
-| DataFrame | 100 | 17 |
-| Series | 72 | 13 |
+| DataFrame | 91 | 26 |
+| Series | 63 | 22 |
 | GroupBy (DataFrame) | 16 | 1 |
 | GroupBy (Series) | 15 | 1 |
 | String accessor | 18 | 1 |
@@ -89,7 +89,7 @@ In CI it runs after the test suite and the result is committed back to the branc
 | Index | 3 | 11 |
 | IO | 12 | 0 |
 | Reshape | 1 | 0 |
-| **Total** | **254** | **45** |
+| **Total** | **236** | **63** |
 <!-- COMPAT_TABLE_END -->
 
 ## Contributing

--- a/bison/column.mojo
+++ b/bison/column.mojo
@@ -1,6 +1,8 @@
 from python import Python, PythonObject
 from utils import Variant
 from memory import bitcast
+from collections import Dict
+from math import sqrt
 from .dtypes import (
     BisonDtype,
     int8, int16, int32, int64,
@@ -275,6 +277,235 @@ struct Column(Copyable, Movable):
             return total
         else:
             raise Error("sum: non-numeric column type")
+
+    fn count(self) -> Int:
+        """Return the number of non-null elements."""
+        var n = self.__len__()
+        if len(self._null_mask) == 0:
+            return n
+        var result = 0
+        for i in range(n):
+            if not self._null_mask[i]:
+                result += 1
+        return result
+
+    fn mean(self, skipna: Bool = True) raises -> Float64:
+        """Return the mean of all values as Float64.
+
+        Returns NaN when all elements are null or the column is empty.
+        Raises for non-numeric column types.
+        """
+        var n = self.count() if skipna else self.__len__()
+        if n == 0:
+            var zero = Float64(0)
+            return zero / zero
+        return self.sum(skipna) / Float64(n)
+
+    fn min(self, skipna: Bool = True) raises -> Float64:
+        """Return the minimum value as Float64.
+
+        Returns NaN when no non-null elements exist.
+        Raises for non-numeric column types.
+        """
+        if not skipna and self.has_nulls():
+            var zero = Float64(0)
+            return zero / zero
+        var has_mask = len(self._null_mask) > 0
+        var found = False
+        var result = Float64(0)
+        if self._data.isa[List[Int64]]():
+            for i in range(len(self._data[List[Int64]])):
+                if has_mask and self._null_mask[i]:
+                    continue
+                var v = Float64(self._data[List[Int64]][i])
+                if not found or v < result:
+                    result = v
+                    found = True
+        elif self._data.isa[List[Float64]]():
+            for i in range(len(self._data[List[Float64]])):
+                if has_mask and self._null_mask[i]:
+                    continue
+                var v = self._data[List[Float64]][i]
+                if not found or v < result:
+                    result = v
+                    found = True
+        elif self._data.isa[List[Bool]]():
+            for i in range(len(self._data[List[Bool]])):
+                if has_mask and self._null_mask[i]:
+                    continue
+                var v = Float64(1.0) if self._data[List[Bool]][i] else Float64(0.0)
+                if not found or v < result:
+                    result = v
+                    found = True
+        else:
+            raise Error("min: non-numeric column type")
+        if not found:
+            var zero = Float64(0)
+            return zero / zero
+        return result
+
+    fn max(self, skipna: Bool = True) raises -> Float64:
+        """Return the maximum value as Float64.
+
+        Returns NaN when no non-null elements exist.
+        Raises for non-numeric column types.
+        """
+        if not skipna and self.has_nulls():
+            var zero = Float64(0)
+            return zero / zero
+        var has_mask = len(self._null_mask) > 0
+        var found = False
+        var result = Float64(0)
+        if self._data.isa[List[Int64]]():
+            for i in range(len(self._data[List[Int64]])):
+                if has_mask and self._null_mask[i]:
+                    continue
+                var v = Float64(self._data[List[Int64]][i])
+                if not found or v > result:
+                    result = v
+                    found = True
+        elif self._data.isa[List[Float64]]():
+            for i in range(len(self._data[List[Float64]])):
+                if has_mask and self._null_mask[i]:
+                    continue
+                var v = self._data[List[Float64]][i]
+                if not found or v > result:
+                    result = v
+                    found = True
+        elif self._data.isa[List[Bool]]():
+            for i in range(len(self._data[List[Bool]])):
+                if has_mask and self._null_mask[i]:
+                    continue
+                var v = Float64(1.0) if self._data[List[Bool]][i] else Float64(0.0)
+                if not found or v > result:
+                    result = v
+                    found = True
+        else:
+            raise Error("max: non-numeric column type")
+        if not found:
+            var zero = Float64(0)
+            return zero / zero
+        return result
+
+    fn var(self, ddof: Int = 1, skipna: Bool = True) raises -> Float64:
+        """Return the variance with Bessel correction (ddof=1 by default).
+
+        Returns NaN when n - ddof <= 0.
+        Raises for non-numeric column types.
+        """
+        var n = self.count() if skipna else self.__len__()
+        if n - ddof <= 0:
+            var zero = Float64(0)
+            return zero / zero
+        var m = self.mean(skipna)
+        var has_mask = len(self._null_mask) > 0
+        var total = Float64(0)
+        if self._data.isa[List[Int64]]():
+            for i in range(len(self._data[List[Int64]])):
+                if has_mask and self._null_mask[i]:
+                    continue
+                var diff = Float64(self._data[List[Int64]][i]) - m
+                total += diff * diff
+        elif self._data.isa[List[Float64]]():
+            for i in range(len(self._data[List[Float64]])):
+                if has_mask and self._null_mask[i]:
+                    continue
+                var diff = self._data[List[Float64]][i] - m
+                total += diff * diff
+        elif self._data.isa[List[Bool]]():
+            for i in range(len(self._data[List[Bool]])):
+                if has_mask and self._null_mask[i]:
+                    continue
+                var v = Float64(1.0) if self._data[List[Bool]][i] else Float64(0.0)
+                var diff = v - m
+                total += diff * diff
+        else:
+            raise Error("var: non-numeric column type")
+        return total / Float64(n - ddof)
+
+    fn std(self, ddof: Int = 1, skipna: Bool = True) raises -> Float64:
+        """Return the standard deviation (square root of variance)."""
+        return sqrt(self.var(ddof, skipna))
+
+    fn nunique(self) raises -> Int:
+        """Return the number of unique non-null values.
+
+        Raises for non-numeric column types.
+        """
+        var seen = Dict[String, Bool]()
+        var has_mask = len(self._null_mask) > 0
+        if self._data.isa[List[Int64]]():
+            for i in range(len(self._data[List[Int64]])):
+                if has_mask and self._null_mask[i]:
+                    continue
+                seen[String(self._data[List[Int64]][i])] = True
+        elif self._data.isa[List[Float64]]():
+            for i in range(len(self._data[List[Float64]])):
+                if has_mask and self._null_mask[i]:
+                    continue
+                seen[String(self._data[List[Float64]][i])] = True
+        elif self._data.isa[List[Bool]]():
+            for i in range(len(self._data[List[Bool]])):
+                if has_mask and self._null_mask[i]:
+                    continue
+                seen[String(self._data[List[Bool]][i])] = True
+        else:
+            raise Error("nunique: non-numeric column type")
+        return len(seen)
+
+    fn quantile(self, q: Float64 = 0.5) raises -> Float64:
+        """Return the q-th quantile using linear interpolation.
+
+        Always skips null elements (matches pandas default behaviour).
+        Raises for non-numeric column types.
+        """
+        var vals = List[Float64]()
+        var has_mask = len(self._null_mask) > 0
+        if self._data.isa[List[Int64]]():
+            for i in range(len(self._data[List[Int64]])):
+                if has_mask and self._null_mask[i]:
+                    continue
+                vals.append(Float64(self._data[List[Int64]][i]))
+        elif self._data.isa[List[Float64]]():
+            for i in range(len(self._data[List[Float64]])):
+                if has_mask and self._null_mask[i]:
+                    continue
+                vals.append(self._data[List[Float64]][i])
+        elif self._data.isa[List[Bool]]():
+            for i in range(len(self._data[List[Bool]])):
+                if has_mask and self._null_mask[i]:
+                    continue
+                vals.append(Float64(1.0) if self._data[List[Bool]][i] else Float64(0.0))
+        else:
+            raise Error("quantile: non-numeric column type")
+        if len(vals) == 0:
+            var zero = Float64(0)
+            return zero / zero
+        # Insertion sort (values list is typically small).
+        for i in range(1, len(vals)):
+            var key = vals[i]
+            var j = i - 1
+            while j >= 0 and vals[j] > key:
+                vals[j + 1] = vals[j]
+                j -= 1
+            vals[j + 1] = key
+        var idx = q * Float64(len(vals) - 1)
+        var lo = Int(idx)
+        var hi = lo + 1
+        if hi >= len(vals):
+            return vals[lo]
+        var frac = idx - Float64(lo)
+        return vals[lo] * (1.0 - frac) + vals[hi] * frac
+
+    fn median(self, skipna: Bool = True) raises -> Float64:
+        """Return the median value.
+
+        When skipna=False and nulls are present, returns NaN.
+        """
+        if not skipna and self.has_nulls():
+            var zero = Float64(0)
+            return zero / zero
+        return self.quantile(0.5)
 
     # ------------------------------------------------------------------
     # Pandas interop

--- a/bison/dataframe.mojo
+++ b/bison/dataframe.mojo
@@ -160,44 +160,107 @@ struct DataFrame(Copyable, Movable):
         return Series(result_col^)
 
     fn mean(self, axis: Int = 0, skipna: Bool = True) raises -> Series:
-        _not_implemented("DataFrame.mean")
-        return Series()
+        if axis != 0:
+            raise Error("DataFrame.mean: axis=1 not yet implemented")
+        var values = List[Float64]()
+        for i in range(len(self._cols)):
+            values.append(self._cols[i].mean(skipna))
+        var col_data = ColumnData(values^)
+        var dtype = Column._sniff_dtype(col_data)
+        var result_col = Column("", col_data^, dtype)
+        return Series(result_col^)
 
     fn median(self, axis: Int = 0, skipna: Bool = True) raises -> Series:
-        _not_implemented("DataFrame.median")
-        return Series()
+        if axis != 0:
+            raise Error("DataFrame.median: axis=1 not yet implemented")
+        var values = List[Float64]()
+        for i in range(len(self._cols)):
+            values.append(self._cols[i].median(skipna))
+        var col_data = ColumnData(values^)
+        var dtype = Column._sniff_dtype(col_data)
+        var result_col = Column("", col_data^, dtype)
+        return Series(result_col^)
 
     fn min(self, axis: Int = 0, skipna: Bool = True) raises -> Series:
-        _not_implemented("DataFrame.min")
-        return Series()
+        if axis != 0:
+            raise Error("DataFrame.min: axis=1 not yet implemented")
+        var values = List[Float64]()
+        for i in range(len(self._cols)):
+            values.append(self._cols[i].min(skipna))
+        var col_data = ColumnData(values^)
+        var dtype = Column._sniff_dtype(col_data)
+        var result_col = Column("", col_data^, dtype)
+        return Series(result_col^)
 
     fn max(self, axis: Int = 0, skipna: Bool = True) raises -> Series:
-        _not_implemented("DataFrame.max")
-        return Series()
+        if axis != 0:
+            raise Error("DataFrame.max: axis=1 not yet implemented")
+        var values = List[Float64]()
+        for i in range(len(self._cols)):
+            values.append(self._cols[i].max(skipna))
+        var col_data = ColumnData(values^)
+        var dtype = Column._sniff_dtype(col_data)
+        var result_col = Column("", col_data^, dtype)
+        return Series(result_col^)
 
     fn std(self, axis: Int = 0, ddof: Int = 1, skipna: Bool = True) raises -> Series:
-        _not_implemented("DataFrame.std")
-        return Series()
+        if axis != 0:
+            raise Error("DataFrame.std: axis=1 not yet implemented")
+        var values = List[Float64]()
+        for i in range(len(self._cols)):
+            values.append(self._cols[i].std(ddof, skipna))
+        var col_data = ColumnData(values^)
+        var dtype = Column._sniff_dtype(col_data)
+        var result_col = Column("", col_data^, dtype)
+        return Series(result_col^)
 
     fn var(self, axis: Int = 0, ddof: Int = 1, skipna: Bool = True) raises -> Series:
-        _not_implemented("DataFrame.var")
-        return Series()
+        if axis != 0:
+            raise Error("DataFrame.var: axis=1 not yet implemented")
+        var values = List[Float64]()
+        for i in range(len(self._cols)):
+            values.append(self._cols[i].var(ddof, skipna))
+        var col_data = ColumnData(values^)
+        var dtype = Column._sniff_dtype(col_data)
+        var result_col = Column("", col_data^, dtype)
+        return Series(result_col^)
 
     fn count(self, axis: Int = 0) raises -> Series:
-        _not_implemented("DataFrame.count")
-        return Series()
+        if axis != 0:
+            raise Error("DataFrame.count: axis=1 not yet implemented")
+        var values = List[Float64]()
+        for i in range(len(self._cols)):
+            values.append(Float64(self._cols[i].count()))
+        var col_data = ColumnData(values^)
+        var dtype = Column._sniff_dtype(col_data)
+        var result_col = Column("", col_data^, dtype)
+        return Series(result_col^)
 
     fn nunique(self, axis: Int = 0) raises -> Series:
-        _not_implemented("DataFrame.nunique")
-        return Series()
+        if axis != 0:
+            raise Error("DataFrame.nunique: axis=1 not yet implemented")
+        var values = List[Float64]()
+        for i in range(len(self._cols)):
+            values.append(Float64(self._cols[i].nunique()))
+        var col_data = ColumnData(values^)
+        var dtype = Column._sniff_dtype(col_data)
+        var result_col = Column("", col_data^, dtype)
+        return Series(result_col^)
 
     fn describe(self, include: Optional[PythonObject] = None, exclude: Optional[PythonObject] = None) raises -> DataFrame:
         _not_implemented("DataFrame.describe")
         return DataFrame()
 
     fn quantile(self, q: Float64 = 0.5, axis: Int = 0) raises -> Series:
-        _not_implemented("DataFrame.quantile")
-        return Series()
+        if axis != 0:
+            raise Error("DataFrame.quantile: axis=1 not yet implemented")
+        var values = List[Float64]()
+        for i in range(len(self._cols)):
+            values.append(self._cols[i].quantile(q))
+        var col_data = ColumnData(values^)
+        var dtype = Column._sniff_dtype(col_data)
+        var result_col = Column("", col_data^, dtype)
+        return Series(result_col^)
 
     fn abs(self) raises -> DataFrame:
         _not_implemented("DataFrame.abs")

--- a/bison/series.mojo
+++ b/bison/series.mojo
@@ -184,37 +184,29 @@ struct Series(Copyable, Movable):
     fn sum(self, skipna: Bool = True) raises -> Float64:
         return self._col.sum(skipna)
 
-    fn mean(self) raises -> Float64:
-        _not_implemented("Series.mean")
-        return Float64(0)
+    fn mean(self, skipna: Bool = True) raises -> Float64:
+        return self._col.mean(skipna)
 
-    fn median(self) raises -> Float64:
-        _not_implemented("Series.median")
-        return Float64(0)
+    fn median(self, skipna: Bool = True) raises -> Float64:
+        return self._col.median(skipna)
 
-    fn min(self) raises -> Float64:
-        _not_implemented("Series.min")
-        return Float64(0)
+    fn min(self, skipna: Bool = True) raises -> Float64:
+        return self._col.min(skipna)
 
-    fn max(self) raises -> Float64:
-        _not_implemented("Series.max")
-        return Float64(0)
+    fn max(self, skipna: Bool = True) raises -> Float64:
+        return self._col.max(skipna)
 
-    fn std(self, ddof: Int = 1) raises -> Float64:
-        _not_implemented("Series.std")
-        return Float64(0)
+    fn std(self, ddof: Int = 1, skipna: Bool = True) raises -> Float64:
+        return self._col.std(ddof, skipna)
 
-    fn var(self, ddof: Int = 1) raises -> Float64:
-        _not_implemented("Series.var")
-        return Float64(0)
+    fn var(self, ddof: Int = 1, skipna: Bool = True) raises -> Float64:
+        return self._col.var(ddof, skipna)
 
-    fn count(self) raises -> Int:
-        _not_implemented("Series.count")
-        return 0
+    fn count(self) -> Int:
+        return self._col.count()
 
     fn nunique(self) raises -> Int:
-        _not_implemented("Series.nunique")
-        return 0
+        return self._col.nunique()
 
     fn describe(self) raises -> Series:
         _not_implemented("Series.describe")
@@ -225,8 +217,7 @@ struct Series(Copyable, Movable):
         return Series()
 
     fn quantile(self, q: Float64 = 0.5) raises -> Float64:
-        _not_implemented("Series.quantile")
-        return Float64(0)
+        return self._col.quantile(q)
 
     fn cumsum(self) raises -> Series:
         _not_implemented("Series.cumsum")

--- a/tests/test_aggregation.mojo
+++ b/tests/test_aggregation.mojo
@@ -1,14 +1,13 @@
-"""Tests aggregation methods (sum implemented; others are stubs)."""
+"""Tests aggregation methods."""
 from python import Python
 from testing import assert_true, TestSuite
 from math import isnan
 from bison import DataFrame, Series
 
 
-def _raises(name: String, raised: Bool):
-    if not raised:
-        raise Error(name + " should have raised")
-
+# ---------------------------------------------------------------------------
+# sum
+# ---------------------------------------------------------------------------
 
 def test_series_sum_int():
     var pd = Python.import_module("pandas")
@@ -53,16 +52,217 @@ def test_df_sum():
     assert_true(Float64(String(result_pd.iloc[1])) == 7.5)
 
 
-def test_df_mean_stub():
-    var pd = Python.import_module("pandas")
-    var df = DataFrame(pd.DataFrame(Python.evaluate("{'a': [1.0, 2.0]}")))
-    var raised = False
-    try:
-        _ = df.mean()
-    except:
-        raised = True
-    _raises("DataFrame.mean", raised)
+# ---------------------------------------------------------------------------
+# count
+# ---------------------------------------------------------------------------
 
+def test_series_count_no_nulls():
+    var pd = Python.import_module("pandas")
+    var s = Series(pd.Series(Python.evaluate("[1, 2, 3]")))
+    assert_true(s.count() == 3)
+
+
+def test_series_count_with_nulls():
+    var pd = Python.import_module("pandas")
+    var s = Series(pd.Series(Python.evaluate("[1.0, float('nan'), 3.0]")))
+    assert_true(s.count() == 2)
+
+
+def test_df_count():
+    var pd = Python.import_module("pandas")
+    var pd_df = pd.DataFrame(Python.evaluate("{'a': [1, 2, 3], 'b': [1.0, float('nan'), 3.0]}"))
+    var df = DataFrame(pd_df)
+    var result_pd = df.count().to_pandas()
+    assert_true(Float64(String(result_pd.iloc[0])) == 3.0)
+    assert_true(Float64(String(result_pd.iloc[1])) == 2.0)
+
+
+# ---------------------------------------------------------------------------
+# mean
+# ---------------------------------------------------------------------------
+
+def test_series_mean_int():
+    var pd = Python.import_module("pandas")
+    var s = Series(pd.Series(Python.evaluate("[1, 2, 3]")))
+    assert_true(s.mean() == 2.0)
+
+
+def test_series_mean_float():
+    var pd = Python.import_module("pandas")
+    var s = Series(pd.Series(Python.evaluate("[1.0, 2.0, 3.0]")))
+    assert_true(s.mean() == 2.0)
+
+
+def test_series_mean_skipna_true():
+    var pd = Python.import_module("pandas")
+    var s = Series(pd.Series(Python.evaluate("[1.0, float('nan'), 3.0]")))
+    assert_true(s.mean(skipna=True) == 2.0)
+
+
+def test_series_mean_skipna_false_nan():
+    var pd = Python.import_module("pandas")
+    var s = Series(pd.Series(Python.evaluate("[1.0, float('nan'), 3.0]")))
+    assert_true(isnan(s.mean(skipna=False)))
+
+
+def test_df_mean():
+    var pd = Python.import_module("pandas")
+    var pd_df = pd.DataFrame(Python.evaluate("{'a': [1.0, 2.0, 3.0], 'b': [4.0, 5.0, 6.0]}"))
+    var df = DataFrame(pd_df)
+    var result_pd = df.mean().to_pandas()
+    assert_true(Float64(String(result_pd.iloc[0])) == 2.0)
+    assert_true(Float64(String(result_pd.iloc[1])) == 5.0)
+
+
+# ---------------------------------------------------------------------------
+# min / max
+# ---------------------------------------------------------------------------
+
+def test_series_min_int():
+    var pd = Python.import_module("pandas")
+    var s = Series(pd.Series(Python.evaluate("[3, 1, 2]")))
+    assert_true(s.min() == 1.0)
+
+
+def test_series_max_int():
+    var pd = Python.import_module("pandas")
+    var s = Series(pd.Series(Python.evaluate("[3, 1, 2]")))
+    assert_true(s.max() == 3.0)
+
+
+def test_series_min_skipna():
+    var pd = Python.import_module("pandas")
+    var s = Series(pd.Series(Python.evaluate("[1.0, float('nan'), 3.0]")))
+    assert_true(s.min(skipna=True) == 1.0)
+    assert_true(isnan(s.min(skipna=False)))
+
+
+def test_df_min():
+    var pd = Python.import_module("pandas")
+    var pd_df = pd.DataFrame(Python.evaluate("{'a': [3.0, 1.0, 2.0], 'b': [10.0, 5.0, 8.0]}"))
+    var df = DataFrame(pd_df)
+    var result_pd = df.min().to_pandas()
+    assert_true(Float64(String(result_pd.iloc[0])) == 1.0)
+    assert_true(Float64(String(result_pd.iloc[1])) == 5.0)
+
+
+def test_df_max():
+    var pd = Python.import_module("pandas")
+    var pd_df = pd.DataFrame(Python.evaluate("{'a': [3.0, 1.0, 2.0], 'b': [10.0, 5.0, 8.0]}"))
+    var df = DataFrame(pd_df)
+    var result_pd = df.max().to_pandas()
+    assert_true(Float64(String(result_pd.iloc[0])) == 3.0)
+    assert_true(Float64(String(result_pd.iloc[1])) == 10.0)
+
+
+# ---------------------------------------------------------------------------
+# std / var
+# ---------------------------------------------------------------------------
+
+def test_series_std():
+    var pd = Python.import_module("pandas")
+    # [1, 2, 3]: mean=2, sum_sq_dev=2, var(ddof=1)=1.0, std=1.0
+    var s = Series(pd.Series(Python.evaluate("[1.0, 2.0, 3.0]")))
+    var result = s.std()
+    assert_true(result - 1.0 < 1e-10 and 1.0 - result < 1e-10)
+
+
+def test_series_var():
+    var pd = Python.import_module("pandas")
+    # [1, 2, 3]: mean=2, sum_sq_dev=2, var(ddof=1)=1.0
+    var s = Series(pd.Series(Python.evaluate("[1.0, 2.0, 3.0]")))
+    var result = s.var()
+    assert_true(result - 1.0 < 1e-10 and 1.0 - result < 1e-10)
+
+
+def test_series_std_single_element():
+    """std of a single-element series with ddof=1 should be NaN."""
+    var pd = Python.import_module("pandas")
+    var s = Series(pd.Series(Python.evaluate("[5.0]")))
+    assert_true(isnan(s.std()))
+
+
+def test_df_std():
+    var pd = Python.import_module("pandas")
+    var pd_df = pd.DataFrame(Python.evaluate("{'a': [1.0, 2.0, 3.0]}"))
+    var df = DataFrame(pd_df)
+    var result = df.std()
+    var result_pd = result.to_pandas()
+    assert_true(abs(Float64(String(result_pd.iloc[0])) - 1.0) < 1e-10)
+
+
+# ---------------------------------------------------------------------------
+# nunique
+# ---------------------------------------------------------------------------
+
+def test_series_nunique_int():
+    var pd = Python.import_module("pandas")
+    var s = Series(pd.Series(Python.evaluate("[1, 1, 2, 3, 3]")))
+    assert_true(s.nunique() == 3)
+
+
+def test_series_nunique_with_nulls():
+    var pd = Python.import_module("pandas")
+    var s = Series(pd.Series(Python.evaluate("[1.0, float('nan'), 2.0, 1.0]")))
+    # nulls excluded from unique count
+    assert_true(s.nunique() == 2)
+
+
+def test_df_nunique():
+    var pd = Python.import_module("pandas")
+    var pd_df = pd.DataFrame(Python.evaluate("{'a': [1, 1, 2], 'b': [1.0, 2.0, 3.0]}"))
+    var df = DataFrame(pd_df)
+    var result_pd = df.nunique().to_pandas()
+    assert_true(Float64(String(result_pd.iloc[0])) == 2.0)
+    assert_true(Float64(String(result_pd.iloc[1])) == 3.0)
+
+
+# ---------------------------------------------------------------------------
+# median / quantile
+# ---------------------------------------------------------------------------
+
+def test_series_median_odd():
+    var pd = Python.import_module("pandas")
+    var s = Series(pd.Series(Python.evaluate("[1.0, 2.0, 3.0]")))
+    assert_true(s.median() == 2.0)
+
+
+def test_series_median_even():
+    var pd = Python.import_module("pandas")
+    var s = Series(pd.Series(Python.evaluate("[1.0, 2.0, 3.0, 4.0]")))
+    assert_true(s.median() == 2.5)
+
+
+def test_series_median_skipna_false():
+    var pd = Python.import_module("pandas")
+    var s = Series(pd.Series(Python.evaluate("[1.0, float('nan'), 3.0]")))
+    assert_true(isnan(s.median(skipna=False)))
+
+
+def test_series_quantile_25():
+    var pd = Python.import_module("pandas")
+    var s = Series(pd.Series(Python.evaluate("[1.0, 2.0, 3.0, 4.0]")))
+    assert_true(s.quantile(0.25) == 1.75)
+
+
+def test_series_quantile_75():
+    var pd = Python.import_module("pandas")
+    var s = Series(pd.Series(Python.evaluate("[1.0, 2.0, 3.0, 4.0]")))
+    assert_true(s.quantile(0.75) == 3.25)
+
+
+def test_df_median():
+    var pd = Python.import_module("pandas")
+    var pd_df = pd.DataFrame(Python.evaluate("{'a': [1.0, 2.0, 3.0], 'b': [4.0, 5.0, 6.0]}"))
+    var df = DataFrame(pd_df)
+    var result_pd = df.median().to_pandas()
+    assert_true(Float64(String(result_pd.iloc[0])) == 2.0)
+    assert_true(Float64(String(result_pd.iloc[1])) == 5.0)
+
+
+# ---------------------------------------------------------------------------
+# describe (still a stub)
+# ---------------------------------------------------------------------------
 
 def test_df_describe_stub():
     var pd = Python.import_module("pandas")
@@ -72,19 +272,13 @@ def test_df_describe_stub():
         _ = df.describe()
     except:
         raised = True
-    _raises("DataFrame.describe", raised)
+    if not raised:
+        raise Error("DataFrame.describe should have raised")
 
 
-def test_series_mean_stub():
-    var pd = Python.import_module("pandas")
-    var s = Series(pd.Series(Python.evaluate("[1.0, 2.0, 3.0]")))
-    var raised = False
-    try:
-        _ = s.mean()
-    except:
-        raised = True
-    _raises("Series.mean", raised)
-
+# ---------------------------------------------------------------------------
+# value_counts (still a stub)
+# ---------------------------------------------------------------------------
 
 def test_series_value_counts_stub():
     var pd = Python.import_module("pandas")
@@ -94,7 +288,8 @@ def test_series_value_counts_stub():
         _ = s.value_counts()
     except:
         raised = True
-    _raises("Series.value_counts", raised)
+    if not raised:
+        raise Error("Series.value_counts should have raised")
 
 
 def main():


### PR DESCRIPTION
## Summary

- Implements `count`, `mean`, `min`, `max`, `var`, `std`, `nunique`, `quantile`, and `median` natively on `Column`, `Series`, and `DataFrame` (closes #1)
- All methods are null-mask-aware (`skipna` / `ddof` parameters), following the same pattern as the existing `sum()` implementation
- `DataFrame` methods delegate per-column to the corresponding `Column` method, producing a `Series` result (same structure as `DataFrame.sum()`)
- `describe()` remains a stub (composite operation, deferred)

## Test plan

- [ ] `pixi run test` passes — all 10 test suites green (34 aggregation tests, up from 7)
- [ ] `pixi run update-compat` run — compat table reflects 63 implemented methods
- [ ] Manually verify `mean`, `std`, `quantile` output matches pandas for int, float, and null-containing columns