### PR TITLE
Implement Series arithmetic operators natively in Mojo

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ In CI it runs after the test suite and the result is committed back to the branc
 | Category | Stubs | Implemented |
 |----------|-------|-------------|
 | DataFrame | 79 | 38 |
-| Series | 57 | 28 |
+| Series | 43 | 42 |
 | GroupBy (DataFrame) | 16 | 1 |
 | GroupBy (Series) | 15 | 1 |
 | String accessor | 18 | 1 |
@@ -90,7 +90,7 @@ In CI it runs after the test suite and the result is committed back to the branc
 | Index | 0 | 14 |
 | IO | 10 | 2 |
 | Reshape | 1 | 0 |
-| **Total** | **213** | **86** |
+| **Total** | **199** | **100** |
 <!-- COMPAT_TABLE_END -->
 
 ## Contributing

--- a/bison/column.mojo
+++ b/bison/column.mojo
@@ -2,7 +2,7 @@ from python import Python, PythonObject
 from utils import Variant
 from memory import bitcast
 from collections import Dict, Set
-from math import sqrt
+from math import sqrt, floor
 from .dtypes import (
     BisonDtype,
     int8, int16, int32, int64,
@@ -781,6 +781,195 @@ struct Column(Copyable, Movable):
             return Column("count", ColumnData(norm_data^), float64, result_idx^)
 
         return Column("count", ColumnData(result_counts^), int64, result_idx^)
+
+    # ------------------------------------------------------------------
+    # Element-wise arithmetic helpers
+    # ------------------------------------------------------------------
+
+    fn _to_float64_list(self) raises -> List[Float64]:
+        """Convert the active numeric arm to a List[Float64].
+
+        Raises for non-numeric (String, PythonObject) column types.
+        """
+        var result = List[Float64]()
+        if self._data.isa[List[Int64]]():
+            ref d = self._data[List[Int64]]
+            for i in range(len(d)):
+                result.append(Float64(d[i]))
+        elif self._data.isa[List[Float64]]():
+            ref d = self._data[List[Float64]]
+            for i in range(len(d)):
+                result.append(d[i])
+        elif self._data.isa[List[Bool]]():
+            ref d = self._data[List[Bool]]
+            for i in range(len(d)):
+                result.append(1.0 if d[i] else 0.0)
+        else:
+            raise Error("arith: non-numeric column type")
+        return result^
+
+    fn _arith_build(self, other: Column, var result: List[Float64], var result_mask: List[Bool], has_any_null: Bool) -> Column:
+        """Wrap a computed Float64 list into a Column, attaching mask only if needed."""
+        var col_data = ColumnData(result^)
+        var dtype = Column._sniff_dtype(col_data)
+        var col = Column(self.name, col_data^, dtype)
+        if has_any_null:
+            col._null_mask = result_mask^
+        return col^
+
+    fn _arith_add(self, other: Column) raises -> Column:
+        if self.__len__() != other.__len__():
+            raise Error("add: length mismatch (" + String(self.__len__()) + " vs " + String(other.__len__()) + ")")
+        var a = self._to_float64_list()
+        var b = other._to_float64_list()
+        var has_a_mask = len(self._null_mask) > 0
+        var has_b_mask = len(other._null_mask) > 0
+        var result = List[Float64]()
+        var result_mask = List[Bool]()
+        var has_any_null = False
+        var nan = Float64(0) / Float64(0)
+        for i in range(len(a)):
+            var is_null = (has_a_mask and self._null_mask[i]) or (has_b_mask and other._null_mask[i])
+            if is_null:
+                result.append(nan)
+                result_mask.append(True)
+                has_any_null = True
+            else:
+                result.append(a[i] + b[i])
+                result_mask.append(False)
+        return self._arith_build(other, result^, result_mask^, has_any_null)
+
+    fn _arith_sub(self, other: Column) raises -> Column:
+        if self.__len__() != other.__len__():
+            raise Error("sub: length mismatch (" + String(self.__len__()) + " vs " + String(other.__len__()) + ")")
+        var a = self._to_float64_list()
+        var b = other._to_float64_list()
+        var has_a_mask = len(self._null_mask) > 0
+        var has_b_mask = len(other._null_mask) > 0
+        var result = List[Float64]()
+        var result_mask = List[Bool]()
+        var has_any_null = False
+        var nan = Float64(0) / Float64(0)
+        for i in range(len(a)):
+            var is_null = (has_a_mask and self._null_mask[i]) or (has_b_mask and other._null_mask[i])
+            if is_null:
+                result.append(nan)
+                result_mask.append(True)
+                has_any_null = True
+            else:
+                result.append(a[i] - b[i])
+                result_mask.append(False)
+        return self._arith_build(other, result^, result_mask^, has_any_null)
+
+    fn _arith_mul(self, other: Column) raises -> Column:
+        if self.__len__() != other.__len__():
+            raise Error("mul: length mismatch (" + String(self.__len__()) + " vs " + String(other.__len__()) + ")")
+        var a = self._to_float64_list()
+        var b = other._to_float64_list()
+        var has_a_mask = len(self._null_mask) > 0
+        var has_b_mask = len(other._null_mask) > 0
+        var result = List[Float64]()
+        var result_mask = List[Bool]()
+        var has_any_null = False
+        var nan = Float64(0) / Float64(0)
+        for i in range(len(a)):
+            var is_null = (has_a_mask and self._null_mask[i]) or (has_b_mask and other._null_mask[i])
+            if is_null:
+                result.append(nan)
+                result_mask.append(True)
+                has_any_null = True
+            else:
+                result.append(a[i] * b[i])
+                result_mask.append(False)
+        return self._arith_build(other, result^, result_mask^, has_any_null)
+
+    fn _arith_div(self, other: Column) raises -> Column:
+        if self.__len__() != other.__len__():
+            raise Error("div: length mismatch (" + String(self.__len__()) + " vs " + String(other.__len__()) + ")")
+        var a = self._to_float64_list()
+        var b = other._to_float64_list()
+        var has_a_mask = len(self._null_mask) > 0
+        var has_b_mask = len(other._null_mask) > 0
+        var result = List[Float64]()
+        var result_mask = List[Bool]()
+        var has_any_null = False
+        var nan = Float64(0) / Float64(0)
+        for i in range(len(a)):
+            var is_null = (has_a_mask and self._null_mask[i]) or (has_b_mask and other._null_mask[i])
+            if is_null:
+                result.append(nan)
+                result_mask.append(True)
+                has_any_null = True
+            else:
+                result.append(a[i] / b[i])
+                result_mask.append(False)
+        return self._arith_build(other, result^, result_mask^, has_any_null)
+
+    fn _arith_floordiv(self, other: Column) raises -> Column:
+        if self.__len__() != other.__len__():
+            raise Error("floordiv: length mismatch (" + String(self.__len__()) + " vs " + String(other.__len__()) + ")")
+        var a = self._to_float64_list()
+        var b = other._to_float64_list()
+        var has_a_mask = len(self._null_mask) > 0
+        var has_b_mask = len(other._null_mask) > 0
+        var result = List[Float64]()
+        var result_mask = List[Bool]()
+        var has_any_null = False
+        var nan = Float64(0) / Float64(0)
+        for i in range(len(a)):
+            var is_null = (has_a_mask and self._null_mask[i]) or (has_b_mask and other._null_mask[i])
+            if is_null:
+                result.append(nan)
+                result_mask.append(True)
+                has_any_null = True
+            else:
+                result.append(floor(a[i] / b[i]))
+                result_mask.append(False)
+        return self._arith_build(other, result^, result_mask^, has_any_null)
+
+    fn _arith_mod(self, other: Column) raises -> Column:
+        if self.__len__() != other.__len__():
+            raise Error("mod: length mismatch (" + String(self.__len__()) + " vs " + String(other.__len__()) + ")")
+        var a = self._to_float64_list()
+        var b = other._to_float64_list()
+        var has_a_mask = len(self._null_mask) > 0
+        var has_b_mask = len(other._null_mask) > 0
+        var result = List[Float64]()
+        var result_mask = List[Bool]()
+        var has_any_null = False
+        var nan = Float64(0) / Float64(0)
+        for i in range(len(a)):
+            var is_null = (has_a_mask and self._null_mask[i]) or (has_b_mask and other._null_mask[i])
+            if is_null:
+                result.append(nan)
+                result_mask.append(True)
+                has_any_null = True
+            else:
+                result.append(a[i] - floor(a[i] / b[i]) * b[i])
+                result_mask.append(False)
+        return self._arith_build(other, result^, result_mask^, has_any_null)
+
+    fn _arith_pow(self, other: Column) raises -> Column:
+        if self.__len__() != other.__len__():
+            raise Error("pow: length mismatch (" + String(self.__len__()) + " vs " + String(other.__len__()) + ")")
+        var a = self._to_float64_list()
+        var b = other._to_float64_list()
+        var has_a_mask = len(self._null_mask) > 0
+        var has_b_mask = len(other._null_mask) > 0
+        var result = List[Float64]()
+        var result_mask = List[Bool]()
+        var has_any_null = False
+        var nan = Float64(0) / Float64(0)
+        for i in range(len(a)):
+            var is_null = (has_a_mask and self._null_mask[i]) or (has_b_mask and other._null_mask[i])
+            if is_null:
+                result.append(nan)
+                result_mask.append(True)
+                has_any_null = True
+            else:
+                result.append(a[i] ** b[i])
+                result_mask.append(False)
+        return self._arith_build(other, result^, result_mask^, has_any_null)
 
     # ------------------------------------------------------------------
     # Cumulative operations

--- a/bison/series.mojo
+++ b/bison/series.mojo
@@ -94,60 +94,46 @@ struct Series(Copyable, Movable):
     # ------------------------------------------------------------------
 
     fn add(self, other: Series) raises -> Series:
-        _not_implemented("Series.add")
-        return Series()
+        return Series(self._col._arith_add(other._col))
 
     fn sub(self, other: Series) raises -> Series:
-        _not_implemented("Series.sub")
-        return Series()
+        return Series(self._col._arith_sub(other._col))
 
     fn mul(self, other: Series) raises -> Series:
-        _not_implemented("Series.mul")
-        return Series()
+        return Series(self._col._arith_mul(other._col))
 
     fn div(self, other: Series) raises -> Series:
-        _not_implemented("Series.div")
-        return Series()
+        return Series(self._col._arith_div(other._col))
 
     fn floordiv(self, other: Series) raises -> Series:
-        _not_implemented("Series.floordiv")
-        return Series()
+        return Series(self._col._arith_floordiv(other._col))
 
     fn mod(self, other: Series) raises -> Series:
-        _not_implemented("Series.mod")
-        return Series()
+        return Series(self._col._arith_mod(other._col))
 
     fn pow(self, other: Series) raises -> Series:
-        _not_implemented("Series.pow")
-        return Series()
+        return Series(self._col._arith_pow(other._col))
 
     fn radd(self, other: Series) raises -> Series:
-        _not_implemented("Series.radd")
-        return Series()
+        return Series(other._col._arith_add(self._col))
 
     fn rsub(self, other: Series) raises -> Series:
-        _not_implemented("Series.rsub")
-        return Series()
+        return Series(other._col._arith_sub(self._col))
 
     fn rmul(self, other: Series) raises -> Series:
-        _not_implemented("Series.rmul")
-        return Series()
+        return Series(other._col._arith_mul(self._col))
 
     fn rdiv(self, other: Series) raises -> Series:
-        _not_implemented("Series.rdiv")
-        return Series()
+        return Series(other._col._arith_div(self._col))
 
     fn rfloordiv(self, other: Series) raises -> Series:
-        _not_implemented("Series.rfloordiv")
-        return Series()
+        return Series(other._col._arith_floordiv(self._col))
 
     fn rmod(self, other: Series) raises -> Series:
-        _not_implemented("Series.rmod")
-        return Series()
+        return Series(other._col._arith_mod(self._col))
 
     fn rpow(self, other: Series) raises -> Series:
-        _not_implemented("Series.rpow")
-        return Series()
+        return Series(other._col._arith_pow(self._col))
 
     # ------------------------------------------------------------------
     # Comparison

--- a/tests/test_series.mojo
+++ b/tests/test_series.mojo
@@ -132,5 +132,157 @@ def test_stub_raises_head():
     assert_true(raised)
 
 
+def test_add():
+    var pd = Python.import_module("pandas")
+    var s1 = Series(pd.Series(Python.evaluate("[1, 2, 3]")))
+    var s2 = Series(pd.Series(Python.evaluate("[4, 5, 6]")))
+    var rp = s1.add(s2).to_pandas()
+    assert_true(Float64(String(rp.iloc[0])) == 5.0)
+    assert_true(Float64(String(rp.iloc[1])) == 7.0)
+    assert_true(Float64(String(rp.iloc[2])) == 9.0)
+
+
+def test_sub():
+    var pd = Python.import_module("pandas")
+    var s1 = Series(pd.Series(Python.evaluate("[1, 2, 3]")))
+    var s2 = Series(pd.Series(Python.evaluate("[4, 5, 6]")))
+    var rp = s1.sub(s2).to_pandas()
+    assert_true(Float64(String(rp.iloc[0])) == -3.0)
+    assert_true(Float64(String(rp.iloc[1])) == -3.0)
+    assert_true(Float64(String(rp.iloc[2])) == -3.0)
+
+
+def test_mul():
+    var pd = Python.import_module("pandas")
+    var s1 = Series(pd.Series(Python.evaluate("[1, 2, 3]")))
+    var s2 = Series(pd.Series(Python.evaluate("[4, 5, 6]")))
+    var rp = s1.mul(s2).to_pandas()
+    assert_true(Float64(String(rp.iloc[0])) == 4.0)
+    assert_true(Float64(String(rp.iloc[1])) == 10.0)
+    assert_true(Float64(String(rp.iloc[2])) == 18.0)
+
+
+def test_div():
+    var pd = Python.import_module("pandas")
+    var s1 = Series(pd.Series(Python.evaluate("[1.0, 2.0, 3.0]")))
+    var s2 = Series(pd.Series(Python.evaluate("[4.0, 5.0, 6.0]")))
+    var rp = s1.div(s2).to_pandas()
+    assert_true(Float64(String(rp.iloc[0])) == 0.25)
+    assert_true(Float64(String(rp.iloc[1])) == 0.4)
+    assert_true(Float64(String(rp.iloc[2])) == 0.5)
+
+
+def test_floordiv():
+    var pd = Python.import_module("pandas")
+    var s1 = Series(pd.Series(Python.evaluate("[1, 2, 3]")))
+    var s2 = Series(pd.Series(Python.evaluate("[4, 5, 6]")))
+    var rp = s1.floordiv(s2).to_pandas()
+    assert_true(Float64(String(rp.iloc[0])) == 0.0)
+    assert_true(Float64(String(rp.iloc[1])) == 0.0)
+    assert_true(Float64(String(rp.iloc[2])) == 0.0)
+
+
+def test_mod():
+    var pd = Python.import_module("pandas")
+    var s1 = Series(pd.Series(Python.evaluate("[10, 7, 9]")))
+    var s2 = Series(pd.Series(Python.evaluate("[3, 4, 5]")))
+    var rp = s1.mod(s2).to_pandas()
+    assert_true(Float64(String(rp.iloc[0])) == 1.0)
+    assert_true(Float64(String(rp.iloc[1])) == 3.0)
+    assert_true(Float64(String(rp.iloc[2])) == 4.0)
+
+
+def test_pow():
+    var pd = Python.import_module("pandas")
+    var s1 = Series(pd.Series(Python.evaluate("[2, 3, 4]")))
+    var s2 = Series(pd.Series(Python.evaluate("[3, 2, 1]")))
+    var rp = s1.pow(s2).to_pandas()
+    assert_true(Float64(String(rp.iloc[0])) == 8.0)
+    assert_true(Float64(String(rp.iloc[1])) == 9.0)
+    assert_true(Float64(String(rp.iloc[2])) == 4.0)
+
+
+def test_radd():
+    var pd = Python.import_module("pandas")
+    var s1 = Series(pd.Series(Python.evaluate("[1, 2, 3]")))
+    var s2 = Series(pd.Series(Python.evaluate("[4, 5, 6]")))
+    var rp = s1.radd(s2).to_pandas()
+    assert_true(Float64(String(rp.iloc[0])) == 5.0)
+    assert_true(Float64(String(rp.iloc[1])) == 7.0)
+    assert_true(Float64(String(rp.iloc[2])) == 9.0)
+
+
+def test_rsub():
+    var pd = Python.import_module("pandas")
+    var s1 = Series(pd.Series(Python.evaluate("[1, 2, 3]")))
+    var s2 = Series(pd.Series(Python.evaluate("[4, 5, 6]")))
+    var rp = s1.rsub(s2).to_pandas()
+    assert_true(Float64(String(rp.iloc[0])) == 3.0)
+    assert_true(Float64(String(rp.iloc[1])) == 3.0)
+    assert_true(Float64(String(rp.iloc[2])) == 3.0)
+
+
+def test_rmul():
+    var pd = Python.import_module("pandas")
+    var s1 = Series(pd.Series(Python.evaluate("[1, 2, 3]")))
+    var s2 = Series(pd.Series(Python.evaluate("[4, 5, 6]")))
+    var rp = s1.rmul(s2).to_pandas()
+    assert_true(Float64(String(rp.iloc[0])) == 4.0)
+    assert_true(Float64(String(rp.iloc[1])) == 10.0)
+    assert_true(Float64(String(rp.iloc[2])) == 18.0)
+
+
+def test_rdiv():
+    var pd = Python.import_module("pandas")
+    var s1 = Series(pd.Series(Python.evaluate("[4.0, 5.0, 6.0]")))
+    var s2 = Series(pd.Series(Python.evaluate("[1.0, 2.0, 3.0]")))
+    var rp = s1.rdiv(s2).to_pandas()
+    assert_true(Float64(String(rp.iloc[0])) == 0.25)
+    assert_true(Float64(String(rp.iloc[1])) == 0.4)
+    assert_true(Float64(String(rp.iloc[2])) == 0.5)
+
+
+def test_rfloordiv():
+    var pd = Python.import_module("pandas")
+    var s1 = Series(pd.Series(Python.evaluate("[4, 5, 6]")))
+    var s2 = Series(pd.Series(Python.evaluate("[1, 2, 3]")))
+    var rp = s1.rfloordiv(s2).to_pandas()
+    assert_true(Float64(String(rp.iloc[0])) == 0.0)
+    assert_true(Float64(String(rp.iloc[1])) == 0.0)
+    assert_true(Float64(String(rp.iloc[2])) == 0.0)
+
+
+def test_rmod():
+    var pd = Python.import_module("pandas")
+    var s1 = Series(pd.Series(Python.evaluate("[3, 4, 5]")))
+    var s2 = Series(pd.Series(Python.evaluate("[10, 7, 9]")))
+    var rp = s1.rmod(s2).to_pandas()
+    assert_true(Float64(String(rp.iloc[0])) == 1.0)
+    assert_true(Float64(String(rp.iloc[1])) == 3.0)
+    assert_true(Float64(String(rp.iloc[2])) == 4.0)
+
+
+def test_rpow():
+    var pd = Python.import_module("pandas")
+    var s1 = Series(pd.Series(Python.evaluate("[3, 2, 1]")))
+    var s2 = Series(pd.Series(Python.evaluate("[2, 3, 4]")))
+    var rp = s1.rpow(s2).to_pandas()
+    assert_true(Float64(String(rp.iloc[0])) == 8.0)
+    assert_true(Float64(String(rp.iloc[1])) == 9.0)
+    assert_true(Float64(String(rp.iloc[2])) == 4.0)
+
+
+def test_add_length_mismatch():
+    var pd = Python.import_module("pandas")
+    var s1 = Series(pd.Series(Python.evaluate("[1, 2]")))
+    var s2 = Series(pd.Series(Python.evaluate("[1]")))
+    var raised = False
+    try:
+        _ = s1.add(s2)
+    except:
+        raised = True
+    assert_true(raised)
+
+
 def main():
     TestSuite.discover_tests[__functions_in_module()]().run()


### PR DESCRIPTION
## Summary

- Adds `_to_float64_list()` and `_arith_build()` helpers plus 7 `_arith_*` methods to `Column` for element-wise arithmetic
- Implements all 14 `Series` arithmetic stubs (`add`/`sub`/`mul`/`div`/`floordiv`/`mod`/`pow` + reversed variants) as one-line delegations to the new `Column` helpers
- All ops promote to Float64, propagate nulls as NaN, and raise on length mismatch or non-numeric column type
- Adds 15 new tests to `tests/test_series.mojo` (7 forward, 7 reversed, 1 length-mismatch error)
- Updates README compatibility table via `update-compat`

Closes #17

## Test plan

- [x] `pixi run test` — all 11 test files pass (34/34 in `test_series.mojo`)
- [x] `pixi run update-compat` — compat table refreshed (Series: 42 implemented)