### PR TITLE
feat: implement Series basic aggregations (closes #15)

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ In CI it runs after the test suite and the result is committed back to the branc
 | Category | Stubs | Implemented |
 |----------|-------|-------------|
 | DataFrame | 91 | 26 |
-| Series | 63 | 22 |
+| Series | 61 | 24 |
 | GroupBy (DataFrame) | 16 | 1 |
 | GroupBy (Series) | 15 | 1 |
 | String accessor | 18 | 1 |
@@ -89,7 +89,7 @@ In CI it runs after the test suite and the result is committed back to the branc
 | Index | 3 | 11 |
 | IO | 12 | 0 |
 | Reshape | 1 | 0 |
-| **Total** | **236** | **63** |
+| **Total** | **234** | **65** |
 <!-- COMPAT_TABLE_END -->
 
 ## Contributing

--- a/bison/column.mojo
+++ b/bison/column.mojo
@@ -507,6 +507,124 @@ struct Column(Copyable, Movable):
             return zero / zero
         return self.quantile(0.5)
 
+    fn describe(self) raises -> Column:
+        """Return summary statistics as a new Column with a string index.
+
+        Produces 8 elements: count, mean, std, min, 25%, 50%, 75%, max.
+        Raises for non-numeric column types (the underlying aggregation
+        methods propagate the error).
+        """
+        var data = List[Float64]()
+        data.append(Float64(self.count()))
+        data.append(self.mean())
+        data.append(self.std())
+        data.append(self.min())
+        data.append(self.quantile(0.25))
+        data.append(self.quantile(0.50))
+        data.append(self.quantile(0.75))
+        data.append(self.max())
+
+        var idx = List[PythonObject]()
+        idx.append(PythonObject("count"))
+        idx.append(PythonObject("mean"))
+        idx.append(PythonObject("std"))
+        idx.append(PythonObject("min"))
+        idx.append(PythonObject("25%"))
+        idx.append(PythonObject("50%"))
+        idx.append(PythonObject("75%"))
+        idx.append(PythonObject("max"))
+
+        return Column(self.name, ColumnData(data^), float64, idx^)
+
+    fn value_counts(self, normalize: Bool = False, sort: Bool = True) raises -> Column:
+        """Return a Column of counts (or proportions) per unique value.
+
+        The index holds the original values; the data holds the counts.
+        sort=True (default) orders results by count descending.
+        Raises for object/datetime column types.
+        """
+        var has_mask = len(self._null_mask) > 0
+        var unique_keys = List[String]()
+        var counts_dict = Dict[String, Int]()
+
+        if self._data.isa[List[Int64]]():
+            for i in range(len(self._data[List[Int64]])):
+                if has_mask and self._null_mask[i]:
+                    continue
+                var k = String(self._data[List[Int64]][i])
+                if k not in counts_dict:
+                    unique_keys.append(k)
+                counts_dict[k] = counts_dict.get(k, 0) + 1
+        elif self._data.isa[List[Float64]]():
+            for i in range(len(self._data[List[Float64]])):
+                if has_mask and self._null_mask[i]:
+                    continue
+                var k = String(self._data[List[Float64]][i])
+                if k not in counts_dict:
+                    unique_keys.append(k)
+                counts_dict[k] = counts_dict.get(k, 0) + 1
+        elif self._data.isa[List[Bool]]():
+            for i in range(len(self._data[List[Bool]])):
+                if has_mask and self._null_mask[i]:
+                    continue
+                var k = String(self._data[List[Bool]][i])
+                if k not in counts_dict:
+                    unique_keys.append(k)
+                counts_dict[k] = counts_dict.get(k, 0) + 1
+        else:
+            raise Error("value_counts: unsupported column type")
+
+        var n = len(unique_keys)
+
+        # Materialise per-key counts in insertion order.
+        var count_vals = List[Int]()
+        for i in range(n):
+            count_vals.append(counts_dict[unique_keys[i]])
+
+        # Compute a sorted permutation (insertion sort, stable, count desc).
+        var sorted_order = List[Int]()
+        for i in range(n):
+            sorted_order.append(i)
+        if sort:
+            for i in range(1, n):
+                var key_idx = sorted_order[i]
+                var key_cnt = count_vals[key_idx]
+                var j = i - 1
+                while j >= 0 and count_vals[sorted_order[j]] < key_cnt:
+                    sorted_order[j + 1] = sorted_order[j]
+                    j -= 1
+                sorted_order[j + 1] = key_idx
+
+        # Build result index (original values) and counts.
+        var builtins = Python.import_module("builtins")
+        var result_counts = List[Int64]()
+        var result_idx = List[PythonObject]()
+
+        if self._data.isa[List[Int64]]():
+            for i in range(n):
+                var si = sorted_order[i]
+                result_counts.append(Int64(count_vals[si]))
+                result_idx.append(builtins.int(unique_keys[si]))
+        elif self._data.isa[List[Float64]]():
+            for i in range(n):
+                var si = sorted_order[i]
+                result_counts.append(Int64(count_vals[si]))
+                result_idx.append(builtins.float(unique_keys[si]))
+        else:  # Bool — only remaining arm after the raise above
+            for i in range(n):
+                var si = sorted_order[i]
+                result_counts.append(Int64(count_vals[si]))
+                result_idx.append(PythonObject(unique_keys[si] == "True"))
+
+        if normalize:
+            var total = Float64(self.count())
+            var norm_data = List[Float64]()
+            for i in range(n):
+                norm_data.append(Float64(result_counts[i]) / total)
+            return Column("count", ColumnData(norm_data^), float64, result_idx^)
+
+        return Column("count", ColumnData(result_counts^), int64, result_idx^)
+
     # ------------------------------------------------------------------
     # Pandas interop
     # ------------------------------------------------------------------

--- a/bison/series.mojo
+++ b/bison/series.mojo
@@ -209,12 +209,12 @@ struct Series(Copyable, Movable):
         return self._col.nunique()
 
     fn describe(self) raises -> Series:
-        _not_implemented("Series.describe")
-        return Series()
+        """Return summary statistics as a Series (count, mean, std, min, quartiles, max)."""
+        return Series(self._col.describe())
 
     fn value_counts(self, normalize: Bool = False, sort: Bool = True) raises -> Series:
-        _not_implemented("Series.value_counts")
-        return Series()
+        """Return a Series with the count (or proportion) of each unique value."""
+        return Series(self._col.value_counts(normalize, sort))
 
     fn quantile(self, q: Float64 = 0.5) raises -> Float64:
         return self._col.quantile(q)

--- a/tests/test_aggregation.mojo
+++ b/tests/test_aggregation.mojo
@@ -277,19 +277,16 @@ def test_df_describe_stub():
 
 
 # ---------------------------------------------------------------------------
-# value_counts (still a stub)
+# value_counts
 # ---------------------------------------------------------------------------
 
-def test_series_value_counts_stub():
+def test_series_value_counts():
     var pd = Python.import_module("pandas")
-    var s = Series(pd.Series(Python.evaluate("['a', 'b', 'a']")))
-    var raised = False
-    try:
-        _ = s.value_counts()
-    except:
-        raised = True
-    if not raised:
-        raise Error("Series.value_counts should have raised")
+    var s = Series(pd.Series(Python.evaluate("[1, 2, 2, 3, 3, 3]")))
+    var vc = s.value_counts()
+    # 3 unique values; first element should have the highest count (3)
+    assert_true(vc.size() == 3)
+    assert_true(vc.to_pandas().iloc[0] == 3)
 
 
 def main():

--- a/tests/test_series.mojo
+++ b/tests/test_series.mojo
@@ -51,6 +51,76 @@ def test_sum():
     assert_true(s.sum() == 6.0)
 
 
+def test_mean():
+    var pd = Python.import_module("pandas")
+    var s = Series(pd.Series(Python.evaluate("[1, 2, 3]")))
+    assert_true(s.mean() == 2.0)
+
+
+def test_median():
+    var pd = Python.import_module("pandas")
+    var s = Series(pd.Series(Python.evaluate("[1, 2, 3]")))
+    assert_true(s.median() == 2.0)
+
+
+def test_min():
+    var pd = Python.import_module("pandas")
+    var s = Series(pd.Series(Python.evaluate("[3, 1, 2]")))
+    assert_true(s.min() == 1.0)
+
+
+def test_max():
+    var pd = Python.import_module("pandas")
+    var s = Series(pd.Series(Python.evaluate("[3, 1, 2]")))
+    assert_true(s.max() == 3.0)
+
+
+def test_std():
+    var pd = Python.import_module("pandas")
+    # std([1, 3, 5], ddof=1) == 2.0
+    var s = Series(pd.Series(Python.evaluate("[1, 3, 5]")))
+    assert_true(s.std() == 2.0)
+
+
+def test_var():
+    var pd = Python.import_module("pandas")
+    # var([1, 3, 5], ddof=1) == 4.0
+    var s = Series(pd.Series(Python.evaluate("[1, 3, 5]")))
+    assert_true(s.var() == 4.0)
+
+
+def test_count():
+    var pd = Python.import_module("pandas")
+    var s = Series(pd.Series(Python.evaluate("[1, 2, 3]")))
+    assert_equal(s.count(), 3)
+
+
+def test_nunique():
+    var pd = Python.import_module("pandas")
+    var s = Series(pd.Series(Python.evaluate("[1, 2, 2, 3, 3, 3]")))
+    assert_equal(s.nunique(), 3)
+
+
+def test_quantile():
+    var pd = Python.import_module("pandas")
+    var s = Series(pd.Series(Python.evaluate("[1, 2, 3, 4, 5]")))
+    assert_true(s.quantile(0.5) == 3.0)
+
+
+def test_describe():
+    var pd = Python.import_module("pandas")
+    var s = Series(pd.Series(Python.evaluate("[1, 2, 3, 4, 5]")))
+    var d = s.describe()
+    assert_equal(d.size(), 8)
+
+
+def test_value_counts():
+    var pd = Python.import_module("pandas")
+    var s = Series(pd.Series(Python.evaluate("[1, 2, 2, 3, 3, 3]")))
+    var vc = s.value_counts()
+    assert_equal(vc.size(), 3)
+
+
 def test_stub_raises_head():
     var pd = Python.import_module("pandas")
     var s = Series(pd.Series(Python.evaluate("[1, 2, 3]")))


### PR DESCRIPTION
## Summary

Closes #15.

### What changed

- **`Column.describe()`** — native Mojo implementation: calls existing aggregation primitives (`count`, `mean`, `std`, `min`, `quantile` at 25/50/75%, `max`) and returns a `Float64` Column with a string-valued PythonObject index matching pandas output.
- **`Column.value_counts()`** — native Mojo implementation: `Dict[String, Int]` counting with a permutation insertion-sort for descending-count ordering. Supports `Int64`, `Float64`, and `Bool` Column arms; raises for `object`/`datetime` arms. `normalize=True` returns float64 proportions.
- **`Series.describe()` / `Series.value_counts()`** — delegate to the new Column methods (no pandas round-trip).

### Tests

- `tests/test_series.mojo`: added real assertions for `mean`, `median`, `min`, `max`, `std`, `var`, `count`, `nunique`, `quantile`, `describe`, `value_counts` (19 tests, all passing).
- `tests/test_aggregation.mojo`: converted `test_series_value_counts_stub` to a real assertion test.

### Compat table

Series implemented count: 22 → 24 (all 10 test files pass).