### PR TITLE
fix: compatibility with Mojo nightly (v0.26.2)

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -4,6 +4,7 @@ on:
   schedule:
     - cron: '0 3 * * *'  # daily at 03:00 UTC
   workflow_dispatch:      # allow manual triggers
+  pull_request:           # run on every PR to catch nightly breakage early
 
 jobs:
   test-nightly:

--- a/bison/column.mojo
+++ b/bison/column.mojo
@@ -219,20 +219,20 @@ struct Column(Copyable, Movable, Sized):
     # them explicitly in __copyinit__ as well.
     # ------------------------------------------------------------------
 
-    fn __copyinit__(out self, existing: Self):
-        self.name  = existing.name
-        self.dtype = existing.dtype
-        self._data = existing._data
+    fn __copyinit__(out self, copy: Self):
+        self.name  = copy.name
+        self.dtype = copy.dtype
+        self._data = copy._data
         # PythonObject is not ImplicitlyCopyable — explicit .copy() required.
-        self._index = existing._index.copy()
-        self._null_mask = existing._null_mask.copy()
+        self._index = copy._index.copy()
+        self._null_mask = copy._null_mask.copy()
 
-    fn __moveinit__(out self, deinit existing: Self):
-        self.name  = existing.name^
-        self.dtype = existing.dtype^
-        self._data = existing._data^
-        self._index = existing._index^
-        self._null_mask = existing._null_mask^
+    fn __moveinit__(out self, deinit take: Self):
+        self.name  = take.name^
+        self.dtype = take.dtype^
+        self._data = take._data^
+        self._index = take._index^
+        self._null_mask = take._null_mask^
 
     # ------------------------------------------------------------------
     # Typed accessor helpers — unsafe direct Variant subscripts; callers

--- a/bison/dataframe.mojo
+++ b/bison/dataframe.mojo
@@ -73,11 +73,11 @@ struct DataFrame(Copyable, Movable):
             var col_name = String(pd_cols[i])
             self._cols.append(Column.from_pandas(pd_df[pd_cols[i]], col_name))
 
-    fn __copyinit__(out self, existing: Self):
-        self._cols = existing._cols.copy()
+    fn __copyinit__(out self, copy: Self):
+        self._cols = copy._cols.copy()
 
-    fn __moveinit__(out self, deinit existing: Self):
-        self._cols = existing._cols^
+    fn __moveinit__(out self, deinit take: Self):
+        self._cols = take._cols^
 
     @staticmethod
     fn from_pandas(pd_df: PythonObject) raises -> DataFrame:
@@ -173,7 +173,9 @@ struct DataFrame(Copyable, Movable):
         for i in range(len(self._cols)):
             if self._cols[i].name == key:
                 return Series(self._cols[i].copy())
-        return default
+        if default:
+            return Optional[Series](default.value().copy())
+        return None
 
     fn head(self, n: Int = 5) -> DataFrame:
         var nrows = self.shape()[0]

--- a/bison/dtypes.mojo
+++ b/bison/dtypes.mojo
@@ -6,13 +6,13 @@ struct BisonDtype(ImplicitlyCopyable, Movable):
         self.name = name
         self.itemsize = itemsize
 
-    fn __copyinit__(out self, existing: Self):
-        self.name = existing.name
-        self.itemsize = existing.itemsize
+    fn __copyinit__(out self, copy: Self):
+        self.name = copy.name
+        self.itemsize = copy.itemsize
 
-    fn __moveinit__(out self, deinit existing: Self):
-        self.name = existing.name^
-        self.itemsize = existing.itemsize
+    fn __moveinit__(out self, deinit take: Self):
+        self.name = take.name^
+        self.itemsize = take.itemsize
 
     fn __str__(self) -> String:
         return self.name

--- a/bison/index.mojo
+++ b/bison/index.mojo
@@ -10,13 +10,13 @@ struct Index(Copyable, Movable):
         self._data = data^
         self.name = name
 
-    fn __copyinit__(out self, existing: Self):
-        self._data = existing._data.copy()
-        self.name = existing.name
+    fn __copyinit__(out self, copy: Self):
+        self._data = copy._data.copy()
+        self.name = copy.name
 
-    fn __moveinit__(out self, deinit existing: Self):
-        self._data = existing._data^
-        self.name = existing.name^
+    fn __moveinit__(out self, deinit take: Self):
+        self._data = take._data^
+        self.name = take.name^
 
     fn __len__(self) -> Int:
         return len(self._data)

--- a/bison/series.mojo
+++ b/bison/series.mojo
@@ -36,13 +36,13 @@ struct Series(Copyable, Movable):
         self._col = Column.from_pandas(pd_s, col_name)
         self.name = self._col.name
 
-    fn __copyinit__(out self, existing: Self):
-        self._col = existing._col.copy()
-        self.name = existing.name
+    fn __copyinit__(out self, copy: Self):
+        self._col = copy._col.copy()
+        self.name = copy.name
 
-    fn __moveinit__(out self, deinit existing: Self):
-        self._col = existing._col^
-        self.name = existing.name^
+    fn __moveinit__(out self, deinit take: Self):
+        self._col = take._col^
+        self.name = take.name^
 
     @staticmethod
     fn from_pandas(pd_s: PythonObject) raises -> Series:

--- a/tests/test_accessors.mojo
+++ b/tests/test_accessors.mojo
@@ -4,7 +4,7 @@ from testing import assert_true, TestSuite
 from bison import Series
 
 
-def test_str_upper_stub():
+fn test_str_upper_stub() raises:
     var pd = Python.import_module("pandas")
     var s = Series(pd.Series(Python.evaluate("['foo', 'bar']")))
     var raised = False
@@ -16,7 +16,7 @@ def test_str_upper_stub():
     assert_true(raised)
 
 
-def test_str_contains_stub():
+fn test_str_contains_stub() raises:
     var pd = Python.import_module("pandas")
     var s = Series(pd.Series(Python.evaluate("['hello', 'world']")))
     var raised = False
@@ -28,7 +28,7 @@ def test_str_contains_stub():
     assert_true(raised)
 
 
-def test_dt_year_stub():
+fn test_dt_year_stub() raises:
     var pd = Python.import_module("pandas")
     var s = Series(pd.Series(pd.to_datetime(Python.evaluate("['2020-01-01', '2021-06-15']"))))
     var raised = False
@@ -40,7 +40,7 @@ def test_dt_year_stub():
     assert_true(raised)
 
 
-def test_dt_month_stub():
+fn test_dt_month_stub() raises:
     var pd = Python.import_module("pandas")
     var s = Series(pd.Series(pd.to_datetime(Python.evaluate("['2020-01-01']"))))
     var raised = False
@@ -52,5 +52,5 @@ def test_dt_month_stub():
     assert_true(raised)
 
 
-def main():
+fn main() raises:
     TestSuite.discover_tests[__functions_in_module()]().run()

--- a/tests/test_aggregation.mojo
+++ b/tests/test_aggregation.mojo
@@ -9,33 +9,33 @@ from bison import DataFrame, Series
 # sum
 # ---------------------------------------------------------------------------
 
-def test_series_sum_int():
+fn test_series_sum_int() raises:
     var pd = Python.import_module("pandas")
     var s = Series(pd.Series(Python.evaluate("[1, 2, 3]")))
     assert_true(s.sum() == 6.0)
 
 
-def test_series_sum_float():
+fn test_series_sum_float() raises:
     var pd = Python.import_module("pandas")
     var s = Series(pd.Series(Python.evaluate("[1.5, 2.5]")))
     assert_true(s.sum() == 4.0)
 
 
-def test_series_sum_skipna_flag():
+fn test_series_sum_skipna_flag() raises:
     var pd = Python.import_module("pandas")
     var s = Series(pd.Series(Python.evaluate("[1.0, 2.0]")))
     # No nulls: skipna=False still returns the full sum.
     assert_true(s.sum(skipna=False) == 3.0)
 
 
-def test_series_sum_skipna_true_nan():
+fn test_series_sum_skipna_true_nan() raises:
     """NaN values are skipped when skipna=True (default); returns sum of the rest."""
     var pd = Python.import_module("pandas")
     var s = Series(pd.Series(Python.evaluate("[1.0, float('nan'), 3.0]")))
     assert_true(s.sum(skipna=True) == 4.0)
 
 
-def test_series_sum_skipna_false_nan():
+fn test_series_sum_skipna_false_nan() raises:
     """Returns NaN when any element is null/NaN and skipna=False."""
     var pd = Python.import_module("pandas")
     var s = Series(pd.Series(Python.evaluate("[1.0, float('nan'), 3.0]")))
@@ -43,7 +43,7 @@ def test_series_sum_skipna_false_nan():
     assert_true(isnan(result))
 
 
-def test_df_sum():
+fn test_df_sum() raises:
     var pd = Python.import_module("pandas")
     var pd_df = pd.DataFrame(Python.evaluate("{'a': [1, 2, 3], 'b': [1.5, 2.5, 3.5]}"))
     var df = DataFrame(pd_df)
@@ -56,19 +56,19 @@ def test_df_sum():
 # count
 # ---------------------------------------------------------------------------
 
-def test_series_count_no_nulls():
+fn test_series_count_no_nulls() raises:
     var pd = Python.import_module("pandas")
     var s = Series(pd.Series(Python.evaluate("[1, 2, 3]")))
     assert_true(s.count() == 3)
 
 
-def test_series_count_with_nulls():
+fn test_series_count_with_nulls() raises:
     var pd = Python.import_module("pandas")
     var s = Series(pd.Series(Python.evaluate("[1.0, float('nan'), 3.0]")))
     assert_true(s.count() == 2)
 
 
-def test_df_count():
+fn test_df_count() raises:
     var pd = Python.import_module("pandas")
     var pd_df = pd.DataFrame(Python.evaluate("{'a': [1, 2, 3], 'b': [1.0, float('nan'), 3.0]}"))
     var df = DataFrame(pd_df)
@@ -81,31 +81,31 @@ def test_df_count():
 # mean
 # ---------------------------------------------------------------------------
 
-def test_series_mean_int():
+fn test_series_mean_int() raises:
     var pd = Python.import_module("pandas")
     var s = Series(pd.Series(Python.evaluate("[1, 2, 3]")))
     assert_true(s.mean() == 2.0)
 
 
-def test_series_mean_float():
+fn test_series_mean_float() raises:
     var pd = Python.import_module("pandas")
     var s = Series(pd.Series(Python.evaluate("[1.0, 2.0, 3.0]")))
     assert_true(s.mean() == 2.0)
 
 
-def test_series_mean_skipna_true():
+fn test_series_mean_skipna_true() raises:
     var pd = Python.import_module("pandas")
     var s = Series(pd.Series(Python.evaluate("[1.0, float('nan'), 3.0]")))
     assert_true(s.mean(skipna=True) == 2.0)
 
 
-def test_series_mean_skipna_false_nan():
+fn test_series_mean_skipna_false_nan() raises:
     var pd = Python.import_module("pandas")
     var s = Series(pd.Series(Python.evaluate("[1.0, float('nan'), 3.0]")))
     assert_true(isnan(s.mean(skipna=False)))
 
 
-def test_df_mean():
+fn test_df_mean() raises:
     var pd = Python.import_module("pandas")
     var pd_df = pd.DataFrame(Python.evaluate("{'a': [1.0, 2.0, 3.0], 'b': [4.0, 5.0, 6.0]}"))
     var df = DataFrame(pd_df)
@@ -118,26 +118,26 @@ def test_df_mean():
 # min / max
 # ---------------------------------------------------------------------------
 
-def test_series_min_int():
+fn test_series_min_int() raises:
     var pd = Python.import_module("pandas")
     var s = Series(pd.Series(Python.evaluate("[3, 1, 2]")))
     assert_true(s.min() == 1.0)
 
 
-def test_series_max_int():
+fn test_series_max_int() raises:
     var pd = Python.import_module("pandas")
     var s = Series(pd.Series(Python.evaluate("[3, 1, 2]")))
     assert_true(s.max() == 3.0)
 
 
-def test_series_min_skipna():
+fn test_series_min_skipna() raises:
     var pd = Python.import_module("pandas")
     var s = Series(pd.Series(Python.evaluate("[1.0, float('nan'), 3.0]")))
     assert_true(s.min(skipna=True) == 1.0)
     assert_true(isnan(s.min(skipna=False)))
 
 
-def test_df_min():
+fn test_df_min() raises:
     var pd = Python.import_module("pandas")
     var pd_df = pd.DataFrame(Python.evaluate("{'a': [3.0, 1.0, 2.0], 'b': [10.0, 5.0, 8.0]}"))
     var df = DataFrame(pd_df)
@@ -146,7 +146,7 @@ def test_df_min():
     assert_true(Float64(String(result_pd.iloc[1])) == 5.0)
 
 
-def test_df_max():
+fn test_df_max() raises:
     var pd = Python.import_module("pandas")
     var pd_df = pd.DataFrame(Python.evaluate("{'a': [3.0, 1.0, 2.0], 'b': [10.0, 5.0, 8.0]}"))
     var df = DataFrame(pd_df)
@@ -159,7 +159,7 @@ def test_df_max():
 # std / var
 # ---------------------------------------------------------------------------
 
-def test_series_std():
+fn test_series_std() raises:
     var pd = Python.import_module("pandas")
     # [1, 2, 3]: mean=2, sum_sq_dev=2, var(ddof=1)=1.0, std=1.0
     var s = Series(pd.Series(Python.evaluate("[1.0, 2.0, 3.0]")))
@@ -167,7 +167,7 @@ def test_series_std():
     assert_true(result - 1.0 < 1e-10 and 1.0 - result < 1e-10)
 
 
-def test_series_var():
+fn test_series_var() raises:
     var pd = Python.import_module("pandas")
     # [1, 2, 3]: mean=2, sum_sq_dev=2, var(ddof=1)=1.0
     var s = Series(pd.Series(Python.evaluate("[1.0, 2.0, 3.0]")))
@@ -175,14 +175,14 @@ def test_series_var():
     assert_true(result - 1.0 < 1e-10 and 1.0 - result < 1e-10)
 
 
-def test_series_std_single_element():
+fn test_series_std_single_element() raises:
     """std of a single-element series with ddof=1 should be NaN."""
     var pd = Python.import_module("pandas")
     var s = Series(pd.Series(Python.evaluate("[5.0]")))
     assert_true(isnan(s.std()))
 
 
-def test_df_std():
+fn test_df_std() raises:
     var pd = Python.import_module("pandas")
     var pd_df = pd.DataFrame(Python.evaluate("{'a': [1.0, 2.0, 3.0]}"))
     var df = DataFrame(pd_df)
@@ -195,20 +195,20 @@ def test_df_std():
 # nunique
 # ---------------------------------------------------------------------------
 
-def test_series_nunique_int():
+fn test_series_nunique_int() raises:
     var pd = Python.import_module("pandas")
     var s = Series(pd.Series(Python.evaluate("[1, 1, 2, 3, 3]")))
     assert_true(s.nunique() == 3)
 
 
-def test_series_nunique_with_nulls():
+fn test_series_nunique_with_nulls() raises:
     var pd = Python.import_module("pandas")
     var s = Series(pd.Series(Python.evaluate("[1.0, float('nan'), 2.0, 1.0]")))
     # nulls excluded from unique count
     assert_true(s.nunique() == 2)
 
 
-def test_df_nunique():
+fn test_df_nunique() raises:
     var pd = Python.import_module("pandas")
     var pd_df = pd.DataFrame(Python.evaluate("{'a': [1, 1, 2], 'b': [1.0, 2.0, 3.0]}"))
     var df = DataFrame(pd_df)
@@ -221,37 +221,37 @@ def test_df_nunique():
 # median / quantile
 # ---------------------------------------------------------------------------
 
-def test_series_median_odd():
+fn test_series_median_odd() raises:
     var pd = Python.import_module("pandas")
     var s = Series(pd.Series(Python.evaluate("[1.0, 2.0, 3.0]")))
     assert_true(s.median() == 2.0)
 
 
-def test_series_median_even():
+fn test_series_median_even() raises:
     var pd = Python.import_module("pandas")
     var s = Series(pd.Series(Python.evaluate("[1.0, 2.0, 3.0, 4.0]")))
     assert_true(s.median() == 2.5)
 
 
-def test_series_median_skipna_false():
+fn test_series_median_skipna_false() raises:
     var pd = Python.import_module("pandas")
     var s = Series(pd.Series(Python.evaluate("[1.0, float('nan'), 3.0]")))
     assert_true(isnan(s.median(skipna=False)))
 
 
-def test_series_quantile_25():
+fn test_series_quantile_25() raises:
     var pd = Python.import_module("pandas")
     var s = Series(pd.Series(Python.evaluate("[1.0, 2.0, 3.0, 4.0]")))
     assert_true(s.quantile(0.25) == 1.75)
 
 
-def test_series_quantile_75():
+fn test_series_quantile_75() raises:
     var pd = Python.import_module("pandas")
     var s = Series(pd.Series(Python.evaluate("[1.0, 2.0, 3.0, 4.0]")))
     assert_true(s.quantile(0.75) == 3.25)
 
 
-def test_df_median():
+fn test_df_median() raises:
     var pd = Python.import_module("pandas")
     var pd_df = pd.DataFrame(Python.evaluate("{'a': [1.0, 2.0, 3.0], 'b': [4.0, 5.0, 6.0]}"))
     var df = DataFrame(pd_df)
@@ -264,7 +264,7 @@ def test_df_median():
 # describe (still a stub)
 # ---------------------------------------------------------------------------
 
-def test_df_describe_stub():
+fn test_df_describe_stub() raises:
     var pd = Python.import_module("pandas")
     var df = DataFrame(pd.DataFrame(Python.evaluate("{'a': [1, 2, 3]}")))
     var raised = False
@@ -280,7 +280,7 @@ def test_df_describe_stub():
 # value_counts
 # ---------------------------------------------------------------------------
 
-def test_series_value_counts():
+fn test_series_value_counts() raises:
     var pd = Python.import_module("pandas")
     var s = Series(pd.Series(Python.evaluate("[1, 2, 2, 3, 3, 3]")))
     var vc = s.value_counts()
@@ -293,7 +293,7 @@ def test_series_value_counts():
 # cumsum
 # ---------------------------------------------------------------------------
 
-def test_series_cumsum_int():
+fn test_series_cumsum_int() raises:
     var pd = Python.import_module("pandas")
     var s = Series(pd.Series(Python.evaluate("[1, 2, 3]")))
     var result_pd = s.cumsum().to_pandas()
@@ -302,7 +302,7 @@ def test_series_cumsum_int():
     assert_true(Float64(String(result_pd.iloc[2])) == 6.0)
 
 
-def test_series_cumsum_float():
+fn test_series_cumsum_float() raises:
     var pd = Python.import_module("pandas")
     var s = Series(pd.Series(Python.evaluate("[1.0, 2.0, 3.0]")))
     var result_pd = s.cumsum().to_pandas()
@@ -311,7 +311,7 @@ def test_series_cumsum_float():
     assert_true(Float64(String(result_pd.iloc[2])) == 6.0)
 
 
-def test_series_cumsum_skipna_true():
+fn test_series_cumsum_skipna_true() raises:
     """Null elements produce NaN but do not break the running sum."""
     var pd = Python.import_module("pandas")
     var s = Series(pd.Series(Python.evaluate("[1.0, float('nan'), 3.0]")))
@@ -321,7 +321,7 @@ def test_series_cumsum_skipna_true():
     assert_true(Float64(String(result_pd.iloc[2])) == 4.0)
 
 
-def test_series_cumsum_skipna_false():
+fn test_series_cumsum_skipna_false() raises:
     """Once a null is encountered, all subsequent values are NaN."""
     var pd = Python.import_module("pandas")
     var s = Series(pd.Series(Python.evaluate("[1.0, float('nan'), 3.0]")))
@@ -331,7 +331,7 @@ def test_series_cumsum_skipna_false():
     assert_true(isnan(Float64(String(result_pd.iloc[2]))))
 
 
-def test_df_cumsum():
+fn test_df_cumsum() raises:
     var pd = Python.import_module("pandas")
     var pd_df = pd.DataFrame(Python.evaluate("{'a': [1, 2, 3], 'b': [4.0, 5.0, 6.0]}"))
     var df = DataFrame(pd_df)
@@ -347,7 +347,7 @@ def test_df_cumsum():
 # cumprod
 # ---------------------------------------------------------------------------
 
-def test_series_cumprod_int():
+fn test_series_cumprod_int() raises:
     var pd = Python.import_module("pandas")
     var s = Series(pd.Series(Python.evaluate("[1, 2, 3]")))
     var result_pd = s.cumprod().to_pandas()
@@ -356,7 +356,7 @@ def test_series_cumprod_int():
     assert_true(Float64(String(result_pd.iloc[2])) == 6.0)
 
 
-def test_series_cumprod_skipna_true():
+fn test_series_cumprod_skipna_true() raises:
     """Null elements produce NaN but do not break the running product."""
     var pd = Python.import_module("pandas")
     var s = Series(pd.Series(Python.evaluate("[2.0, float('nan'), 3.0]")))
@@ -366,7 +366,7 @@ def test_series_cumprod_skipna_true():
     assert_true(Float64(String(result_pd.iloc[2])) == 6.0)
 
 
-def test_df_cumprod():
+fn test_df_cumprod() raises:
     var pd = Python.import_module("pandas")
     var pd_df = pd.DataFrame(Python.evaluate("{'a': [1, 2, 4]}"))
     var df = DataFrame(pd_df)
@@ -380,7 +380,7 @@ def test_df_cumprod():
 # cummin
 # ---------------------------------------------------------------------------
 
-def test_series_cummin_int():
+fn test_series_cummin_int() raises:
     var pd = Python.import_module("pandas")
     var s = Series(pd.Series(Python.evaluate("[3, 1, 2]")))
     var result_pd = s.cummin().to_pandas()
@@ -389,7 +389,7 @@ def test_series_cummin_int():
     assert_true(Float64(String(result_pd.iloc[2])) == 1.0)
 
 
-def test_series_cummin_skipna_true():
+fn test_series_cummin_skipna_true() raises:
     """Null elements produce NaN but do not break the running minimum."""
     var pd = Python.import_module("pandas")
     var s = Series(pd.Series(Python.evaluate("[3.0, float('nan'), 1.0]")))
@@ -399,7 +399,7 @@ def test_series_cummin_skipna_true():
     assert_true(Float64(String(result_pd.iloc[2])) == 1.0)
 
 
-def test_df_cummin():
+fn test_df_cummin() raises:
     var pd = Python.import_module("pandas")
     var pd_df = pd.DataFrame(Python.evaluate("{'a': [3.0, 1.0, 2.0]}"))
     var df = DataFrame(pd_df)
@@ -413,7 +413,7 @@ def test_df_cummin():
 # cummax
 # ---------------------------------------------------------------------------
 
-def test_series_cummax_int():
+fn test_series_cummax_int() raises:
     var pd = Python.import_module("pandas")
     var s = Series(pd.Series(Python.evaluate("[3, 1, 5]")))
     var result_pd = s.cummax().to_pandas()
@@ -422,7 +422,7 @@ def test_series_cummax_int():
     assert_true(Float64(String(result_pd.iloc[2])) == 5.0)
 
 
-def test_series_cummax_skipna_true():
+fn test_series_cummax_skipna_true() raises:
     """Null elements produce NaN but do not break the running maximum."""
     var pd = Python.import_module("pandas")
     var s = Series(pd.Series(Python.evaluate("[3.0, float('nan'), 5.0]")))
@@ -432,7 +432,7 @@ def test_series_cummax_skipna_true():
     assert_true(Float64(String(result_pd.iloc[2])) == 5.0)
 
 
-def test_df_cummax():
+fn test_df_cummax() raises:
     var pd = Python.import_module("pandas")
     var pd_df = pd.DataFrame(Python.evaluate("{'a': [3.0, 1.0, 5.0]}"))
     var df = DataFrame(pd_df)
@@ -442,5 +442,5 @@ def test_df_cummax():
     assert_true(Float64(String(result_pd["a"].iloc[2])) == 5.0)
 
 
-def main():
+fn main() raises:
     TestSuite.discover_tests[__functions_in_module()]().run()

--- a/tests/test_combining.mojo
+++ b/tests/test_combining.mojo
@@ -4,7 +4,7 @@ from testing import assert_true, TestSuite
 from bison import DataFrame
 
 
-def test_merge_stub():
+fn test_merge_stub() raises:
     var pd = Python.import_module("pandas")
     var left = DataFrame(pd.DataFrame(Python.evaluate("{'key': [1, 2], 'a': [10, 20]}")))
     var right = DataFrame(pd.DataFrame(Python.evaluate("{'key': [1, 2], 'b': [30, 40]}")))
@@ -16,7 +16,7 @@ def test_merge_stub():
     assert_true(raised)
 
 
-def test_join_stub():
+fn test_join_stub() raises:
     var pd = Python.import_module("pandas")
     var left = DataFrame(pd.DataFrame(Python.evaluate("{'a': [1, 2]}")))
     var right = DataFrame(pd.DataFrame(Python.evaluate("{'b': [3, 4]}")))
@@ -28,7 +28,7 @@ def test_join_stub():
     assert_true(raised)
 
 
-def test_append_stub():
+fn test_append_stub() raises:
     var pd = Python.import_module("pandas")
     var df1 = DataFrame(pd.DataFrame(Python.evaluate("{'a': [1]}")))
     var df2 = DataFrame(pd.DataFrame(Python.evaluate("{'a': [2]}")))
@@ -40,5 +40,5 @@ def test_append_stub():
     assert_true(raised)
 
 
-def main():
+fn main() raises:
     TestSuite.discover_tests[__functions_in_module()]().run()

--- a/tests/test_dataframe.mojo
+++ b/tests/test_dataframe.mojo
@@ -5,7 +5,7 @@ from testing import assert_equal, assert_true, assert_false, TestSuite
 from bison import DataFrame, ColumnData, Series
 
 
-def test_shape_from_pandas():
+fn test_shape_from_pandas() raises:
     var pd = Python.import_module("pandas")
     var pd_df = pd.DataFrame(Python.evaluate("{'a': [1, 2, 3], 'b': [4, 5, 6]}"))
     var df = DataFrame(pd_df)
@@ -14,28 +14,28 @@ def test_shape_from_pandas():
     assert_equal(s[1], 2)
 
 
-def test_len():
+fn test_len() raises:
     var pd = Python.import_module("pandas")
     var pd_df = pd.DataFrame(Python.evaluate("{'x': [10, 20]}"))
     var df = DataFrame(pd_df)
     assert_equal(df.__len__(), 2)
 
 
-def test_empty_false():
+fn test_empty_false() raises:
     var pd = Python.import_module("pandas")
     var pd_df = pd.DataFrame(Python.evaluate("{'a': [1]}"))
     var df = DataFrame(pd_df)
     assert_false(df.empty())
 
 
-def test_empty_true():
+fn test_empty_true() raises:
     var pd = Python.import_module("pandas")
     var pd_df = pd.DataFrame()
     var df = DataFrame(pd_df)
     assert_true(df.empty())
 
 
-def test_columns():
+fn test_columns() raises:
     var pd = Python.import_module("pandas")
     var pd_df = pd.DataFrame(Python.evaluate("{'col1': [1], 'col2': [2]}"))
     var df = DataFrame(pd_df)
@@ -45,26 +45,26 @@ def test_columns():
     assert_equal(cols[1], "col2")
 
 
-def test_ndim():
+fn test_ndim() raises:
     var pd = Python.import_module("pandas")
     var df = DataFrame(pd.DataFrame(Python.evaluate("{'a': [1]}")))
     assert_equal(df.ndim(), 2)
 
 
-def test_size():
+fn test_size() raises:
     var pd = Python.import_module("pandas")
     var df = DataFrame(pd.DataFrame(Python.evaluate("{'a': [1, 2], 'b': [3, 4]}")))
     assert_equal(df.size(), 4)
 
 
-def test_contains():
+fn test_contains() raises:
     var pd = Python.import_module("pandas")
     var df = DataFrame(pd.DataFrame(Python.evaluate("{'a': [1], 'b': [2]}")))
     assert_true(df.__contains__("a"))
     assert_false(df.__contains__("z"))
 
 
-def test_to_pandas_roundtrip():
+fn test_to_pandas_roundtrip() raises:
     var pd = Python.import_module("pandas")
     var pd_df = pd.DataFrame(Python.evaluate("{'a': [1, 2, 3]}"))
     var df = DataFrame.from_pandas(pd_df)
@@ -73,7 +73,7 @@ def test_to_pandas_roundtrip():
     assert_equal(back.__len__(), 3)
 
 
-def test_from_dict():
+fn test_from_dict() raises:
     var d = Dict[String, ColumnData]()
     var col_a = List[Int64]()
     col_a.append(1)
@@ -95,14 +95,14 @@ def test_from_dict():
 # ------------------------------------------------------------------
 
 
-def test_getitem_column():
+fn test_getitem_column() raises:
     var pd = Python.import_module("pandas")
     var df = DataFrame(pd.DataFrame(Python.evaluate("{'a': [1, 2, 3], 'b': [4, 5, 6]}")))
     var s = df["a"]
     assert_equal(s.size(), 3)
 
 
-def test_getitem_missing_raises():
+fn test_getitem_missing_raises() raises:
     var pd = Python.import_module("pandas")
     var df = DataFrame(pd.DataFrame(Python.evaluate("{'a': [1]}")))
     var raised = False
@@ -113,7 +113,7 @@ def test_getitem_missing_raises():
     assert_true(raised)
 
 
-def test_setitem_new_column():
+fn test_setitem_new_column() raises:
     var pd = Python.import_module("pandas")
     var df = DataFrame(pd.DataFrame(Python.evaluate("{'a': [1, 2]}")))
     var new_series = Series(pd.Series(Python.evaluate("[10, 20]"), name="b"))
@@ -122,7 +122,7 @@ def test_setitem_new_column():
     assert_true(df.__contains__("b"))
 
 
-def test_setitem_replace_column():
+fn test_setitem_replace_column() raises:
     var pd = Python.import_module("pandas")
     var df = DataFrame(pd.DataFrame(Python.evaluate("{'a': [1, 2]}")))
     var new_series = Series(pd.Series(Python.evaluate("[99, 98]"), name="a"))
@@ -132,7 +132,7 @@ def test_setitem_replace_column():
     assert_equal(s.size(), 2)
 
 
-def test_get_existing_key():
+fn test_get_existing_key() raises:
     var pd = Python.import_module("pandas")
     var df = DataFrame(pd.DataFrame(Python.evaluate("{'a': [1, 2, 3]}")))
     var result = df.get("a")
@@ -140,14 +140,14 @@ def test_get_existing_key():
     assert_equal(result.value().size(), 3)
 
 
-def test_get_missing_key_default_none():
+fn test_get_missing_key_default_none() raises:
     var pd = Python.import_module("pandas")
     var df = DataFrame(pd.DataFrame(Python.evaluate("{'a': [1]}")))
     var result = df.get("z")
     assert_false(result.__bool__())
 
 
-def test_head_basic():
+fn test_head_basic() raises:
     var pd = Python.import_module("pandas")
     var df = DataFrame(pd.DataFrame(Python.evaluate("{'a': [1, 2, 3, 4, 5]}")))
     var h = df.head(3)
@@ -155,14 +155,14 @@ def test_head_basic():
     assert_equal(h.shape()[1], 1)
 
 
-def test_head_larger_than_rows():
+fn test_head_larger_than_rows() raises:
     var pd = Python.import_module("pandas")
     var df = DataFrame(pd.DataFrame(Python.evaluate("{'a': [1, 2]}")))
     var h = df.head(10)
     assert_equal(h.shape()[0], 2)
 
 
-def test_tail_basic():
+fn test_tail_basic() raises:
     var pd = Python.import_module("pandas")
     var df = DataFrame(pd.DataFrame(Python.evaluate("{'a': [1, 2, 3, 4, 5]}")))
     var t = df.tail(2)
@@ -170,14 +170,14 @@ def test_tail_basic():
     assert_equal(t.shape()[1], 1)
 
 
-def test_tail_larger_than_rows():
+fn test_tail_larger_than_rows() raises:
     var pd = Python.import_module("pandas")
     var df = DataFrame(pd.DataFrame(Python.evaluate("{'a': [1, 2]}")))
     var t = df.tail(10)
     assert_equal(t.shape()[0], 2)
 
 
-def test_head_tail_values():
+fn test_head_tail_values() raises:
     """Verify head/tail return the correct rows using native sum aggregation."""
     var pd = Python.import_module("pandas")
     var df = DataFrame(pd.DataFrame(Python.evaluate("{'a': [10, 20, 30, 40, 50]}")))
@@ -189,7 +189,7 @@ def test_head_tail_values():
     assert_true(t.sum().sum() == 90.0)
 
 
-def test_sample_n():
+fn test_sample_n() raises:
     var pd = Python.import_module("pandas")
     var df = DataFrame(pd.DataFrame(Python.evaluate("{'a': [1, 2, 3, 4, 5]}")))
     var s = df.sample(3, random_state=42)
@@ -197,14 +197,14 @@ def test_sample_n():
     assert_equal(s.shape()[1], 1)
 
 
-def test_sample_n_larger_than_rows():
+fn test_sample_n_larger_than_rows() raises:
     var pd = Python.import_module("pandas")
     var df = DataFrame(pd.DataFrame(Python.evaluate("{'a': [1, 2]}")))
     var s = df.sample(10, random_state=0)
     assert_equal(s.shape()[0], 2)
 
 
-def test_filter_items():
+fn test_filter_items() raises:
     var pd = Python.import_module("pandas")
     var df = DataFrame(pd.DataFrame(Python.evaluate("{'a': [1], 'b': [2], 'c': [3]}")))
     var items = List[String]()
@@ -217,7 +217,7 @@ def test_filter_items():
     assert_false(result.__contains__("b"))
 
 
-def test_filter_like():
+fn test_filter_like() raises:
     var pd = Python.import_module("pandas")
     var df = DataFrame(pd.DataFrame(Python.evaluate("{'foo_1': [1], 'foo_2': [2], 'bar': [3]}")))
     var result = df.filter(like="foo")
@@ -227,7 +227,7 @@ def test_filter_like():
     assert_false(result.__contains__("bar"))
 
 
-def test_filter_regex():
+fn test_filter_regex() raises:
     var pd = Python.import_module("pandas")
     var df = DataFrame(pd.DataFrame(Python.evaluate("{'a1': [1], 'b2': [2], 'c1': [3]}")))
     var result = df.filter(regex=".*1$")
@@ -237,14 +237,14 @@ def test_filter_regex():
     assert_false(result.__contains__("b2"))
 
 
-def test_filter_no_args_keeps_all():
+fn test_filter_no_args_keeps_all() raises:
     var pd = Python.import_module("pandas")
     var df = DataFrame(pd.DataFrame(Python.evaluate("{'a': [1], 'b': [2]}")))
     var result = df.filter()
     assert_equal(result.shape()[1], 2)
 
 
-def test_select_dtypes_include():
+fn test_select_dtypes_include() raises:
     var pd = Python.import_module("pandas")
     var df = DataFrame(pd.DataFrame(Python.evaluate("{'a': [1, 2], 'b': [1.0, 2.0]}")))
     var inc = List[String]()
@@ -255,7 +255,7 @@ def test_select_dtypes_include():
     assert_false(result.__contains__("b"))
 
 
-def test_select_dtypes_exclude():
+fn test_select_dtypes_exclude() raises:
     var pd = Python.import_module("pandas")
     var df = DataFrame(pd.DataFrame(Python.evaluate("{'a': [1, 2], 'b': [1.0, 2.0]}")))
     var exc = List[String]()
@@ -266,5 +266,5 @@ def test_select_dtypes_exclude():
     assert_false(result.__contains__("b"))
 
 
-def main():
+fn main() raises:
     TestSuite.discover_tests[__functions_in_module()]().run()

--- a/tests/test_groupby.mojo
+++ b/tests/test_groupby.mojo
@@ -4,7 +4,7 @@ from testing import assert_true, TestSuite
 from bison import DataFrame
 
 
-def test_groupby_stub():
+fn test_groupby_stub() raises:
     var pd = Python.import_module("pandas")
     var df = DataFrame(pd.DataFrame(Python.evaluate("{'grp': ['a', 'a', 'b'], 'val': [1, 2, 3]}")))
     var raised = False
@@ -15,7 +15,7 @@ def test_groupby_stub():
     assert_true(raised)
 
 
-def test_groupby_sum_stub():
+fn test_groupby_sum_stub() raises:
     """DataFrameGroupBy.sum is also a stub."""
     from bison import DataFrameGroupBy
     var pd = Python.import_module("pandas")
@@ -29,5 +29,5 @@ def test_groupby_sum_stub():
     assert_true(raised)
 
 
-def main():
+fn main() raises:
     TestSuite.discover_tests[__functions_in_module()]().run()

--- a/tests/test_index.mojo
+++ b/tests/test_index.mojo
@@ -19,14 +19,14 @@ def _make_index_named(a: String, b: String, c: String, name: String) -> Index:
     return Index(data^, name)
 
 
-def test_get_loc_found():
+fn test_get_loc_found() raises:
     var idx = _make_index("a", "b", "c")
     assert_equal(idx.get_loc("a"), 0)
     assert_equal(idx.get_loc("b"), 1)
     assert_equal(idx.get_loc("c"), 2)
 
 
-def test_get_loc_first_occurrence():
+fn test_get_loc_first_occurrence() raises:
     var data = List[String]()
     data.append("x")
     data.append("y")
@@ -35,7 +35,7 @@ def test_get_loc_first_occurrence():
     assert_equal(idx.get_loc("x"), 0)
 
 
-def test_get_loc_not_found():
+fn test_get_loc_not_found() raises:
     var idx = _make_index("a", "b", "c")
     var raised = False
     try:
@@ -45,7 +45,7 @@ def test_get_loc_not_found():
     assert_true(raised)
 
 
-def test_unique_no_duplicates():
+fn test_unique_no_duplicates() raises:
     var idx = _make_index("a", "b", "c")
     var u = idx.unique()
     assert_equal(u.__len__(), 3)
@@ -54,7 +54,7 @@ def test_unique_no_duplicates():
     assert_equal(u[2], "c")
 
 
-def test_unique_with_duplicates():
+fn test_unique_with_duplicates() raises:
     var data = List[String]()
     data.append("a")
     data.append("b")
@@ -69,20 +69,20 @@ def test_unique_with_duplicates():
     assert_equal(u[2], "c")
 
 
-def test_unique_preserves_name():
+fn test_unique_preserves_name() raises:
     var idx = _make_index_named("x", "x", "y", "myname")
     var u = idx.unique()
     assert_equal(u.name, "myname")
 
 
-def test_unique_empty():
+fn test_unique_empty() raises:
     var data = List[String]()
     var idx = Index(data^)
     var u = idx.unique()
     assert_equal(u.__len__(), 0)
 
 
-def test_sort_values_ascending():
+fn test_sort_values_ascending() raises:
     var idx = _make_index("c", "a", "b")
     var s = idx.sort_values()
     assert_equal(s[0], "a")
@@ -90,7 +90,7 @@ def test_sort_values_ascending():
     assert_equal(s[2], "c")
 
 
-def test_sort_values_descending():
+fn test_sort_values_descending() raises:
     var idx = _make_index("c", "a", "b")
     var s = idx.sort_values(ascending=False)
     assert_equal(s[0], "c")
@@ -98,7 +98,7 @@ def test_sort_values_descending():
     assert_equal(s[2], "a")
 
 
-def test_sort_values_already_sorted():
+fn test_sort_values_already_sorted() raises:
     var idx = _make_index("a", "b", "c")
     var s = idx.sort_values()
     assert_equal(s[0], "a")
@@ -106,13 +106,13 @@ def test_sort_values_already_sorted():
     assert_equal(s[2], "c")
 
 
-def test_sort_values_preserves_name():
+fn test_sort_values_preserves_name() raises:
     var idx = _make_index_named("b", "a", "c", "myname")
     var s = idx.sort_values()
     assert_equal(s.name, "myname")
 
 
-def test_sort_values_single_element():
+fn test_sort_values_single_element() raises:
     var data = List[String]()
     data.append("a")
     var idx = Index(data^)
@@ -121,7 +121,7 @@ def test_sort_values_single_element():
     assert_equal(s[0], "a")
 
 
-def test_sort_values_does_not_mutate_original():
+fn test_sort_values_does_not_mutate_original() raises:
     var idx = _make_index("c", "a", "b")
     _ = idx.sort_values()
     assert_equal(idx[0], "c")
@@ -129,5 +129,5 @@ def test_sort_values_does_not_mutate_original():
     assert_equal(idx[2], "b")
 
 
-def main():
+fn main() raises:
     TestSuite.discover_tests[__functions_in_module()]().run()

--- a/tests/test_interop.mojo
+++ b/tests/test_interop.mojo
@@ -4,7 +4,7 @@ from testing import assert_equal, assert_true, TestSuite
 from bison import DataFrame, Series, Column
 
 
-def test_df_from_pandas_preserves_shape():
+fn test_df_from_pandas_preserves_shape() raises:
     var pd = Python.import_module("pandas")
     var pd_df = pd.DataFrame(Python.evaluate("{'a': [1, 2, 3], 'b': [4, 5, 6], 'c': [7, 8, 9]}"))
     var df = DataFrame.from_pandas(pd_df)
@@ -12,7 +12,7 @@ def test_df_from_pandas_preserves_shape():
     assert_equal(df.shape()[1], 3)
 
 
-def test_df_to_pandas_identity():
+fn test_df_to_pandas_identity() raises:
     var pd = Python.import_module("pandas")
     var pd_df = pd.DataFrame(Python.evaluate("{'x': [10, 20]}"))
     var df = DataFrame.from_pandas(pd_df)
@@ -21,7 +21,7 @@ def test_df_to_pandas_identity():
     testing.assert_frame_equal(pd_df, back)
 
 
-def test_series_from_pandas_preserves_name():
+fn test_series_from_pandas_preserves_name() raises:
     var pd = Python.import_module("pandas")
     var pd_s = pd.Series(Python.evaluate("[1, 2, 3]"), name="score")
     var s = Series.from_pandas(pd_s)
@@ -29,7 +29,7 @@ def test_series_from_pandas_preserves_name():
     assert_equal(s.__len__(), 3)
 
 
-def test_series_to_pandas_identity():
+fn test_series_to_pandas_identity() raises:
     var pd = Python.import_module("pandas")
     var pd_s = pd.Series(Python.evaluate("[5, 6, 7]"), name="v")
     var s = Series.from_pandas(pd_s)
@@ -38,7 +38,7 @@ def test_series_to_pandas_identity():
     testing.assert_series_equal(pd_s, back)
 
 
-def test_df_columns_match():
+fn test_df_columns_match() raises:
     var pd = Python.import_module("pandas")
     var pd_df = pd.DataFrame(Python.evaluate("{'alpha': [1], 'beta': [2], 'gamma': [3]}"))
     var df = DataFrame.from_pandas(pd_df)
@@ -48,7 +48,7 @@ def test_df_columns_match():
     assert_equal(cols[2], "gamma")
 
 
-def test_quickstart_example():
+fn test_quickstart_example() raises:
     var pd = Python.import_module("pandas")
     var pd_df = pd.DataFrame(Python.evaluate("{'a': [1, 2, 3], 'b': [4, 5, 6]}"))
 
@@ -65,7 +65,7 @@ def test_quickstart_example():
     testing.assert_frame_equal(pd_df, original)
 
 
-def test_column_typed_storage():
+fn test_column_typed_storage() raises:
     """Verify from_pandas routes values into the correct Variant arm."""
     var pd = Python.import_module("pandas")
 
@@ -94,7 +94,7 @@ def test_column_typed_storage():
     assert_equal(col_obj.__len__(), 2)
 
 
-def test_series_index_roundtrip():
+fn test_series_index_roundtrip() raises:
     """Custom string index must survive from_pandas → to_pandas."""
     var pd = Python.import_module("pandas")
     var testing = Python.import_module("pandas.testing")
@@ -108,7 +108,7 @@ def test_series_index_roundtrip():
     testing.assert_series_equal(pd_s, back)
 
 
-def test_df_index_roundtrip():
+fn test_df_index_roundtrip() raises:
     """Custom string index on a DataFrame must survive from_pandas → to_pandas."""
     var pd = Python.import_module("pandas")
     var testing = Python.import_module("pandas.testing")
@@ -121,7 +121,7 @@ def test_df_index_roundtrip():
     testing.assert_frame_equal(pd_df, back)
 
 
-def test_float64_bitcast_roundtrip():
+fn test_float64_bitcast_roundtrip() raises:
     """Float64 values must survive from_pandas with exact bit-for-bit fidelity.
 
     Uses Python struct to verify that the bits stored in the Column exactly
@@ -147,5 +147,5 @@ def test_float64_bitcast_roundtrip():
         assert_equal(got_bits, expected_bits)
 
 
-def main():
+fn main() raises:
     TestSuite.discover_tests[__functions_in_module()]().run()

--- a/tests/test_io.mojo
+++ b/tests/test_io.mojo
@@ -4,7 +4,7 @@ from testing import assert_equal, assert_true, TestSuite
 from bison import read_csv, read_parquet, read_json, read_excel, DataFrame
 
 
-def test_read_csv_basic():
+fn test_read_csv_basic() raises:
     """Read a CSV file with int, float, and string columns."""
     var tempfile = Python.import_module("tempfile")
     var path = String(tempfile.mktemp(suffix=".csv"))
@@ -21,7 +21,7 @@ def test_read_csv_basic():
     assert_equal(cols[2], "c")
 
 
-def test_read_csv_sep():
+fn test_read_csv_sep() raises:
     """Custom separator (tab-separated values)."""
     var tempfile = Python.import_module("tempfile")
     var path = String(tempfile.mktemp(suffix=".tsv"))
@@ -35,7 +35,7 @@ def test_read_csv_sep():
     assert_equal(df.columns()[1], "y")
 
 
-def test_read_csv_nrows():
+fn test_read_csv_nrows() raises:
     """Nrows parameter limits the number of data rows read."""
     var tempfile = Python.import_module("tempfile")
     var path = String(tempfile.mktemp(suffix=".csv"))
@@ -47,7 +47,7 @@ def test_read_csv_nrows():
     assert_equal(df.shape()[1], 2)
 
 
-def test_read_csv_no_header():
+fn test_read_csv_no_header() raises:
     """With header=-1 there is no header row; columns are auto-numbered as strings."""
     var tempfile = Python.import_module("tempfile")
     var path = String(tempfile.mktemp(suffix=".csv"))
@@ -63,7 +63,7 @@ def test_read_csv_no_header():
     assert_equal(cols[2], "2")
 
 
-def test_to_csv_returns_string():
+fn test_to_csv_returns_string() raises:
     """Calling to_csv() with no path returns a non-empty CSV string."""
     var pd = Python.import_module("pandas")
     var df = DataFrame(pd.DataFrame(Python.evaluate("{'a': [1, 2], 'b': [3, 4]}")))
@@ -73,7 +73,7 @@ def test_to_csv_returns_string():
     assert_true(csv_str.find("b") >= 0)
 
 
-def test_to_csv_no_index():
+fn test_to_csv_no_index() raises:
     """Passing index=False omits the row-number column (no leading comma in header)."""
     var pd = Python.import_module("pandas")
     var df = DataFrame(pd.DataFrame(Python.evaluate("{'x': [10, 20]}")))
@@ -85,7 +85,7 @@ def test_to_csv_no_index():
     assert_true(csv_str.find("20") >= 0)
 
 
-def test_csv_roundtrip():
+fn test_csv_roundtrip() raises:
     """Write a DataFrame to CSV with index=False, read it back, check shape."""
     var pd = Python.import_module("pandas")
     var tempfile = Python.import_module("tempfile")
@@ -102,7 +102,7 @@ def test_csv_roundtrip():
     assert_equal(df2.columns()[1], "b")
 
 
-def test_read_parquet_stub():
+fn test_read_parquet_stub() raises:
     var raised = False
     try:
         _ = read_parquet("/tmp/nonexistent.parquet")
@@ -111,7 +111,7 @@ def test_read_parquet_stub():
     assert_true(raised)
 
 
-def test_read_json_stub():
+fn test_read_json_stub() raises:
     var raised = False
     try:
         _ = read_json("/tmp/nonexistent.json")
@@ -120,7 +120,7 @@ def test_read_json_stub():
     assert_true(raised)
 
 
-def test_read_excel_stub():
+fn test_read_excel_stub() raises:
     var raised = False
     try:
         _ = read_excel("/tmp/nonexistent.xlsx")
@@ -129,5 +129,5 @@ def test_read_excel_stub():
     assert_true(raised)
 
 
-def main():
+fn main() raises:
     TestSuite.discover_tests[__functions_in_module()]().run()

--- a/tests/test_missing.mojo
+++ b/tests/test_missing.mojo
@@ -4,7 +4,7 @@ from testing import assert_true, TestSuite
 from bison import DataFrame, Series, DFScalar
 
 
-def test_df_isna_stub():
+fn test_df_isna_stub() raises:
     var pd = Python.import_module("pandas")
     var df = DataFrame(pd.DataFrame(Python.evaluate("{'a': [1, 2, 3]}")))
     var raised = False
@@ -15,7 +15,7 @@ def test_df_isna_stub():
     assert_true(raised)
 
 
-def test_df_fillna_stub():
+fn test_df_fillna_stub() raises:
     var pd = Python.import_module("pandas")
     var df = DataFrame(pd.DataFrame(Python.evaluate("{'a': [1.0, 2.0]}")))
     var raised = False
@@ -26,7 +26,7 @@ def test_df_fillna_stub():
     assert_true(raised)
 
 
-def test_df_dropna_stub():
+fn test_df_dropna_stub() raises:
     var pd = Python.import_module("pandas")
     var df = DataFrame(pd.DataFrame(Python.evaluate("{'a': [1.0, 2.0]}")))
     var raised = False
@@ -37,7 +37,7 @@ def test_df_dropna_stub():
     assert_true(raised)
 
 
-def test_df_ffill_stub():
+fn test_df_ffill_stub() raises:
     var pd = Python.import_module("pandas")
     var df = DataFrame(pd.DataFrame(Python.evaluate("{'a': [1.0, 2.0]}")))
     var raised = False
@@ -48,12 +48,12 @@ def test_df_ffill_stub():
     assert_true(raised)
 
 
-def test_series_fillna_works():
+fn test_series_fillna_works() raises:
     var pd = Python.import_module("pandas")
     var s = Series(pd.Series(Python.evaluate("[1.0, None, 2.0]")))
     var filled = s.fillna(DFScalar(Float64(0.0)))
     assert_true(filled.size() == 3)
 
 
-def main():
+fn main() raises:
     TestSuite.discover_tests[__functions_in_module()]().run()

--- a/tests/test_reshaping.mojo
+++ b/tests/test_reshaping.mojo
@@ -4,7 +4,7 @@ from testing import assert_true, TestSuite
 from bison import DataFrame, Series, SeriesScalar
 
 
-def test_sort_values_stub():
+fn test_sort_values_stub() raises:
     var pd = Python.import_module("pandas")
     var df = DataFrame(pd.DataFrame(Python.evaluate("{'a': [3, 1, 2]}")))
     var raised = False
@@ -15,7 +15,7 @@ def test_sort_values_stub():
     assert_true(raised)
 
 
-def test_pivot_stub():
+fn test_pivot_stub() raises:
     var pd = Python.import_module("pandas")
     var df = DataFrame(pd.DataFrame(Python.evaluate("{'a': [1], 'b': [2], 'c': [3]}")))
     var raised = False
@@ -26,7 +26,7 @@ def test_pivot_stub():
     assert_true(raised)
 
 
-def test_melt_stub():
+fn test_melt_stub() raises:
     var pd = Python.import_module("pandas")
     var df = DataFrame(pd.DataFrame(Python.evaluate("{'id': [1], 'val': [10]}")))
     var raised = False
@@ -37,7 +37,7 @@ def test_melt_stub():
     assert_true(raised)
 
 
-def test_transpose_stub():
+fn test_transpose_stub() raises:
     var pd = Python.import_module("pandas")
     var df = DataFrame(pd.DataFrame(Python.evaluate("{'a': [1, 2]}")))
     var raised = False
@@ -48,7 +48,7 @@ def test_transpose_stub():
     assert_true(raised)
 
 
-def test_drop_duplicates_stub():
+fn test_drop_duplicates_stub() raises:
     var pd = Python.import_module("pandas")
     var df = DataFrame(pd.DataFrame(Python.evaluate("{'a': [1, 1, 2]}")))
     var raised = False
@@ -59,7 +59,7 @@ def test_drop_duplicates_stub():
     assert_true(raised)
 
 
-def test_series_sort_values():
+fn test_series_sort_values() raises:
     var pd = Python.import_module("pandas")
     var s = Series(pd.Series(Python.evaluate("[3, 1, 2]"), dtype="int64"))
     var r = s.sort_values()
@@ -68,5 +68,5 @@ def test_series_sort_values():
     assert_true(r.iloc(2)[Int64] == 3)
 
 
-def main():
+fn main() raises:
     TestSuite.discover_tests[__functions_in_module()]().run()

--- a/tests/test_series.mojo
+++ b/tests/test_series.mojo
@@ -4,7 +4,7 @@ from testing import assert_equal, assert_true, assert_false, TestSuite
 from bison import Series, SeriesScalar, DFScalar, FloatTransformFn
 
 
-def test_from_pandas():
+fn test_from_pandas() raises:
     var pd = Python.import_module("pandas")
     var pd_s = pd.Series(Python.evaluate("[1, 2, 3]"), name="vals")
     var s = Series.from_pandas(pd_s)
@@ -12,32 +12,32 @@ def test_from_pandas():
     assert_equal(s.__len__(), 3)
 
 
-def test_size():
+fn test_size() raises:
     var pd = Python.import_module("pandas")
     var s = Series(pd.Series(Python.evaluate("[10, 20, 30]")))
     assert_equal(s.size(), 3)
 
 
-def test_empty_false():
+fn test_empty_false() raises:
     var pd = Python.import_module("pandas")
     var s = Series(pd.Series(Python.evaluate("[1]")))
     assert_false(s.empty())
 
 
-def test_empty_true():
+fn test_empty_true() raises:
     var pd = Python.import_module("pandas")
     var s = Series(pd.Series(Python.evaluate("[]"), dtype="float64"))
     assert_true(s.empty())
 
 
-def test_shape():
+fn test_shape() raises:
     var pd = Python.import_module("pandas")
     var s = Series(pd.Series(Python.evaluate("[1, 2, 3, 4]")))
     var sh = s.shape()
     assert_equal(sh[0], 4)
 
 
-def test_to_pandas_roundtrip():
+fn test_to_pandas_roundtrip() raises:
     var pd = Python.import_module("pandas")
     var pd_s = pd.Series(Python.evaluate("[7, 8, 9]"))
     var s = Series(pd_s)
@@ -45,83 +45,83 @@ def test_to_pandas_roundtrip():
     assert_equal(back.__len__(), 3)
 
 
-def test_sum():
+fn test_sum() raises:
     var pd = Python.import_module("pandas")
     var s = Series(pd.Series(Python.evaluate("[1, 2, 3]")))
     assert_true(s.sum() == 6.0)
 
 
-def test_mean():
+fn test_mean() raises:
     var pd = Python.import_module("pandas")
     var s = Series(pd.Series(Python.evaluate("[1, 2, 3]")))
     assert_true(s.mean() == 2.0)
 
 
-def test_median():
+fn test_median() raises:
     var pd = Python.import_module("pandas")
     var s = Series(pd.Series(Python.evaluate("[1, 2, 3]")))
     assert_true(s.median() == 2.0)
 
 
-def test_min():
+fn test_min() raises:
     var pd = Python.import_module("pandas")
     var s = Series(pd.Series(Python.evaluate("[3, 1, 2]")))
     assert_true(s.min() == 1.0)
 
 
-def test_max():
+fn test_max() raises:
     var pd = Python.import_module("pandas")
     var s = Series(pd.Series(Python.evaluate("[3, 1, 2]")))
     assert_true(s.max() == 3.0)
 
 
-def test_std():
+fn test_std() raises:
     var pd = Python.import_module("pandas")
     # std([1, 3, 5], ddof=1) == 2.0
     var s = Series(pd.Series(Python.evaluate("[1, 3, 5]")))
     assert_true(s.std() == 2.0)
 
 
-def test_var():
+fn test_var() raises:
     var pd = Python.import_module("pandas")
     # var([1, 3, 5], ddof=1) == 4.0
     var s = Series(pd.Series(Python.evaluate("[1, 3, 5]")))
     assert_true(s.var() == 4.0)
 
 
-def test_count():
+fn test_count() raises:
     var pd = Python.import_module("pandas")
     var s = Series(pd.Series(Python.evaluate("[1, 2, 3]")))
     assert_equal(s.count(), 3)
 
 
-def test_nunique():
+fn test_nunique() raises:
     var pd = Python.import_module("pandas")
     var s = Series(pd.Series(Python.evaluate("[1, 2, 2, 3, 3, 3]")))
     assert_equal(s.nunique(), 3)
 
 
-def test_quantile():
+fn test_quantile() raises:
     var pd = Python.import_module("pandas")
     var s = Series(pd.Series(Python.evaluate("[1, 2, 3, 4, 5]")))
     assert_true(s.quantile(0.5) == 3.0)
 
 
-def test_describe():
+fn test_describe() raises:
     var pd = Python.import_module("pandas")
     var s = Series(pd.Series(Python.evaluate("[1, 2, 3, 4, 5]")))
     var d = s.describe()
     assert_equal(d.size(), 8)
 
 
-def test_value_counts():
+fn test_value_counts() raises:
     var pd = Python.import_module("pandas")
     var s = Series(pd.Series(Python.evaluate("[1, 2, 2, 3, 3, 3]")))
     var vc = s.value_counts()
     assert_equal(vc.size(), 3)
 
 
-def test_head():
+fn test_head() raises:
     var pd = Python.import_module("pandas")
     var s = Series(pd.Series(Python.evaluate("[1, 2, 3, 4, 5]")))
     var h = s.head(3)
@@ -130,21 +130,21 @@ def test_head():
     assert_true(Float64(String(h.to_pandas().iloc[2])) == 3.0)
 
 
-def test_head_default():
+fn test_head_default() raises:
     var pd = Python.import_module("pandas")
     var s = Series(pd.Series(Python.evaluate("[1, 2, 3, 4, 5, 6, 7]")))
     var h = s.head()
     assert_equal(h.size(), 5)
 
 
-def test_head_clamps():
+fn test_head_clamps() raises:
     var pd = Python.import_module("pandas")
     var s = Series(pd.Series(Python.evaluate("[1, 2]")))
     var h = s.head(10)
     assert_equal(h.size(), 2)
 
 
-def test_tail():
+fn test_tail() raises:
     var pd = Python.import_module("pandas")
     var s = Series(pd.Series(Python.evaluate("[1, 2, 3, 4, 5]")))
     var t = s.tail(3)
@@ -153,21 +153,21 @@ def test_tail():
     assert_true(Float64(String(t.to_pandas().iloc[2])) == 5.0)
 
 
-def test_tail_default():
+fn test_tail_default() raises:
     var pd = Python.import_module("pandas")
     var s = Series(pd.Series(Python.evaluate("[1, 2, 3, 4, 5, 6, 7]")))
     var t = s.tail()
     assert_equal(t.size(), 5)
 
 
-def test_tail_clamps():
+fn test_tail_clamps() raises:
     var pd = Python.import_module("pandas")
     var s = Series(pd.Series(Python.evaluate("[1, 2]")))
     var t = s.tail(10)
     assert_equal(t.size(), 2)
 
 
-def test_iloc():
+fn test_iloc() raises:
     var pd = Python.import_module("pandas")
     var s = Series(pd.Series(Python.evaluate("[10, 20, 30]")))
     assert_equal(s.iloc(0)[Int64], 10)
@@ -175,14 +175,14 @@ def test_iloc():
     assert_equal(s.iloc(2)[Int64], 30)
 
 
-def test_iloc_negative():
+fn test_iloc_negative() raises:
     var pd = Python.import_module("pandas")
     var s = Series(pd.Series(Python.evaluate("[10, 20, 30]")))
     assert_equal(s.iloc(-1)[Int64], 30)
     assert_equal(s.iloc(-3)[Int64], 10)
 
 
-def test_iloc_out_of_bounds():
+fn test_iloc_out_of_bounds() raises:
     var pd = Python.import_module("pandas")
     var s = Series(pd.Series(Python.evaluate("[1, 2, 3]")))
     var raised = False
@@ -193,7 +193,7 @@ def test_iloc_out_of_bounds():
     assert_true(raised)
 
 
-def test_at():
+fn test_at() raises:
     var pd = Python.import_module("pandas")
     var idx = Python.evaluate("['a', 'b', 'c']")
     var s = Series(pd.Series(Python.evaluate("[10, 20, 30]"), index=idx))
@@ -202,7 +202,7 @@ def test_at():
     assert_equal(s.at("c")[Int64], 30)
 
 
-def test_at_missing_label():
+fn test_at_missing_label() raises:
     var pd = Python.import_module("pandas")
     var idx = Python.evaluate("['x', 'y']")
     var s = Series(pd.Series(Python.evaluate("[1, 2]"), index=idx))
@@ -214,7 +214,7 @@ def test_at_missing_label():
     assert_true(raised)
 
 
-def test_add():
+fn test_add() raises:
     var pd = Python.import_module("pandas")
     var s1 = Series(pd.Series(Python.evaluate("[1, 2, 3]")))
     var s2 = Series(pd.Series(Python.evaluate("[4, 5, 6]")))
@@ -224,7 +224,7 @@ def test_add():
     assert_true(Float64(String(rp.iloc[2])) == 9.0)
 
 
-def test_sub():
+fn test_sub() raises:
     var pd = Python.import_module("pandas")
     var s1 = Series(pd.Series(Python.evaluate("[1, 2, 3]")))
     var s2 = Series(pd.Series(Python.evaluate("[4, 5, 6]")))
@@ -234,7 +234,7 @@ def test_sub():
     assert_true(Float64(String(rp.iloc[2])) == -3.0)
 
 
-def test_mul():
+fn test_mul() raises:
     var pd = Python.import_module("pandas")
     var s1 = Series(pd.Series(Python.evaluate("[1, 2, 3]")))
     var s2 = Series(pd.Series(Python.evaluate("[4, 5, 6]")))
@@ -244,7 +244,7 @@ def test_mul():
     assert_true(Float64(String(rp.iloc[2])) == 18.0)
 
 
-def test_div():
+fn test_div() raises:
     var pd = Python.import_module("pandas")
     var s1 = Series(pd.Series(Python.evaluate("[1.0, 2.0, 3.0]")))
     var s2 = Series(pd.Series(Python.evaluate("[4.0, 5.0, 6.0]")))
@@ -254,7 +254,7 @@ def test_div():
     assert_true(Float64(String(rp.iloc[2])) == 0.5)
 
 
-def test_floordiv():
+fn test_floordiv() raises:
     var pd = Python.import_module("pandas")
     var s1 = Series(pd.Series(Python.evaluate("[1, 2, 3]")))
     var s2 = Series(pd.Series(Python.evaluate("[4, 5, 6]")))
@@ -264,7 +264,7 @@ def test_floordiv():
     assert_true(Float64(String(rp.iloc[2])) == 0.0)
 
 
-def test_mod():
+fn test_mod() raises:
     var pd = Python.import_module("pandas")
     var s1 = Series(pd.Series(Python.evaluate("[10, 7, 9]")))
     var s2 = Series(pd.Series(Python.evaluate("[3, 4, 5]")))
@@ -274,7 +274,7 @@ def test_mod():
     assert_true(Float64(String(rp.iloc[2])) == 4.0)
 
 
-def test_pow():
+fn test_pow() raises:
     var pd = Python.import_module("pandas")
     var s1 = Series(pd.Series(Python.evaluate("[2, 3, 4]")))
     var s2 = Series(pd.Series(Python.evaluate("[3, 2, 1]")))
@@ -284,7 +284,7 @@ def test_pow():
     assert_true(Float64(String(rp.iloc[2])) == 4.0)
 
 
-def test_radd():
+fn test_radd() raises:
     var pd = Python.import_module("pandas")
     var s1 = Series(pd.Series(Python.evaluate("[1, 2, 3]")))
     var s2 = Series(pd.Series(Python.evaluate("[4, 5, 6]")))
@@ -294,7 +294,7 @@ def test_radd():
     assert_true(Float64(String(rp.iloc[2])) == 9.0)
 
 
-def test_rsub():
+fn test_rsub() raises:
     var pd = Python.import_module("pandas")
     var s1 = Series(pd.Series(Python.evaluate("[1, 2, 3]")))
     var s2 = Series(pd.Series(Python.evaluate("[4, 5, 6]")))
@@ -304,7 +304,7 @@ def test_rsub():
     assert_true(Float64(String(rp.iloc[2])) == 3.0)
 
 
-def test_rmul():
+fn test_rmul() raises:
     var pd = Python.import_module("pandas")
     var s1 = Series(pd.Series(Python.evaluate("[1, 2, 3]")))
     var s2 = Series(pd.Series(Python.evaluate("[4, 5, 6]")))
@@ -314,7 +314,7 @@ def test_rmul():
     assert_true(Float64(String(rp.iloc[2])) == 18.0)
 
 
-def test_rdiv():
+fn test_rdiv() raises:
     var pd = Python.import_module("pandas")
     var s1 = Series(pd.Series(Python.evaluate("[4.0, 5.0, 6.0]")))
     var s2 = Series(pd.Series(Python.evaluate("[1.0, 2.0, 3.0]")))
@@ -324,7 +324,7 @@ def test_rdiv():
     assert_true(Float64(String(rp.iloc[2])) == 0.5)
 
 
-def test_rfloordiv():
+fn test_rfloordiv() raises:
     var pd = Python.import_module("pandas")
     var s1 = Series(pd.Series(Python.evaluate("[4, 5, 6]")))
     var s2 = Series(pd.Series(Python.evaluate("[1, 2, 3]")))
@@ -334,7 +334,7 @@ def test_rfloordiv():
     assert_true(Float64(String(rp.iloc[2])) == 0.0)
 
 
-def test_rmod():
+fn test_rmod() raises:
     var pd = Python.import_module("pandas")
     var s1 = Series(pd.Series(Python.evaluate("[3, 4, 5]")))
     var s2 = Series(pd.Series(Python.evaluate("[10, 7, 9]")))
@@ -344,7 +344,7 @@ def test_rmod():
     assert_true(Float64(String(rp.iloc[2])) == 4.0)
 
 
-def test_rpow():
+fn test_rpow() raises:
     var pd = Python.import_module("pandas")
     var s1 = Series(pd.Series(Python.evaluate("[3, 2, 1]")))
     var s2 = Series(pd.Series(Python.evaluate("[2, 3, 4]")))
@@ -354,7 +354,7 @@ def test_rpow():
     assert_true(Float64(String(rp.iloc[2])) == 4.0)
 
 
-def test_add_length_mismatch():
+fn test_add_length_mismatch() raises:
     var pd = Python.import_module("pandas")
     var s1 = Series(pd.Series(Python.evaluate("[1, 2]")))
     var s2 = Series(pd.Series(Python.evaluate("[1]")))
@@ -366,7 +366,7 @@ def test_add_length_mismatch():
     assert_true(raised)
 
 
-def test_isna():
+fn test_isna() raises:
     var pd = Python.import_module("pandas")
     var s = Series(pd.Series(Python.evaluate("[1.0, None, 3.0]")))
     var na = s.isna()
@@ -376,7 +376,7 @@ def test_isna():
     assert_false(na.iloc(2)[Bool])
 
 
-def test_isna_no_nulls():
+fn test_isna_no_nulls() raises:
     var pd = Python.import_module("pandas")
     var s = Series(pd.Series(Python.evaluate("[1.0, 2.0, 3.0]")))
     var na = s.isna()
@@ -385,7 +385,7 @@ def test_isna_no_nulls():
     assert_false(na.iloc(2)[Bool])
 
 
-def test_isnull():
+fn test_isnull() raises:
     var pd = Python.import_module("pandas")
     var s = Series(pd.Series(Python.evaluate("[1.0, None, 3.0]")))
     var na = s.isnull()
@@ -394,7 +394,7 @@ def test_isnull():
     assert_false(na.iloc(2)[Bool])
 
 
-def test_notna():
+fn test_notna() raises:
     var pd = Python.import_module("pandas")
     var s = Series(pd.Series(Python.evaluate("[1.0, None, 3.0]")))
     var na = s.notna()
@@ -404,7 +404,7 @@ def test_notna():
     assert_true(na.iloc(2)[Bool])
 
 
-def test_notnull():
+fn test_notnull() raises:
     var pd = Python.import_module("pandas")
     var s = Series(pd.Series(Python.evaluate("[1.0, None, 3.0]")))
     var na = s.notnull()
@@ -413,7 +413,7 @@ def test_notnull():
     assert_true(na.iloc(2)[Bool])
 
 
-def test_fillna():
+fn test_fillna() raises:
     var pd = Python.import_module("pandas")
     var s = Series(pd.Series(Python.evaluate("[1.0, None, 3.0]")))
     var filled = s.fillna(DFScalar(Float64(0.0)))
@@ -424,7 +424,7 @@ def test_fillna():
     assert_true(Float64(String(rp.iloc[2])) == 3.0)
 
 
-def test_fillna_no_nulls():
+fn test_fillna_no_nulls() raises:
     var pd = Python.import_module("pandas")
     var s = Series(pd.Series(Python.evaluate("[1.0, 2.0, 3.0]")))
     var filled = s.fillna(DFScalar(Float64(0.0)))
@@ -433,7 +433,7 @@ def test_fillna_no_nulls():
     assert_true(Float64(String(rp.iloc[1])) == 2.0)
 
 
-def test_fillna_int():
+fn test_fillna_int() raises:
     var pd = Python.import_module("pandas")
     var s = Series(pd.Series(Python.evaluate("[1, None, 3]"), dtype="float64"))
     var filled = s.fillna(DFScalar(Float64(9.0)))
@@ -441,7 +441,7 @@ def test_fillna_int():
     assert_true(Float64(String(rp.iloc[1])) == 9.0)
 
 
-def test_dropna():
+fn test_dropna() raises:
     var pd = Python.import_module("pandas")
     var s = Series(pd.Series(Python.evaluate("[1.0, None, 3.0]")))
     var dropped = s.dropna()
@@ -451,21 +451,21 @@ def test_dropna():
     assert_true(Float64(String(rp.iloc[1])) == 3.0)
 
 
-def test_dropna_no_nulls():
+fn test_dropna_no_nulls() raises:
     var pd = Python.import_module("pandas")
     var s = Series(pd.Series(Python.evaluate("[1.0, 2.0, 3.0]")))
     var dropped = s.dropna()
     assert_equal(dropped.size(), 3)
 
 
-def test_dropna_all_nulls():
+fn test_dropna_all_nulls() raises:
     var pd = Python.import_module("pandas")
     var s = Series(pd.Series(Python.evaluate("[None, None]"), dtype="float64"))
     var dropped = s.dropna()
     assert_equal(dropped.size(), 0)
 
 
-def test_ffill():
+fn test_ffill() raises:
     var pd = Python.import_module("pandas")
     # [1.0, NaN, 3.0] → ffill → [1.0, 1.0, 3.0]
     var s = Series(pd.Series(Python.evaluate("[1.0, None, 3.0]")))
@@ -477,7 +477,7 @@ def test_ffill():
     assert_true(Float64(String(rp.iloc[2])) == 3.0)
 
 
-def test_ffill_leading_null():
+fn test_ffill_leading_null() raises:
     var pd = Python.import_module("pandas")
     # [NaN, 2.0, NaN] → ffill → [NaN, 2.0, 2.0]
     var s = Series(pd.Series(Python.evaluate("[None, 2.0, None]")))
@@ -491,7 +491,7 @@ def test_ffill_leading_null():
     assert_true(Float64(String(rp.iloc[2])) == 2.0)
 
 
-def test_ffill_no_nulls():
+fn test_ffill_no_nulls() raises:
     var pd = Python.import_module("pandas")
     var s = Series(pd.Series(Python.evaluate("[1.0, 2.0, 3.0]")))
     var filled = s.ffill()
@@ -500,7 +500,7 @@ def test_ffill_no_nulls():
     assert_true(Float64(String(rp.iloc[1])) == 2.0)
 
 
-def test_bfill():
+fn test_bfill() raises:
     var pd = Python.import_module("pandas")
     # [1.0, NaN, 3.0] → bfill → [1.0, 3.0, 3.0]
     var s = Series(pd.Series(Python.evaluate("[1.0, None, 3.0]")))
@@ -512,7 +512,7 @@ def test_bfill():
     assert_true(Float64(String(rp.iloc[2])) == 3.0)
 
 
-def test_bfill_trailing_null():
+fn test_bfill_trailing_null() raises:
     var pd = Python.import_module("pandas")
     # [NaN, 2.0, NaN] → bfill → [2.0, 2.0, NaN]
     var s = Series(pd.Series(Python.evaluate("[None, 2.0, None]")))
@@ -524,7 +524,7 @@ def test_bfill_trailing_null():
     assert_true(Float64(String(rp.iloc[0])) == 2.0)
 
 
-def test_bfill_no_nulls():
+fn test_bfill_no_nulls() raises:
     var pd = Python.import_module("pandas")
     var s = Series(pd.Series(Python.evaluate("[1.0, 2.0, 3.0]")))
     var filled = s.bfill()
@@ -533,7 +533,7 @@ def test_bfill_no_nulls():
     assert_true(Float64(String(rp.iloc[1])) == 2.0)
 
 
-def test_eq():
+fn test_eq() raises:
     var pd = Python.import_module("pandas")
     var s1 = Series(pd.Series(Python.evaluate("[1, 2, 3]")))
     var s2 = Series(pd.Series(Python.evaluate("[1, 0, 3]")))
@@ -543,7 +543,7 @@ def test_eq():
     assert_true(Bool(rp.iloc[2]) == True)
 
 
-def test_ne():
+fn test_ne() raises:
     var pd = Python.import_module("pandas")
     var s1 = Series(pd.Series(Python.evaluate("[1, 2, 3]")))
     var s2 = Series(pd.Series(Python.evaluate("[1, 0, 3]")))
@@ -553,7 +553,7 @@ def test_ne():
     assert_true(Bool(rp.iloc[2]) == False)
 
 
-def test_lt():
+fn test_lt() raises:
     var pd = Python.import_module("pandas")
     var s1 = Series(pd.Series(Python.evaluate("[1, 2, 3]")))
     var s2 = Series(pd.Series(Python.evaluate("[2, 2, 2]")))
@@ -563,7 +563,7 @@ def test_lt():
     assert_true(Bool(rp.iloc[2]) == False)
 
 
-def test_le():
+fn test_le() raises:
     var pd = Python.import_module("pandas")
     var s1 = Series(pd.Series(Python.evaluate("[1, 2, 3]")))
     var s2 = Series(pd.Series(Python.evaluate("[2, 2, 2]")))
@@ -573,7 +573,7 @@ def test_le():
     assert_true(Bool(rp.iloc[2]) == False)
 
 
-def test_gt():
+fn test_gt() raises:
     var pd = Python.import_module("pandas")
     var s1 = Series(pd.Series(Python.evaluate("[1, 2, 3]")))
     var s2 = Series(pd.Series(Python.evaluate("[2, 2, 2]")))
@@ -583,7 +583,7 @@ def test_gt():
     assert_true(Bool(rp.iloc[2]) == True)
 
 
-def test_ge():
+fn test_ge() raises:
     var pd = Python.import_module("pandas")
     var s1 = Series(pd.Series(Python.evaluate("[1, 2, 3]")))
     var s2 = Series(pd.Series(Python.evaluate("[2, 2, 2]")))
@@ -593,7 +593,7 @@ def test_ge():
     assert_true(Bool(rp.iloc[2]) == True)
 
 
-def test_eq_null_propagation():
+fn test_eq_null_propagation() raises:
     var pd = Python.import_module("pandas")
     var s1 = Series(pd.Series(Python.evaluate("[1.0, None, 3.0]")))
     var s2 = Series(pd.Series(Python.evaluate("[1.0, 2.0, 3.0]")))
@@ -604,7 +604,7 @@ def test_eq_null_propagation():
 
 
 # Bool column comparison tests — exercises the direct Bool arm in _cmp_op
-def test_bool_eq():
+fn test_bool_eq() raises:
     var pd = Python.import_module("pandas")
     var s1 = Series(pd.Series(Python.evaluate("[True, False, True, False]"), dtype="bool"))
     var s2 = Series(pd.Series(Python.evaluate("[True, True, False, False]"), dtype="bool"))
@@ -615,7 +615,7 @@ def test_bool_eq():
     assert_true(Bool(rp.iloc[3]) == True)
 
 
-def test_bool_ne():
+fn test_bool_ne() raises:
     var pd = Python.import_module("pandas")
     var s1 = Series(pd.Series(Python.evaluate("[True, False, True, False]"), dtype="bool"))
     var s2 = Series(pd.Series(Python.evaluate("[True, True, False, False]"), dtype="bool"))
@@ -626,7 +626,7 @@ def test_bool_ne():
     assert_true(Bool(rp.iloc[3]) == False)
 
 
-def test_bool_lt():
+fn test_bool_lt() raises:
     var pd = Python.import_module("pandas")
     var s1 = Series(pd.Series(Python.evaluate("[False, False, True, True]"), dtype="bool"))
     var s2 = Series(pd.Series(Python.evaluate("[False, True, False, True]"), dtype="bool"))
@@ -637,7 +637,7 @@ def test_bool_lt():
     assert_true(Bool(rp.iloc[3]) == False)
 
 
-def test_bool_le():
+fn test_bool_le() raises:
     var pd = Python.import_module("pandas")
     var s1 = Series(pd.Series(Python.evaluate("[False, False, True, True]"), dtype="bool"))
     var s2 = Series(pd.Series(Python.evaluate("[False, True, False, True]"), dtype="bool"))
@@ -648,7 +648,7 @@ def test_bool_le():
     assert_true(Bool(rp.iloc[3]) == True)
 
 
-def test_bool_gt():
+fn test_bool_gt() raises:
     var pd = Python.import_module("pandas")
     var s1 = Series(pd.Series(Python.evaluate("[False, False, True, True]"), dtype="bool"))
     var s2 = Series(pd.Series(Python.evaluate("[False, True, False, True]"), dtype="bool"))
@@ -659,7 +659,7 @@ def test_bool_gt():
     assert_true(Bool(rp.iloc[3]) == False)
 
 
-def test_bool_ge():
+fn test_bool_ge() raises:
     var pd = Python.import_module("pandas")
     var s1 = Series(pd.Series(Python.evaluate("[False, False, True, True]"), dtype="bool"))
     var s2 = Series(pd.Series(Python.evaluate("[False, True, False, True]"), dtype="bool"))
@@ -670,7 +670,7 @@ def test_bool_ge():
     assert_true(Bool(rp.iloc[3]) == True)
 
 
-def test_copy():
+fn test_copy() raises:
     var pd = Python.import_module("pandas")
     var s = Series(pd.Series(Python.evaluate("[1, 2, 3]"), dtype="int64"))
     var c = s.copy()
@@ -678,7 +678,7 @@ def test_copy():
     assert_true(c.iloc(2)[Int64] == 3)
 
 
-def test_rename():
+fn test_rename() raises:
     var pd = Python.import_module("pandas")
     var s = Series(pd.Series(Python.evaluate("[1, 2, 3]")), "original")
     var r = s.rename("renamed")
@@ -686,7 +686,7 @@ def test_rename():
     assert_true(s.name == "original")
 
 
-def test_abs_float():
+fn test_abs_float() raises:
     var pd = Python.import_module("pandas")
     var s = Series(pd.Series(Python.evaluate("[-1.0, -2.5, 3.0, -4.0]")))
     var r = s.abs()
@@ -695,7 +695,7 @@ def test_abs_float():
     assert_true(r.iloc(2)[Float64] == 3.0)
 
 
-def test_abs_int():
+fn test_abs_int() raises:
     var pd = Python.import_module("pandas")
     var s = Series(pd.Series(Python.evaluate("[-3, -1, 0, 2]"), dtype="int64"))
     var r = s.abs()
@@ -704,7 +704,7 @@ def test_abs_int():
     assert_true(r.iloc(3)[Int64] == 2)
 
 
-def test_abs_null_propagation():
+fn test_abs_null_propagation() raises:
     var pd = Python.import_module("pandas")
     var s = Series(pd.Series(Python.evaluate("[-1.0, None, 3.0]")))
     var result = s.abs()
@@ -712,7 +712,7 @@ def test_abs_null_propagation():
     assert_false(result.isna().iloc(0)[Bool])
 
 
-def test_round_float():
+fn test_round_float() raises:
     var pd = Python.import_module("pandas")
     var s = Series(pd.Series(Python.evaluate("[1.123, 2.567, 3.001]")))
     var r = s.round(2)
@@ -720,7 +720,7 @@ def test_round_float():
     assert_true(r.iloc(1)[Float64] == 2.57)
 
 
-def test_round_int_identity():
+fn test_round_int_identity() raises:
     var pd = Python.import_module("pandas")
     var s = Series(pd.Series(Python.evaluate("[1, 2, 3]"), dtype="int64"))
     var r = s.round(0)
@@ -728,7 +728,7 @@ def test_round_int_identity():
     assert_true(r.iloc(2)[Int64] == 3)
 
 
-def test_round_null_propagation():
+fn test_round_null_propagation() raises:
     var pd = Python.import_module("pandas")
     var s = Series(pd.Series(Python.evaluate("[1.5, None, 3.7]")))
     var result = s.round(0)
@@ -736,7 +736,7 @@ def test_round_null_propagation():
     assert_false(result.isna().iloc(0)[Bool])
 
 
-def test_round_bankers():
+fn test_round_bankers() raises:
     """Verify banker's rounding (round-half-to-even) at exact half-way points."""
     var pd = Python.import_module("pandas")
     # 0.5 → 0 (even), 1.5 → 2 (even), 2.5 → 2 (even), 3.5 → 4 (even)
@@ -754,7 +754,7 @@ def test_round_bankers():
     assert_true(r2.iloc(2)[Float64] == -2.0)
 
 
-def test_clip_float():
+fn test_clip_float() raises:
     var pd = Python.import_module("pandas")
     var s = Series(pd.Series(Python.evaluate("[0.0, 5.0, 10.0, 15.0]")))
     var r = s.clip(Float64(2.0), Float64(12.0))
@@ -764,7 +764,7 @@ def test_clip_float():
     assert_true(r.iloc(3)[Float64] == 12.0)
 
 
-def test_clip_int():
+fn test_clip_int() raises:
     var pd = Python.import_module("pandas")
     var s = Series(pd.Series(Python.evaluate("[1, 5, 10, 20]"), dtype="int64"))
     var r = s.clip(Float64(3.0), Float64(15.0))
@@ -773,7 +773,7 @@ def test_clip_int():
     assert_true(r.iloc(3)[Int64] == 15)
 
 
-def test_clip_null_propagation():
+fn test_clip_null_propagation() raises:
     var pd = Python.import_module("pandas")
     var s = Series(pd.Series(Python.evaluate("[1.0, None, 10.0]")))
     var result = s.clip(Float64(2.0), Float64(8.0))
@@ -790,7 +790,7 @@ fn _identity(v: Float64) -> Float64:
 fn _negate(v: Float64) -> Float64:
     return -v
 
-def test_apply():
+fn test_apply() raises:
     var pd = Python.import_module("pandas")
     var s = Series(pd.Series(Python.evaluate("[1.0, 2.0, 3.0]")))
     var r = s.apply[_double]()
@@ -799,7 +799,7 @@ def test_apply():
     assert_true(r.iloc(2)[Float64] == 6.0)
 
 
-def test_apply_null_propagation():
+fn test_apply_null_propagation() raises:
     var pd = Python.import_module("pandas")
     var s = Series(pd.Series(Python.evaluate("[1.0, None, 3.0]")))
     var result = s.apply[_identity]()
@@ -807,7 +807,7 @@ def test_apply_null_propagation():
     assert_false(result.isna().iloc(0)[Bool])
 
 
-def test_map():
+fn test_map() raises:
     var pd = Python.import_module("pandas")
     var s = Series(pd.Series(Python.evaluate("[1.0, 2.0, 3.0]")))
     var r = s.map[_negate]()
@@ -816,7 +816,7 @@ def test_map():
     assert_true(r.iloc(2)[Float64] == -3.0)
 
 
-def test_isin_int():
+fn test_isin_int() raises:
     var pd = Python.import_module("pandas")
     var s = Series(pd.Series(Python.evaluate("[1, 2, 3, 4]"), dtype="int64"))
     var vals = List[Int64]()
@@ -829,7 +829,7 @@ def test_isin_int():
     assert_true(r.iloc(3)[Bool])
 
 
-def test_isin_float():
+fn test_isin_float() raises:
     var pd = Python.import_module("pandas")
     var s = Series(pd.Series(Python.evaluate("[1.0, 2.0, 3.0, 4.0]")))
     var vals = List[Float64]()
@@ -842,7 +842,7 @@ def test_isin_float():
     assert_false(r.iloc(3)[Bool])
 
 
-def test_isin_str():
+fn test_isin_str() raises:
     var pd = Python.import_module("pandas")
     var s = Series(pd.Series(Python.evaluate('["a", "b", "c", "d"]'), dtype="string"))
     var vals = List[String]()
@@ -855,7 +855,7 @@ def test_isin_str():
     assert_false(r.iloc(3)[Bool])
 
 
-def test_isin_bool():
+fn test_isin_bool() raises:
     var pd = Python.import_module("pandas")
     var s = Series(pd.Series(Python.evaluate("[True, False, True, False]"), dtype="bool"))
     var vals = List[Bool]()
@@ -867,7 +867,7 @@ def test_isin_bool():
     assert_false(r.iloc(3)[Bool])
 
 
-def test_between():
+fn test_between() raises:
     var pd = Python.import_module("pandas")
     var s = Series(pd.Series(Python.evaluate("[1.0, 2.0, 3.0, 4.0, 5.0]")))
     var r = s.between(Float64(2.0), Float64(4.0))
@@ -878,7 +878,7 @@ def test_between():
     assert_false(r.iloc(4)[Bool])
 
 
-def test_where():
+fn test_where() raises:
     var pd = Python.import_module("pandas")
     var s = Series(pd.Series(Python.evaluate("[1.0, 2.0, 3.0, 4.0]")))
     var cond = Series(pd.Series(Python.evaluate("[True, False, True, False]"), dtype="bool"))
@@ -889,7 +889,7 @@ def test_where():
     assert_true(result.isna().iloc(3)[Bool])
 
 
-def test_where_null_propagation():
+fn test_where_null_propagation() raises:
     var pd = Python.import_module("pandas")
     var s = Series(pd.Series(Python.evaluate("[1.0, None, 3.0]")))
     var cond = Series(pd.Series(Python.evaluate("[True, True, False]"), dtype="bool"))
@@ -899,7 +899,7 @@ def test_where_null_propagation():
     assert_true(result.isna().iloc(2)[Bool])
 
 
-def test_mask():
+fn test_mask() raises:
     var pd = Python.import_module("pandas")
     var s = Series(pd.Series(Python.evaluate("[1.0, 2.0, 3.0, 4.0]")))
     var cond = Series(pd.Series(Python.evaluate("[True, False, True, False]"), dtype="bool"))
@@ -910,7 +910,7 @@ def test_mask():
     assert_true(result.iloc(3)[Float64] == 4.0)
 
 
-def test_mask_null_propagation():
+fn test_mask_null_propagation() raises:
     var pd = Python.import_module("pandas")
     var s = Series(pd.Series(Python.evaluate("[1.0, None, 3.0]")))
     var cond = Series(pd.Series(Python.evaluate("[False, False, True]"), dtype="bool"))
@@ -920,7 +920,7 @@ def test_mask_null_propagation():
     assert_true(result.isna().iloc(2)[Bool])
 
 
-def test_unique_int():
+fn test_unique_int() raises:
     var pd = Python.import_module("pandas")
     var s = Series(pd.Series(Python.evaluate("[3, 1, 2, 1, 3]"), dtype="int64"))
     var r = s.unique()
@@ -930,7 +930,7 @@ def test_unique_int():
     assert_true(r.iloc(2)[Int64] == 2)
 
 
-def test_unique_float():
+fn test_unique_float() raises:
     var pd = Python.import_module("pandas")
     var s = Series(pd.Series(Python.evaluate("[1.0, 2.0, 1.0, 3.0]")))
     var r = s.unique()
@@ -940,7 +940,7 @@ def test_unique_float():
     assert_true(r.iloc(2)[Float64] == 3.0)
 
 
-def test_astype():
+fn test_astype() raises:
     var pd = Python.import_module("pandas")
     var s = Series(pd.Series(Python.evaluate("[1, 2, 3]"), dtype="int64"))
     var r = s.astype("float64")
@@ -948,7 +948,7 @@ def test_astype():
     assert_true(r.iloc(2)[Float64] == 3.0)
 
 
-def test_astype_null_propagation():
+fn test_astype_null_propagation() raises:
     var pd = Python.import_module("pandas")
     # Float64 → Int64: null at index 1 must propagate
     var sf = Series(pd.Series(Python.evaluate("[1.0, None, 3.0]")))
@@ -963,7 +963,7 @@ def test_astype_null_propagation():
     assert_false(rb.isna().iloc(2)[Bool])
 
 
-def test_reset_index():
+fn test_reset_index() raises:
     var pd = Python.import_module("pandas")
     var s = Series(pd.Series(Python.evaluate("[10, 20, 30]"), index=Python.evaluate("[5, 6, 7]")))
     var r = s.reset_index(drop=True)
@@ -975,7 +975,7 @@ def test_reset_index():
 # Sorting
 # ------------------------------------------------------------------
 
-def test_sort_values_ascending_int():
+fn test_sort_values_ascending_int() raises:
     var pd = Python.import_module("pandas")
     var s = Series(pd.Series(Python.evaluate("[3, 1, 2]"), dtype="int64"))
     var r = s.sort_values()
@@ -984,7 +984,7 @@ def test_sort_values_ascending_int():
     assert_true(r.iloc(2)[Int64] == 3)
 
 
-def test_sort_values_descending_int():
+fn test_sort_values_descending_int() raises:
     var pd = Python.import_module("pandas")
     var s = Series(pd.Series(Python.evaluate("[3, 1, 2]"), dtype="int64"))
     var r = s.sort_values(ascending=False)
@@ -993,7 +993,7 @@ def test_sort_values_descending_int():
     assert_true(r.iloc(2)[Int64] == 1)
 
 
-def test_sort_values_float():
+fn test_sort_values_float() raises:
     var pd = Python.import_module("pandas")
     var s = Series(pd.Series(Python.evaluate("[3.0, 1.0, 2.0]")))
     var r = s.sort_values()
@@ -1002,7 +1002,7 @@ def test_sort_values_float():
     assert_true(r.iloc(2)[Float64] == 3.0)
 
 
-def test_sort_values_string():
+fn test_sort_values_string() raises:
     var pd = Python.import_module("pandas")
     var s = Series(pd.Series(Python.evaluate("['c', 'a', 'b']"), dtype="string"))
     var r = s.sort_values()
@@ -1011,7 +1011,7 @@ def test_sort_values_string():
     assert_true(r.iloc(2)[String] == "c")
 
 
-def test_sort_values_null_last():
+fn test_sort_values_null_last() raises:
     var pd = Python.import_module("pandas")
     var s = Series(pd.Series(Python.evaluate("[3.0, None, 1.0]")))
     var r = s.sort_values()
@@ -1020,7 +1020,7 @@ def test_sort_values_null_last():
     assert_true(r.isna().iloc(2)[Bool])
 
 
-def test_sort_values_preserves_index():
+fn test_sort_values_preserves_index() raises:
     var pd = Python.import_module("pandas")
     # s: label 'b'->3, 'a'->1, 'c'->2.  Sorted by value: 1,2,3 → labels a,c,b.
     var s = Series(pd.Series(Python.evaluate("[3, 1, 2]"), dtype="int64", index=Python.evaluate("['b', 'a', 'c']")))
@@ -1034,7 +1034,7 @@ def test_sort_values_preserves_index():
     assert_true(r.at("b")[Int64] == 3)
 
 
-def test_sort_index_ascending_default():
+fn test_sort_index_ascending_default() raises:
     var pd = Python.import_module("pandas")
     # Default RangeIndex — ascending is a no-op.
     var s = Series(pd.Series(Python.evaluate("[30, 10, 20]"), dtype="int64"))
@@ -1044,7 +1044,7 @@ def test_sort_index_ascending_default():
     assert_true(r.iloc(2)[Int64] == 20)
 
 
-def test_sort_index_descending_default():
+fn test_sort_index_descending_default() raises:
     var pd = Python.import_module("pandas")
     var s = Series(pd.Series(Python.evaluate("[30, 10, 20]"), dtype="int64"))
     var r = s.sort_index(ascending=False)
@@ -1053,7 +1053,7 @@ def test_sort_index_descending_default():
     assert_true(r.iloc(2)[Int64] == 30)
 
 
-def test_sort_index_custom():
+fn test_sort_index_custom() raises:
     var pd = Python.import_module("pandas")
     # index labels [2, 0, 1] → sorted ascending → [0, 1, 2] → data [10, 20, 30]
     var s = Series(pd.Series(Python.evaluate("[30, 10, 20]"), dtype="int64", index=Python.evaluate("[2, 0, 1]")))
@@ -1063,7 +1063,7 @@ def test_sort_index_custom():
     assert_true(r.iloc(2)[Int64] == 30)
 
 
-def test_sort_index_custom_descending():
+fn test_sort_index_custom_descending() raises:
     var pd = Python.import_module("pandas")
     var s = Series(pd.Series(Python.evaluate("[30, 10, 20]"), dtype="int64", index=Python.evaluate("[2, 0, 1]")))
     var r = s.sort_index(ascending=False)
@@ -1072,7 +1072,7 @@ def test_sort_index_custom_descending():
     assert_true(r.iloc(2)[Int64] == 10)
 
 
-def test_argsort_int():
+fn test_argsort_int() raises:
     var pd = Python.import_module("pandas")
     var s = Series(pd.Series(Python.evaluate("[3, 1, 2]"), dtype="int64"))
     var r = s.argsort()
@@ -1082,7 +1082,7 @@ def test_argsort_int():
     assert_true(r.iloc(2)[Int64] == 0)
 
 
-def test_argsort_float():
+fn test_argsort_float() raises:
     var pd = Python.import_module("pandas")
     var s = Series(pd.Series(Python.evaluate("[3.0, 1.0, 2.0]")))
     var r = s.argsort()
@@ -1091,7 +1091,7 @@ def test_argsort_float():
     assert_true(r.iloc(2)[Int64] == 0)
 
 
-def test_argsort_with_null():
+fn test_argsort_with_null() raises:
     var pd = Python.import_module("pandas")
     # s=[3.0, None, 1.0]: perm=[2,0,1]; perm[2]=1 is null → NaN at result pos 2
     var s = Series(pd.Series(Python.evaluate("[3.0, None, 1.0]")))
@@ -1101,7 +1101,7 @@ def test_argsort_with_null():
     assert_true(r.isna().iloc(2)[Bool])
 
 
-def test_rank_no_ties():
+fn test_rank_no_ties() raises:
     var pd = Python.import_module("pandas")
     var s = Series(pd.Series(Python.evaluate("[3.0, 1.0, 2.0]")))
     var r = s.rank()
@@ -1110,7 +1110,7 @@ def test_rank_no_ties():
     assert_true(r.iloc(2)[Float64] == 2.0)
 
 
-def test_rank_with_ties():
+fn test_rank_with_ties() raises:
     var pd = Python.import_module("pandas")
     var s = Series(pd.Series(Python.evaluate("[1.0, 1.0, 2.0]")))
     var r = s.rank()
@@ -1120,7 +1120,7 @@ def test_rank_with_ties():
     assert_true(r.iloc(2)[Float64] == 3.0)
 
 
-def test_rank_with_null():
+fn test_rank_with_null() raises:
     var pd = Python.import_module("pandas")
     var s = Series(pd.Series(Python.evaluate("[3.0, None, 1.0]")))
     var r = s.rank()
@@ -1129,5 +1129,5 @@ def test_rank_with_null():
     assert_true(r.iloc(2)[Float64] == 1.0)
 
 
-def main():
+fn main() raises:
     TestSuite.discover_tests[__functions_in_module()]().run()


### PR DESCRIPTION
## Summary

- Rename `__copyinit__` source parameter `existing` → `copy` and `__moveinit__` source parameter `existing` → `take` across all structs — nightly now enforces these names
- Convert all `def test_*():` and `def main():` in test files to `fn ... raises:` — nightly dropped implicit `raises` from `def` functions
- Fix `DataFrame.get()` to explicitly copy `Optional[Series]` default — no longer `ImplicitlyCopyable` in nightly
- Add `pull_request` trigger to `nightly.yml` so breakage surfaces on PRs, not just in the daily schedule

All changes are backward-compatible with stable 26.1.0.

## Test plan

- [x] `pixi run test` (stable 26.1.0) — 249 tests, 0 failed
- [x] `pixi run test --locked=false` (nightly channel) — 249 tests, 0 failed