### PR TITLE
Implement Series comparison operators (eq, ne, lt, le, gt, ge)

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ In CI it runs after the test suite and the result is committed back to the branc
 | Category | Stubs | Implemented |
 |----------|-------|-------------|
 | DataFrame | 79 | 38 |
-| Series | 31 | 54 |
+| Series | 25 | 60 |
 | GroupBy (DataFrame) | 16 | 1 |
 | GroupBy (Series) | 15 | 1 |
 | String accessor | 18 | 1 |
@@ -90,7 +90,7 @@ In CI it runs after the test suite and the result is committed back to the branc
 | Index | 0 | 14 |
 | IO | 10 | 2 |
 | Reshape | 1 | 0 |
-| **Total** | **187** | **112** |
+| **Total** | **181** | **118** |
 <!-- COMPAT_TABLE_END -->
 
 ## Contributing

--- a/bison/column.mojo
+++ b/bison/column.mojo
@@ -130,6 +130,17 @@ comptime _ARITH_MOD      = 5
 comptime _ARITH_POW      = 6
 
 
+# ------------------------------------------------------------------
+# Compile-time operation selectors for Column._cmp_op
+# ------------------------------------------------------------------
+comptime _CMP_EQ = 0
+comptime _CMP_NE = 1
+comptime _CMP_LT = 2
+comptime _CMP_LE = 3
+comptime _CMP_GT = 4
+comptime _CMP_GE = 5
+
+
 struct Column(Copyable, Movable, Sized):
     """A single typed array representing one column of a DataFrame or a Series.
 
@@ -900,6 +911,77 @@ struct Column(Copyable, Movable, Sized):
 
     fn _arith_pow(self, other: Column) raises -> Column:
         return self._arith_op[_ARITH_POW]("pow", other)
+
+    # ------------------------------------------------------------------
+    # Comparison operations
+    # ------------------------------------------------------------------
+
+    fn _cmp_op[op: Int](self, op_name: String, other: Column) raises -> Column:
+        """Core element-wise binary comparison kernel.
+
+        ``op`` is a compile-time constant (``_CMP_*``) that selects the
+        operation; ``@parameter if`` folds the branch at compile time so each
+        specialisation compiles to a tight scalar loop with no runtime dispatch.
+        Null propagation: if either input element is null, the result is null.
+        """
+        if len(self) != len(other):
+            raise Error(op_name + ": length mismatch (" + String(len(self)) + " vs " + String(len(other)) + ")")
+        var a = self._to_float64_list()
+        var b = other._to_float64_list()
+        var has_a_mask = len(self._null_mask) > 0
+        var has_b_mask = len(other._null_mask) > 0
+        var result = List[Bool]()
+        var result_mask = List[Bool]()
+        var has_any_null = False
+        for i in range(len(a)):
+            var is_null = (has_a_mask and self._null_mask[i]) or (has_b_mask and other._null_mask[i])
+            if is_null:
+                result.append(False)
+                result_mask.append(True)
+                has_any_null = True
+            else:
+                var v: Bool
+                @parameter
+                if op == _CMP_EQ:
+                    v = a[i] == b[i]
+                elif op == _CMP_NE:
+                    v = a[i] != b[i]
+                elif op == _CMP_LT:
+                    v = a[i] < b[i]
+                elif op == _CMP_LE:
+                    v = a[i] <= b[i]
+                elif op == _CMP_GT:
+                    v = a[i] > b[i]
+                elif op == _CMP_GE:
+                    v = a[i] >= b[i]
+                else:
+                    v = False  # unreachable: compile-time guard
+                result.append(v)
+                result_mask.append(False)
+        var col_data = ColumnData(result^)
+        var dtype = Column._sniff_dtype(col_data)
+        var col = Column(self.name, col_data^, dtype)
+        if has_any_null:
+            col._null_mask = result_mask^
+        return col^
+
+    fn _cmp_eq(self, other: Column) raises -> Column:
+        return self._cmp_op[_CMP_EQ]("eq", other)
+
+    fn _cmp_ne(self, other: Column) raises -> Column:
+        return self._cmp_op[_CMP_NE]("ne", other)
+
+    fn _cmp_lt(self, other: Column) raises -> Column:
+        return self._cmp_op[_CMP_LT]("lt", other)
+
+    fn _cmp_le(self, other: Column) raises -> Column:
+        return self._cmp_op[_CMP_LE]("le", other)
+
+    fn _cmp_gt(self, other: Column) raises -> Column:
+        return self._cmp_op[_CMP_GT]("gt", other)
+
+    fn _cmp_ge(self, other: Column) raises -> Column:
+        return self._cmp_op[_CMP_GE]("ge", other)
 
     # ------------------------------------------------------------------
     # Cumulative operations

--- a/bison/series.mojo
+++ b/bison/series.mojo
@@ -169,28 +169,22 @@ struct Series(Copyable, Movable):
     # ------------------------------------------------------------------
 
     fn eq(self, other: Series) raises -> Series:
-        _not_implemented("Series.eq")
-        return Series()
+        return Series(self._col._cmp_eq(other._col))
 
     fn ne(self, other: Series) raises -> Series:
-        _not_implemented("Series.ne")
-        return Series()
+        return Series(self._col._cmp_ne(other._col))
 
     fn lt(self, other: Series) raises -> Series:
-        _not_implemented("Series.lt")
-        return Series()
+        return Series(self._col._cmp_lt(other._col))
 
     fn le(self, other: Series) raises -> Series:
-        _not_implemented("Series.le")
-        return Series()
+        return Series(self._col._cmp_le(other._col))
 
     fn gt(self, other: Series) raises -> Series:
-        _not_implemented("Series.gt")
-        return Series()
+        return Series(self._col._cmp_gt(other._col))
 
     fn ge(self, other: Series) raises -> Series:
-        _not_implemented("Series.ge")
-        return Series()
+        return Series(self._col._cmp_ge(other._col))
 
     # ------------------------------------------------------------------
     # Aggregation

--- a/tests/test_series.mojo
+++ b/tests/test_series.mojo
@@ -533,5 +533,75 @@ def test_bfill_no_nulls():
     assert_true(Float64(String(rp.iloc[1])) == 2.0)
 
 
+def test_eq():
+    var pd = Python.import_module("pandas")
+    var s1 = Series(pd.Series(Python.evaluate("[1, 2, 3]")))
+    var s2 = Series(pd.Series(Python.evaluate("[1, 0, 3]")))
+    var rp = s1.eq(s2).to_pandas()
+    assert_true(Bool(rp.iloc[0]) == True)
+    assert_true(Bool(rp.iloc[1]) == False)
+    assert_true(Bool(rp.iloc[2]) == True)
+
+
+def test_ne():
+    var pd = Python.import_module("pandas")
+    var s1 = Series(pd.Series(Python.evaluate("[1, 2, 3]")))
+    var s2 = Series(pd.Series(Python.evaluate("[1, 0, 3]")))
+    var rp = s1.ne(s2).to_pandas()
+    assert_true(Bool(rp.iloc[0]) == False)
+    assert_true(Bool(rp.iloc[1]) == True)
+    assert_true(Bool(rp.iloc[2]) == False)
+
+
+def test_lt():
+    var pd = Python.import_module("pandas")
+    var s1 = Series(pd.Series(Python.evaluate("[1, 2, 3]")))
+    var s2 = Series(pd.Series(Python.evaluate("[2, 2, 2]")))
+    var rp = s1.lt(s2).to_pandas()
+    assert_true(Bool(rp.iloc[0]) == True)
+    assert_true(Bool(rp.iloc[1]) == False)
+    assert_true(Bool(rp.iloc[2]) == False)
+
+
+def test_le():
+    var pd = Python.import_module("pandas")
+    var s1 = Series(pd.Series(Python.evaluate("[1, 2, 3]")))
+    var s2 = Series(pd.Series(Python.evaluate("[2, 2, 2]")))
+    var rp = s1.le(s2).to_pandas()
+    assert_true(Bool(rp.iloc[0]) == True)
+    assert_true(Bool(rp.iloc[1]) == True)
+    assert_true(Bool(rp.iloc[2]) == False)
+
+
+def test_gt():
+    var pd = Python.import_module("pandas")
+    var s1 = Series(pd.Series(Python.evaluate("[1, 2, 3]")))
+    var s2 = Series(pd.Series(Python.evaluate("[2, 2, 2]")))
+    var rp = s1.gt(s2).to_pandas()
+    assert_true(Bool(rp.iloc[0]) == False)
+    assert_true(Bool(rp.iloc[1]) == False)
+    assert_true(Bool(rp.iloc[2]) == True)
+
+
+def test_ge():
+    var pd = Python.import_module("pandas")
+    var s1 = Series(pd.Series(Python.evaluate("[1, 2, 3]")))
+    var s2 = Series(pd.Series(Python.evaluate("[2, 2, 2]")))
+    var rp = s1.ge(s2).to_pandas()
+    assert_true(Bool(rp.iloc[0]) == False)
+    assert_true(Bool(rp.iloc[1]) == True)
+    assert_true(Bool(rp.iloc[2]) == True)
+
+
+def test_eq_null_propagation():
+    var pd = Python.import_module("pandas")
+    var s1 = Series(pd.Series(Python.evaluate("[1.0, None, 3.0]")))
+    var s2 = Series(pd.Series(Python.evaluate("[1.0, 2.0, 3.0]")))
+    var result = s1.eq(s2)
+    assert_true(result.isna().iloc(1)[Bool])
+    assert_false(result.isna().iloc(0)[Bool])
+    assert_false(result.isna().iloc(2)[Bool])
+
+
 def main():
     TestSuite.discover_tests[__functions_in_module()]().run()


### PR DESCRIPTION
## Summary

- Adds a parameterized `_cmp_op[op: Int]` kernel on `Column` (mirrors the `_arith_op` pattern from #114): compile-time op dispatch via `@parameter if`, null propagation, `List[Bool]` result column
- Wires six thin delegating methods on `Series`: `eq`, `ne`, `lt`, `le`, `gt`, `ge`
- Adds 7 tests in `tests/test_series.mojo` (one per operator + null propagation); all 68 tests pass

Closes #18

## Test plan

- [x] `pixi run test` — 68/68 pass
- [x] `pixi run update-compat` — compat table updated (Series: 54 → 60 implemented)