### PR TITLE
feat: implement 15 DataFrame structural operations

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ In CI it runs after the test suite and the result is committed back to the branc
 <!-- COMPAT_TABLE_START -->
 | Category | Stubs | Implemented |
 |----------|-------|-------------|
-| DataFrame | 69 | 48 |
+| DataFrame | 54 | 64 |
 | Series | 7 | 80 |
 | GroupBy (DataFrame) | 16 | 1 |
 | GroupBy (Series) | 15 | 1 |
@@ -91,7 +91,7 @@ In CI it runs after the test suite and the result is committed back to the branc
 | Index | 0 | 14 |
 | IO | 10 | 2 |
 | Reshape | 0 | 1 |
-| **Total** | **134** | **169** |
+| **Total** | **119** | **185** |
 <!-- COMPAT_TABLE_END -->
 
 ## Known limitations

--- a/bison/column.mojo
+++ b/bison/column.mojo
@@ -763,6 +763,129 @@ struct _WhereMaskVisitor(ColumnDataVisitorRaises, Copyable, Movable):
         raise Error("where/mask: not supported for object dtype")
 
 
+struct _CombineFirstVisitor(ColumnDataVisitorRaises, Copyable, Movable):
+    """Row-wise null-coalesce: keeps self's value where non-null, takes other's otherwise.
+
+    Used by ``_combine_first_col`` (backing ``DataFrame.combine_first`` and
+    ``DataFrame.update``).  For each row i: if self is non-null keep self;
+    else take other (which may itself be null).
+    Raises if the two ColumnData arms have different types.
+    """
+    var col_data: ColumnData
+    var result_mask: List[Bool]
+    var has_any_null: Bool
+    var self_null_mask: List[Bool]
+    var other_data: ColumnData
+    var other_null_mask: List[Bool]
+
+    fn __init__(out self, self_null_mask: List[Bool], other_data: ColumnData,
+                other_null_mask: List[Bool]):
+        self.col_data = ColumnData(List[PythonObject]())
+        self.result_mask = List[Bool]()
+        self.has_any_null = False
+        self.self_null_mask = self_null_mask.copy()
+        var v = _CopyDataVisitor()
+        visit_col_data(v, other_data)
+        self.other_data = v^.result
+        self.other_null_mask = other_null_mask.copy()
+
+    fn on_int64(mut self, data: List[Int64]) raises:
+        if not self.other_data.isa[List[Int64]]():
+            raise Error("combine_first: dtype mismatch between columns")
+        ref od = self.other_data[List[Int64]]
+        var has_self_mask = len(self.self_null_mask) > 0
+        var has_other_mask = len(self.other_null_mask) > 0
+        var result = List[Int64]()
+        for i in range(len(data)):
+            var self_null = has_self_mask and self.self_null_mask[i]
+            if not self_null:
+                result.append(data[i])
+                self.result_mask.append(False)
+            else:
+                var other_null = has_other_mask and self.other_null_mask[i]
+                if other_null:
+                    result.append(Int64(0))
+                    self.result_mask.append(True)
+                    self.has_any_null = True
+                else:
+                    result.append(od[i])
+                    self.result_mask.append(False)
+        self.col_data = ColumnData(result^)
+
+    fn on_float64(mut self, data: List[Float64]) raises:
+        if not self.other_data.isa[List[Float64]]():
+            raise Error("combine_first: dtype mismatch between columns")
+        ref od = self.other_data[List[Float64]]
+        var has_self_mask = len(self.self_null_mask) > 0
+        var has_other_mask = len(self.other_null_mask) > 0
+        var nan = Float64(0) / Float64(0)
+        var result = List[Float64]()
+        for i in range(len(data)):
+            var self_null = has_self_mask and self.self_null_mask[i]
+            if not self_null:
+                result.append(data[i])
+                self.result_mask.append(False)
+            else:
+                var other_null = has_other_mask and self.other_null_mask[i]
+                if other_null:
+                    result.append(nan)
+                    self.result_mask.append(True)
+                    self.has_any_null = True
+                else:
+                    result.append(od[i])
+                    self.result_mask.append(False)
+        self.col_data = ColumnData(result^)
+
+    fn on_bool(mut self, data: List[Bool]) raises:
+        if not self.other_data.isa[List[Bool]]():
+            raise Error("combine_first: dtype mismatch between columns")
+        ref od = self.other_data[List[Bool]]
+        var has_self_mask = len(self.self_null_mask) > 0
+        var has_other_mask = len(self.other_null_mask) > 0
+        var result = List[Bool]()
+        for i in range(len(data)):
+            var self_null = has_self_mask and self.self_null_mask[i]
+            if not self_null:
+                result.append(data[i])
+                self.result_mask.append(False)
+            else:
+                var other_null = has_other_mask and self.other_null_mask[i]
+                if other_null:
+                    result.append(False)
+                    self.result_mask.append(True)
+                    self.has_any_null = True
+                else:
+                    result.append(od[i])
+                    self.result_mask.append(False)
+        self.col_data = ColumnData(result^)
+
+    fn on_str(mut self, data: List[String]) raises:
+        if not self.other_data.isa[List[String]]():
+            raise Error("combine_first: dtype mismatch between columns")
+        ref od = self.other_data[List[String]]
+        var has_self_mask = len(self.self_null_mask) > 0
+        var has_other_mask = len(self.other_null_mask) > 0
+        var result = List[String]()
+        for i in range(len(data)):
+            var self_null = has_self_mask and self.self_null_mask[i]
+            if not self_null:
+                result.append(data[i])
+                self.result_mask.append(False)
+            else:
+                var other_null = has_other_mask and self.other_null_mask[i]
+                if other_null:
+                    result.append(String(""))
+                    self.result_mask.append(True)
+                    self.has_any_null = True
+                else:
+                    result.append(od[i])
+                    self.result_mask.append(False)
+        self.col_data = ColumnData(result^)
+
+    fn on_obj(mut self, data: List[PythonObject]) raises:
+        raise Error("combine_first: not supported for object dtype")
+
+
 struct _UniqueVisitor(ColumnDataVisitorRaises, Copyable, Movable):
     """Returns unique values in first-occurrence order; nulls appended once at end."""
     var col_data: ColumnData
@@ -2046,6 +2169,24 @@ struct Column(Copyable, Movable, Sized):
         """Null value where ``cond`` is True; keep otherwise."""
         return self._where_mask[0](cond)
 
+    fn _combine_first_col(self, other: Column) raises -> Column:
+        """Return a Column whose values come from self where non-null, otherwise from other.
+
+        Both columns must have the same length and the same ColumnData arm type.
+        Raises on length mismatch or dtype mismatch.
+        """
+        if len(self) != len(other):
+            raise Error(
+                "combine_first: length mismatch ("
+                + String(len(self))
+                + " vs "
+                + String(len(other))
+                + ")"
+            )
+        var visitor = _CombineFirstVisitor(self._null_mask, other._data, other._null_mask)
+        visit_col_data_raises(visitor, self._data)
+        return self._build_result_col(visitor.col_data.copy(), visitor.result_mask.copy(), visitor.has_any_null)
+
     fn _unique(self) raises -> Column:
         """Return a Column of unique values, preserving first-occurrence order.
 
@@ -2523,6 +2664,38 @@ struct Column(Copyable, Movable, Sized):
         var visitor = _DtypeSniffVisitor()
         visit_col_data(visitor, data)
         return visitor.result
+
+    @staticmethod
+    fn _fill_scalar(name: String, value: DFScalar, n: Int, index: List[PythonObject]) -> Column:
+        """Create a Column of length *n* with every element equal to *value*.
+
+        The dtype is inferred from the DFScalar arm: Int64 → int64, Float64 → float64,
+        Bool → bool, String → object (matching pandas string storage).
+        """
+        if value.isa[Int64]():
+            var v = value[Int64]
+            var data = List[Int64]()
+            for i in range(n):
+                data.append(v)
+            return Column(name, ColumnData(data^), int64, index.copy())
+        elif value.isa[Float64]():
+            var v = value[Float64]
+            var data = List[Float64]()
+            for i in range(n):
+                data.append(v)
+            return Column(name, ColumnData(data^), float64, index.copy())
+        elif value.isa[Bool]():
+            var v = value[Bool]
+            var data = List[Bool]()
+            for i in range(n):
+                data.append(v)
+            return Column(name, ColumnData(data^), bool_, index.copy())
+        else:
+            var v = value[String]
+            var data = List[String]()
+            for i in range(n):
+                data.append(v)
+            return Column(name, ColumnData(data^), object_, index.copy())
 
     fn to_pandas(self) raises -> PythonObject:
         """Reconstruct a pandas Series from stored values."""

--- a/bison/dataframe.mojo
+++ b/bison/dataframe.mojo
@@ -2,7 +2,7 @@ from std.python import Python, PythonObject
 from std.collections import Optional, Dict
 from ._errors import _not_implemented
 from .column import Column, ColumnData, DFScalar
-from .dtypes import float64 as _float64
+from .dtypes import BisonDtype, dtype_from_string, bool_ as _bool_, float64 as _float64
 from .series import Series
 from .groupby import DataFrameGroupBy
 
@@ -849,16 +849,182 @@ struct DataFrame(Copyable, Movable):
         return DataFrame()
 
     fn drop(self, labels: Optional[List[String]] = None, axis: Int = 0, columns: Optional[List[String]] = None) raises -> DataFrame:
-        _not_implemented("DataFrame.drop")
-        return DataFrame()
+        """Drop columns (axis=1 / columns kwarg) or rows (axis=0) by label.
+
+        Column drop: pass ``columns=[...]`` or ``axis=1`` with ``labels=[...]``.
+        Row drop: pass ``axis=0`` with ``labels=[...]`` matching index labels or
+        (for default RangeIndex) integer row positions as strings.
+        Raises if a requested label is not found.
+        """
+        var ncols = len(self._cols)
+        if ncols == 0:
+            return DataFrame()
+
+        # Determine drop mode: column axis if ``columns`` kwarg is set, or axis==1.
+        var drop_cols: Bool
+        var drop_labels: List[String]
+        if columns:
+            drop_cols = True
+            drop_labels = columns.value().copy()
+        elif axis == 1:
+            drop_cols = True
+            if labels:
+                drop_labels = labels.value().copy()
+            else:
+                drop_labels = List[String]()
+        else:
+            drop_cols = False
+            if labels:
+                drop_labels = labels.value().copy()
+            else:
+                drop_labels = List[String]()
+
+        if drop_cols:
+            # Build a set of column names to remove.
+            var drop_set = Dict[String, Bool]()
+            for i in range(len(drop_labels)):
+                drop_set[drop_labels[i]] = True
+            # Verify all requested labels exist.
+            for i in range(len(drop_labels)):
+                var found = False
+                for j in range(ncols):
+                    if self._cols[j].name == drop_labels[i]:
+                        found = True
+                        break
+                if not found:
+                    raise Error("DataFrame.drop: column not found: " + drop_labels[i])
+            # Collect surviving columns.
+            var result_cols = List[Column]()
+            for i in range(ncols):
+                if self._cols[i].name not in drop_set:
+                    result_cols.append(self._cols[i].copy())
+            return DataFrame(result_cols^)
+        else:
+            # Row drop: match drop_labels against the index.
+            var nrows = self.shape()[0]
+            var has_index = ncols > 0 and len(self._cols[0]._index) > 0
+            var drop_set = Dict[String, Bool]()
+            for i in range(len(drop_labels)):
+                drop_set[drop_labels[i]] = True
+            var keep_indices = List[Int]()
+            for i in range(nrows):
+                var key: String
+                if has_index:
+                    key = String(self._cols[0]._index[i])
+                else:
+                    key = String(i)
+                if key not in drop_set:
+                    keep_indices.append(i)
+            # Verify all requested labels were found.
+            var found_set = Dict[String, Bool]()
+            for i in range(nrows):
+                var key: String
+                if has_index:
+                    key = String(self._cols[0]._index[i])
+                else:
+                    key = String(i)
+                if key in drop_set:
+                    found_set[key] = True
+            for i in range(len(drop_labels)):
+                if drop_labels[i] not in found_set:
+                    raise Error("DataFrame.drop: index label not found: " + drop_labels[i])
+            var result_cols = List[Column]()
+            for i in range(ncols):
+                result_cols.append(self._cols[i].take(keep_indices))
+            return DataFrame(result_cols^)
 
     fn drop_duplicates(self, subset: Optional[List[String]] = None, keep: String = "first") raises -> DataFrame:
-        _not_implemented("DataFrame.drop_duplicates")
-        return DataFrame()
+        """Return a DataFrame with duplicate rows removed.
+
+        Delegates to ``duplicated`` to identify duplicates, then retains rows
+        where the duplicate flag is False.  See ``duplicated`` for ``subset``
+        and ``keep`` semantics.
+        """
+        var dup = self.duplicated(subset, keep)
+        ref dup_data = dup._col._data[List[Bool]]
+        var keep_indices = List[Int]()
+        for i in range(len(dup_data)):
+            if not dup_data[i]:
+                keep_indices.append(i)
+        var result_cols = List[Column]()
+        for i in range(len(self._cols)):
+            result_cols.append(self._cols[i].take(keep_indices))
+        return DataFrame(result_cols^)
 
     fn duplicated(self, subset: Optional[List[String]] = None, keep: String = "first") raises -> Series:
-        _not_implemented("DataFrame.duplicated")
-        return Series()
+        """Return a boolean Series indicating duplicate rows.
+
+        Each row is fingerprinted by concatenating per-column string
+        representations separated by ``\\x00``.
+
+        - ``keep="first"``  — False for the first occurrence, True for subsequent.
+        - ``keep="last"``   — False for the last occurrence, True for earlier ones.
+        - ``keep=False``    — True for every occurrence of a repeated row.
+
+        ``subset`` restricts the columns used to build the fingerprint.
+        Raises if any name in ``subset`` is not a column in this DataFrame.
+        """
+        var nrows = self.shape()[0]
+        var ncols = len(self._cols)
+
+        # Build list of working column indices (subset or all).
+        var work_indices = List[Int]()
+        if subset:
+            var sub = subset.value().copy()
+            for s in range(len(sub)):
+                var name = sub[s]
+                var found = False
+                for j in range(ncols):
+                    if self._cols[j].name == name:
+                        work_indices.append(j)
+                        found = True
+                        break
+                if not found:
+                    raise Error("DataFrame.duplicated: column not found in subset: " + name)
+        else:
+            for j in range(ncols):
+                work_indices.append(j)
+
+        # Build a row-key string for each row.
+        var keys = List[String]()
+        for i in range(nrows):
+            var key = String("")
+            for k in range(len(work_indices)):
+                if k > 0:
+                    key = key + "\x00"
+                key = key + _col_cell_str(self._cols[work_indices[k]], i)
+            keys.append(key)
+
+        var result = List[Bool]()
+
+        if keep == "first":
+            var seen = Dict[String, Bool]()
+            for i in range(nrows):
+                if keys[i] in seen:
+                    result.append(True)
+                else:
+                    seen[keys[i]] = True
+                    result.append(False)
+        elif keep == "last":
+            # Pass 1: find last occurrence index of each key.
+            var last_idx = Dict[String, Int]()
+            for i in range(nrows):
+                last_idx[keys[i]] = i
+            # Pass 2: mark True for all rows that are NOT the last occurrence.
+            for i in range(nrows):
+                result.append(last_idx[keys[i]] != i)
+        elif keep == "False":
+            # Count all occurrences.
+            var counts = Dict[String, Int]()
+            for i in range(nrows):
+                counts[keys[i]] = counts.get(keys[i], 0) + 1
+            for i in range(nrows):
+                result.append(counts[keys[i]] > 1)
+        else:
+            raise Error("DataFrame.duplicated: keep must be 'first', 'last', or 'False'")
+
+        var col = Column("", ColumnData(result^), _bool_)
+        return Series(col^)
 
     fn pivot(self, index: String = "", columns: String = "", values: String = "") raises -> DataFrame:
         _not_implemented("DataFrame.pivot")
@@ -897,50 +1063,248 @@ struct DataFrame(Copyable, Movable):
         return DataFrame()
 
     fn clip(self, lower: Optional[Float64] = None, upper: Optional[Float64] = None) raises -> DataFrame:
-        _not_implemented("DataFrame.clip")
-        return DataFrame()
+        """Clamp numeric column values to [lower, upper].
+
+        Either bound may be ``None`` (no clipping on that side).  Non-numeric
+        columns (Bool, String, Object) raise from the underlying ``Column._clip``.
+        Uses sentinel values ±1e308 when a bound is ``None``.
+        """
+        if not lower and not upper:
+            return self._deep_copy()
+        var lo = Float64(-1e308)
+        if lower:
+            lo = lower.value()
+        var hi = Float64(1e308)
+        if upper:
+            hi = upper.value()
+        var result_cols = List[Column]()
+        for i in range(len(self._cols)):
+            result_cols.append(self._cols[i]._clip(lo, hi))
+        return DataFrame(result_cols^)
 
     fn round(self, decimals: Int = 0) raises -> DataFrame:
-        _not_implemented("DataFrame.round")
-        return DataFrame()
+        """Round numeric column values to *decimals* decimal places."""
+        var result_cols = List[Column]()
+        for i in range(len(self._cols)):
+            result_cols.append(self._cols[i]._round(decimals))
+        return DataFrame(result_cols^)
 
     fn astype(self, dtype: String) raises -> DataFrame:
-        _not_implemented("DataFrame.astype")
-        return DataFrame()
+        """Cast every column to *dtype*.
 
-    fn copy(self, deep: Bool = True) raises -> DataFrame:
-        _not_implemented("DataFrame.copy")
-        return DataFrame()
+        Supported target dtypes: any value accepted by ``dtype_from_string``
+        (e.g. ``"float64"``, ``"int64"``, ``"bool"``).
+        """
+        var target = dtype_from_string(dtype)
+        var result_cols = List[Column]()
+        for i in range(len(self._cols)):
+            result_cols.append(self._cols[i]._astype(target))
+        return DataFrame(result_cols^)
+
+    fn _deep_copy(self) -> DataFrame:
+        """Return an independent column-wise copy of this DataFrame (internal helper)."""
+        var result_cols = List[Column]()
+        for i in range(len(self._cols)):
+            result_cols.append(self._cols[i].copy())
+        return DataFrame(result_cols^)
+
+    fn copy(self, deep: Bool) raises -> DataFrame:
+        """Return an independent copy of this DataFrame.
+
+        ``deep=False`` is accepted but behaves identically to ``deep=True``
+        because ``Column.copy()`` always performs a deep copy.
+        Calling ``df.copy()`` (no args) uses the Copyable-trait copy, which
+        is also a deep copy via ``__copyinit__``.
+        """
+        return self._deep_copy()
 
     fn assign(self, cols: Dict[String, Series]) raises -> DataFrame:
-        _not_implemented("DataFrame.assign")
-        return DataFrame()
+        """Return a new DataFrame with additional or replaced columns.
 
-    fn insert(inout self, loc: Int, column: String, value: DFScalar) raises:
-        _not_implemented("DataFrame.insert")
+        Each key in *cols* is a column name; the value is the new Series.
+        Existing columns are replaced in-place; new columns are appended.
+        """
+        var df = self._deep_copy()
+        for entry in cols.items():
+            df[entry.key] = entry.value
+        return df^
 
-    fn pop(inout self, item: String) raises -> Series:
-        _not_implemented("DataFrame.pop")
-        return Series()
+    fn insert(mut self, loc: Int, column: String, value: DFScalar) raises:
+        """Insert a constant-valued column at position *loc*.
+
+        *loc* is clamped to ``[0, ncols]``.  Raises if *column* already exists.
+        """
+        for i in range(len(self._cols)):
+            if self._cols[i].name == column:
+                raise Error("DataFrame.insert: column already exists: " + column)
+        var nrows = self.shape()[0]
+        var idx = List[PythonObject]()
+        if len(self._cols) > 0:
+            idx = self._cols[0]._index.copy()
+        var new_col = Column._fill_scalar(column, value, nrows, idx)
+        var insert_at = loc
+        if insert_at < 0:
+            insert_at = 0
+        if insert_at > len(self._cols):
+            insert_at = len(self._cols)
+        var new_cols = List[Column]()
+        for i in range(insert_at):
+            new_cols.append(self._cols[i].copy())
+        new_cols.append(new_col^)
+        for i in range(insert_at, len(self._cols)):
+            new_cols.append(self._cols[i].copy())
+        self._cols = new_cols^
+
+    fn pop(mut self, item: String) raises -> Series:
+        """Remove column *item* and return it as a Series.
+
+        Raises if *item* is not a column in this DataFrame.
+        """
+        var idx = -1
+        for i in range(len(self._cols)):
+            if self._cols[i].name == item:
+                idx = i
+                break
+        if idx == -1:
+            raise Error("DataFrame.pop: column not found: " + item)
+        var result = Series(self._cols[idx].copy())
+        var new_cols = List[Column]()
+        for i in range(len(self._cols)):
+            if i != idx:
+                new_cols.append(self._cols[i].copy())
+        self._cols = new_cols^
+        return result^
 
     fn where(self, cond: Series, other: Optional[DFScalar] = None) raises -> DataFrame:
-        _not_implemented("DataFrame.where")
-        return DataFrame()
+        """Keep each element where *cond* is True; replace with null otherwise.
+
+        ``other`` (replacement value for False positions) is not yet supported;
+        pass ``other=None`` (the default).
+        """
+        if other:
+            raise Error("DataFrame.where: other= parameter is not yet implemented; pass other=None")
+        var result_cols = List[Column]()
+        for i in range(len(self._cols)):
+            result_cols.append(self._cols[i]._where(cond._col))
+        return DataFrame(result_cols^)
 
     fn mask(self, cond: Series, other: Optional[DFScalar] = None) raises -> DataFrame:
-        _not_implemented("DataFrame.mask")
-        return DataFrame()
+        """Replace each element with null where *cond* is True; keep otherwise.
+
+        ``other`` (replacement value for True positions) is not yet supported;
+        pass ``other=None`` (the default).
+        """
+        if other:
+            raise Error("DataFrame.mask: other= parameter is not yet implemented; pass other=None")
+        var result_cols = List[Column]()
+        for i in range(len(self._cols)):
+            result_cols.append(self._cols[i]._mask(cond._col))
+        return DataFrame(result_cols^)
 
     fn isin(self, values: Dict[String, List[DFScalar]]) raises -> DataFrame:
-        _not_implemented("DataFrame.isin")
-        return DataFrame()
+        """Return a boolean DataFrame: True where each element is in the corresponding list.
+
+        *values* maps column names to lists of scalars.  Columns not present in
+        *values* produce an all-False Bool column.  Scalar types are coerced to
+        match the column arm (e.g. Int64 scalars against a Float64 column).
+        """
+        var nrows = self.shape()[0]
+        var result_cols = List[Column]()
+        for i in range(len(self._cols)):
+            var col_name = self._cols[i].name
+            if col_name not in values:
+                # All-False Bool column for columns not in the dict.
+                var false_data = List[Bool]()
+                for j in range(nrows):
+                    false_data.append(False)
+                result_cols.append(Column(col_name, ColumnData(false_data^), _bool_))
+            else:
+                # Dispatch based on column arm type; coerce scalar types as needed.
+                var result_col: Column
+                if self._cols[i]._data.isa[List[Int64]]():
+                    var int_vals = List[Int64]()
+                    var n_vals = len(values[col_name])
+                    for k in range(n_vals):
+                        if values[col_name][k].isa[Int64]():
+                            int_vals.append(values[col_name][k][Int64])
+                        elif values[col_name][k].isa[Float64]():
+                            int_vals.append(Int64(Int(values[col_name][k][Float64])))
+                        elif values[col_name][k].isa[Bool]():
+                            int_vals.append(Int64(1) if values[col_name][k][Bool] else Int64(0))
+                    result_col = self._cols[i]._isin_int(int_vals)
+                elif self._cols[i]._data.isa[List[Float64]]():
+                    var float_vals = List[Float64]()
+                    var n_vals = len(values[col_name])
+                    for k in range(n_vals):
+                        if values[col_name][k].isa[Float64]():
+                            float_vals.append(values[col_name][k][Float64])
+                        elif values[col_name][k].isa[Int64]():
+                            float_vals.append(Float64(values[col_name][k][Int64]))
+                        elif values[col_name][k].isa[Bool]():
+                            float_vals.append(Float64(1.0) if values[col_name][k][Bool] else Float64(0.0))
+                    result_col = self._cols[i]._isin_float(float_vals)
+                elif self._cols[i]._data.isa[List[Bool]]():
+                    var bool_vals = List[Bool]()
+                    var n_vals = len(values[col_name])
+                    for k in range(n_vals):
+                        if values[col_name][k].isa[Bool]():
+                            bool_vals.append(values[col_name][k][Bool])
+                    result_col = self._cols[i]._isin_bool(bool_vals)
+                elif self._cols[i]._data.isa[List[String]]():
+                    var str_vals = List[String]()
+                    var n_vals = len(values[col_name])
+                    for k in range(n_vals):
+                        if values[col_name][k].isa[String]():
+                            str_vals.append(values[col_name][k][String])
+                    result_col = self._cols[i]._isin_str(str_vals)
+                else:
+                    raise Error("DataFrame.isin: unsupported column dtype for column: " + col_name)
+                result_col.name = col_name
+                result_cols.append(result_col^)
+        return DataFrame(result_cols^)
 
     fn combine_first(self, other: DataFrame) raises -> DataFrame:
-        _not_implemented("DataFrame.combine_first")
-        return DataFrame()
+        """Fill null positions in self with corresponding values from other.
 
-    fn update(inout self, other: DataFrame) raises:
-        _not_implemented("DataFrame.update")
+        For each column present in both DataFrames: keep self's value where
+        non-null; take other's value otherwise.  Columns present only in
+        ``other`` are appended as-is.  Same-named columns must have the same
+        dtype; raises on dtype mismatch.
+        """
+        var result_cols = List[Column]()
+        # Phase 1: iterate self columns, fill from other where available.
+        for i in range(len(self._cols)):
+            var found = False
+            for j in range(len(other._cols)):
+                if other._cols[j].name == self._cols[i].name:
+                    result_cols.append(self._cols[i]._combine_first_col(other._cols[j]))
+                    found = True
+                    break
+            if not found:
+                result_cols.append(self._cols[i].copy())
+        # Phase 2: append columns that exist only in other.
+        for j in range(len(other._cols)):
+            var in_self = False
+            for i in range(len(self._cols)):
+                if self._cols[i].name == other._cols[j].name:
+                    in_self = True
+                    break
+            if not in_self:
+                result_cols.append(other._cols[j].copy())
+        return DataFrame(result_cols^)
+
+    fn update(mut self, other: DataFrame) raises:
+        """Update in-place with non-null values from other.
+
+        For each column present in both DataFrames: overwrite self's null
+        positions with other's non-null values (other wins where non-null).
+        Columns in other that are absent from self are ignored.
+        """
+        for j in range(len(other._cols)):
+            for i in range(len(self._cols)):
+                if self._cols[i].name == other._cols[j].name:
+                    self._cols[i] = other._cols[j]._combine_first_col(self._cols[i])
+                    break
 
     # ------------------------------------------------------------------
     # Combining

--- a/tests/test_reshaping.mojo
+++ b/tests/test_reshaping.mojo
@@ -124,15 +124,13 @@ fn test_transpose_stub() raises:
     assert_true(raised)
 
 
-fn test_drop_duplicates_stub() raises:
+fn test_drop_duplicates_removes_duplicates() raises:
     var pd = Python.import_module("pandas")
-    var df = DataFrame(pd.DataFrame(Python.evaluate("{'a': [1, 1, 2]}")))
-    var raised = False
-    try:
-        _ = df.drop_duplicates()
-    except:
-        raised = True
-    assert_true(raised)
+    var df = DataFrame(pd.DataFrame(Python.evaluate("{'a': [1, 1, 2], 'b': [10, 10, 20]}")))
+    var r = df.drop_duplicates()
+    assert_true(r.shape()[0] == 2)
+    assert_true(r["a"].iloc(0)[Int64] == 1)
+    assert_true(r["a"].iloc(1)[Int64] == 2)
 
 
 fn test_series_sort_values() raises:

--- a/tests/test_structural.mojo
+++ b/tests/test_structural.mojo
@@ -1,0 +1,480 @@
+"""Tests for DataFrame structural operations (issue #9):
+copy, round, astype, clip, insert, pop, assign, drop, where, mask,
+duplicated, drop_duplicates, isin, combine_first, update.
+"""
+from std.python import Python
+from std.collections import Dict, Optional
+from testing import assert_equal, assert_true, assert_false, TestSuite
+from bison import DataFrame, Series, ColumnData, DFScalar
+
+
+# ------------------------------------------------------------------
+# copy
+# ------------------------------------------------------------------
+
+fn test_copy_returns_equal_shape() raises:
+    var pd = Python.import_module("pandas")
+    var df = DataFrame(pd.DataFrame(Python.evaluate("{'a': [1, 2, 3], 'b': [4, 5, 6]}")))
+    var c = df.copy(True)
+    assert_equal(c.shape()[0], 3)
+    assert_equal(c.shape()[1], 2)
+
+
+fn test_copy_values_match() raises:
+    var pd = Python.import_module("pandas")
+    var df = DataFrame(pd.DataFrame(Python.evaluate("{'a': [10, 20]}")))
+    var c = df.copy(True)
+    assert_true(c["a"].iloc(0)[Int64] == 10)
+    assert_true(c["a"].iloc(1)[Int64] == 20)
+
+
+fn test_copy_is_independent() raises:
+    # Modifying the copy must not change the original.
+    var pd = Python.import_module("pandas")
+    var df = DataFrame(pd.DataFrame(Python.evaluate("{'a': [1, 2]}")))
+    var c = df.copy(True)
+    var new_s = Series(pd.Series(Python.evaluate("[99, 99]"), dtype="int64"))
+    c["a"] = new_s^
+    # original still has its own values
+    assert_true(df["a"].iloc(0)[Int64] == 1)
+
+
+# ------------------------------------------------------------------
+# round
+# ------------------------------------------------------------------
+
+fn test_round_float() raises:
+    var pd = Python.import_module("pandas")
+    var df = DataFrame(pd.DataFrame(Python.evaluate("{'a': [1.234, 5.678]}")))
+    var r = df.round(2)
+    assert_true(r["a"].iloc(0)[Float64] == 1.23)
+    assert_true(r["a"].iloc(1)[Float64] == 5.68)
+
+
+fn test_round_int_identity() raises:
+    var pd = Python.import_module("pandas")
+    var df = DataFrame(pd.DataFrame(Python.evaluate("{'a': [1, 2, 3]}")))
+    var r = df.round(0)
+    assert_true(r["a"].iloc(0)[Int64] == 1)
+    assert_true(r["a"].iloc(2)[Int64] == 3)
+
+
+# ------------------------------------------------------------------
+# astype
+# ------------------------------------------------------------------
+
+fn test_astype_int_to_float() raises:
+    var pd = Python.import_module("pandas")
+    var df = DataFrame(pd.DataFrame(Python.evaluate("{'a': [1, 2, 3]}")))
+    var r = df.astype("float64")
+    assert_true(r["a"].iloc(0)[Float64] == 1.0)
+    assert_true(r["a"].iloc(2)[Float64] == 3.0)
+
+
+fn test_astype_float_to_int() raises:
+    var pd = Python.import_module("pandas")
+    var df = DataFrame(pd.DataFrame(Python.evaluate("{'a': [1.9, 2.1]}")))
+    var r = df.astype("int64")
+    assert_true(r["a"].iloc(0)[Int64] == 1)
+    assert_true(r["a"].iloc(1)[Int64] == 2)
+
+
+# ------------------------------------------------------------------
+# clip
+# ------------------------------------------------------------------
+
+fn test_clip_both_bounds() raises:
+    var pd = Python.import_module("pandas")
+    var df = DataFrame(pd.DataFrame(Python.evaluate("{'a': [1.0, 5.0, 10.0]}")))
+    var r = df.clip(lower=2.0, upper=8.0)
+    assert_true(r["a"].iloc(0)[Float64] == 2.0)
+    assert_true(r["a"].iloc(1)[Float64] == 5.0)
+    assert_true(r["a"].iloc(2)[Float64] == 8.0)
+
+
+fn test_clip_lower_only() raises:
+    var pd = Python.import_module("pandas")
+    var df = DataFrame(pd.DataFrame(Python.evaluate("{'a': [1.0, 5.0, 10.0]}")))
+    var r = df.clip(lower=3.0)
+    assert_true(r["a"].iloc(0)[Float64] == 3.0)
+    assert_true(r["a"].iloc(1)[Float64] == 5.0)
+    assert_true(r["a"].iloc(2)[Float64] == 10.0)
+
+
+fn test_clip_upper_only() raises:
+    var pd = Python.import_module("pandas")
+    var df = DataFrame(pd.DataFrame(Python.evaluate("{'a': [1.0, 5.0, 10.0]}")))
+    var r = df.clip(upper=7.0)
+    assert_true(r["a"].iloc(0)[Float64] == 1.0)
+    assert_true(r["a"].iloc(1)[Float64] == 5.0)
+    assert_true(r["a"].iloc(2)[Float64] == 7.0)
+
+
+fn test_clip_no_bounds_returns_copy() raises:
+    var pd = Python.import_module("pandas")
+    var df = DataFrame(pd.DataFrame(Python.evaluate("{'a': [1.0, 2.0]}")))
+    var r = df.clip()
+    assert_true(r["a"].iloc(0)[Float64] == 1.0)
+    assert_true(r["a"].iloc(1)[Float64] == 2.0)
+
+
+# ------------------------------------------------------------------
+# insert
+# ------------------------------------------------------------------
+
+fn test_insert_at_front() raises:
+    var pd = Python.import_module("pandas")
+    var df = DataFrame(pd.DataFrame(Python.evaluate("{'b': [1, 2]}")))
+    var v = DFScalar(Int64(99))
+    df.insert(0, "a", v^)
+    assert_equal(df.shape()[1], 2)
+    var cols = df.columns()
+    assert_equal(cols[0], "a")
+    assert_equal(cols[1], "b")
+    assert_true(df["a"].iloc(0)[Int64] == 99)
+    assert_true(df["a"].iloc(1)[Int64] == 99)
+
+
+fn test_insert_at_end() raises:
+    var pd = Python.import_module("pandas")
+    var df = DataFrame(pd.DataFrame(Python.evaluate("{'a': [1, 2]}")))
+    var v = DFScalar(Float64(3.0))
+    df.insert(10, "z", v^)
+    assert_equal(df.shape()[1], 2)
+    var cols = df.columns()
+    assert_equal(cols[1], "z")
+
+
+fn test_insert_duplicate_raises() raises:
+    var pd = Python.import_module("pandas")
+    var df = DataFrame(pd.DataFrame(Python.evaluate("{'a': [1]}")))
+    var v = DFScalar(Int64(0))
+    var raised = False
+    try:
+        df.insert(0, "a", v^)
+    except:
+        raised = True
+    assert_true(raised)
+
+
+# ------------------------------------------------------------------
+# pop
+# ------------------------------------------------------------------
+
+fn test_pop_returns_series() raises:
+    var pd = Python.import_module("pandas")
+    var df = DataFrame(pd.DataFrame(Python.evaluate("{'a': [1, 2], 'b': [3, 4]}")))
+    var s = df.pop("a")
+    assert_true(s.iloc(0)[Int64] == 1)
+    assert_true(s.iloc(1)[Int64] == 2)
+
+
+fn test_pop_removes_column() raises:
+    var pd = Python.import_module("pandas")
+    var df = DataFrame(pd.DataFrame(Python.evaluate("{'a': [1], 'b': [2]}")))
+    _ = df.pop("a")
+    assert_equal(df.shape()[1], 1)
+    assert_false(df.__contains__("a"))
+    assert_true(df.__contains__("b"))
+
+
+fn test_pop_missing_raises() raises:
+    var pd = Python.import_module("pandas")
+    var df = DataFrame(pd.DataFrame(Python.evaluate("{'a': [1]}")))
+    var raised = False
+    try:
+        _ = df.pop("x")
+    except:
+        raised = True
+    assert_true(raised)
+
+
+# ------------------------------------------------------------------
+# assign
+# ------------------------------------------------------------------
+
+fn test_assign_adds_column() raises:
+    var pd = Python.import_module("pandas")
+    var df = DataFrame(pd.DataFrame(Python.evaluate("{'a': [1, 2]}")))
+    var new_s = Series(pd.Series(Python.evaluate("[10, 20]"), dtype="int64"))
+    var cols = Dict[String, Series]()
+    cols["b"] = new_s^
+    var r = df.assign(cols^)
+    assert_equal(r.shape()[1], 2)
+    assert_true(r["b"].iloc(0)[Int64] == 10)
+    assert_true(r["b"].iloc(1)[Int64] == 20)
+
+
+fn test_assign_replaces_column() raises:
+    var pd = Python.import_module("pandas")
+    var df = DataFrame(pd.DataFrame(Python.evaluate("{'a': [1, 2]}")))
+    var new_s = Series(pd.Series(Python.evaluate("[99, 99]"), dtype="int64"))
+    var cols = Dict[String, Series]()
+    cols["a"] = new_s^
+    var r = df.assign(cols^)
+    assert_equal(r.shape()[1], 1)
+    assert_true(r["a"].iloc(0)[Int64] == 99)
+
+
+fn test_assign_does_not_mutate_original() raises:
+    var pd = Python.import_module("pandas")
+    var df = DataFrame(pd.DataFrame(Python.evaluate("{'a': [1, 2]}")))
+    var new_s = Series(pd.Series(Python.evaluate("[10, 20]"), dtype="int64"))
+    var cols = Dict[String, Series]()
+    cols["b"] = new_s^
+    _ = df.assign(cols^)
+    assert_equal(df.shape()[1], 1)
+
+
+# ------------------------------------------------------------------
+# drop (columns)
+# ------------------------------------------------------------------
+
+fn test_drop_column() raises:
+    var pd = Python.import_module("pandas")
+    var df = DataFrame(pd.DataFrame(Python.evaluate("{'a': [1, 2], 'b': [3, 4]}")))
+    var labels = List[String]()
+    labels.append("a")
+    var r = df.drop(columns=labels^)
+    assert_equal(r.shape()[1], 1)
+    assert_false(r.__contains__("a"))
+    assert_true(r.__contains__("b"))
+
+
+fn test_drop_column_axis1() raises:
+    var pd = Python.import_module("pandas")
+    var df = DataFrame(pd.DataFrame(Python.evaluate("{'a': [1], 'b': [2], 'c': [3]}")))
+    var labels = List[String]()
+    labels.append("b")
+    var r = df.drop(labels=labels^, axis=1)
+    assert_equal(r.shape()[1], 2)
+    assert_false(r.__contains__("b"))
+
+
+fn test_drop_missing_column_raises() raises:
+    var pd = Python.import_module("pandas")
+    var df = DataFrame(pd.DataFrame(Python.evaluate("{'a': [1]}")))
+    var labels = List[String]()
+    labels.append("z")
+    var raised = False
+    try:
+        _ = df.drop(columns=labels^)
+    except:
+        raised = True
+    assert_true(raised)
+
+
+# ------------------------------------------------------------------
+# drop (rows, axis=0)
+# ------------------------------------------------------------------
+
+fn test_drop_rows_by_integer_label() raises:
+    var pd = Python.import_module("pandas")
+    var df = DataFrame(pd.DataFrame(Python.evaluate("{'a': [10, 20, 30]}")))
+    var labels = List[String]()
+    labels.append("1")
+    var r = df.drop(labels=labels^, axis=0)
+    assert_equal(r.shape()[0], 2)
+    assert_true(r["a"].iloc(0)[Int64] == 10)
+    assert_true(r["a"].iloc(1)[Int64] == 30)
+
+
+# ------------------------------------------------------------------
+# where / mask
+# ------------------------------------------------------------------
+
+fn test_where_keeps_true_positions() raises:
+    var pd = Python.import_module("pandas")
+    var df = DataFrame(pd.DataFrame(Python.evaluate("{'a': [1.0, 2.0, 3.0]}")))
+    var cond = Series(pd.Series(Python.evaluate("[True, False, True]")))
+    var r = df.where(cond)
+    assert_true(r["a"].iloc(0)[Float64] == 1.0)
+    assert_true(r["a"].isna().iloc(1)[Bool])
+    assert_true(r["a"].iloc(2)[Float64] == 3.0)
+
+
+fn test_mask_nulls_true_positions() raises:
+    var pd = Python.import_module("pandas")
+    var df = DataFrame(pd.DataFrame(Python.evaluate("{'a': [1.0, 2.0, 3.0]}")))
+    var cond = Series(pd.Series(Python.evaluate("[True, False, True]")))
+    var r = df.mask(cond)
+    assert_true(r["a"].isna().iloc(0)[Bool])
+    assert_true(r["a"].iloc(1)[Float64] == 2.0)
+    assert_true(r["a"].isna().iloc(2)[Bool])
+
+
+fn test_where_other_raises() raises:
+    var pd = Python.import_module("pandas")
+    var df = DataFrame(pd.DataFrame(Python.evaluate("{'a': [1.0, 2.0]}")))
+    var cond = Series(pd.Series(Python.evaluate("[True, False]")))
+    var other = Optional[DFScalar](DFScalar(Float64(0.0)))
+    var raised = False
+    try:
+        _ = df.where(cond, other)
+    except:
+        raised = True
+    assert_true(raised)
+
+
+# ------------------------------------------------------------------
+# duplicated
+# ------------------------------------------------------------------
+
+fn test_duplicated_keep_first() raises:
+    var pd = Python.import_module("pandas")
+    var df = DataFrame(pd.DataFrame(Python.evaluate("{'a': [1, 1, 2]}")))
+    var d = df.duplicated()
+    assert_false(d.iloc(0)[Bool])
+    assert_true(d.iloc(1)[Bool])
+    assert_false(d.iloc(2)[Bool])
+
+
+fn test_duplicated_keep_last() raises:
+    var pd = Python.import_module("pandas")
+    var df = DataFrame(pd.DataFrame(Python.evaluate("{'a': [1, 1, 2]}")))
+    var d = df.duplicated(keep="last")
+    assert_true(d.iloc(0)[Bool])
+    assert_false(d.iloc(1)[Bool])
+    assert_false(d.iloc(2)[Bool])
+
+
+fn test_duplicated_keep_false() raises:
+    var pd = Python.import_module("pandas")
+    var df = DataFrame(pd.DataFrame(Python.evaluate("{'a': [1, 1, 2]}")))
+    var d = df.duplicated(keep="False")
+    assert_true(d.iloc(0)[Bool])
+    assert_true(d.iloc(1)[Bool])
+    assert_false(d.iloc(2)[Bool])
+
+
+fn test_duplicated_subset() raises:
+    # Rows differ in 'b' but not in 'a'; subset=['a'] treats them as duplicates.
+    var pd = Python.import_module("pandas")
+    var df = DataFrame(pd.DataFrame(Python.evaluate("{'a': [1, 1], 'b': [10, 20]}")))
+    var sub = List[String]()
+    sub.append("a")
+    var d = df.duplicated(subset=sub^)
+    assert_false(d.iloc(0)[Bool])
+    assert_true(d.iloc(1)[Bool])
+
+
+# ------------------------------------------------------------------
+# drop_duplicates
+# ------------------------------------------------------------------
+
+fn test_drop_duplicates_keep_first() raises:
+    var pd = Python.import_module("pandas")
+    var df = DataFrame(pd.DataFrame(Python.evaluate("{'a': [1, 1, 2]}")))
+    var r = df.drop_duplicates()
+    assert_equal(r.shape()[0], 2)
+    assert_true(r["a"].iloc(0)[Int64] == 1)
+    assert_true(r["a"].iloc(1)[Int64] == 2)
+
+
+fn test_drop_duplicates_keep_last() raises:
+    var pd = Python.import_module("pandas")
+    var df = DataFrame(pd.DataFrame(Python.evaluate("{'a': [1, 1, 2]}")))
+    var r = df.drop_duplicates(keep="last")
+    assert_equal(r.shape()[0], 2)
+
+
+fn test_drop_duplicates_no_duplicates() raises:
+    var pd = Python.import_module("pandas")
+    var df = DataFrame(pd.DataFrame(Python.evaluate("{'a': [1, 2, 3]}")))
+    var r = df.drop_duplicates()
+    assert_equal(r.shape()[0], 3)
+
+
+# ------------------------------------------------------------------
+# isin
+# ------------------------------------------------------------------
+
+fn test_isin_int_column() raises:
+    var pd = Python.import_module("pandas")
+    var df = DataFrame(pd.DataFrame(Python.evaluate("{'a': [1, 2, 3]}")))
+    var vals = List[DFScalar]()
+    vals.append(DFScalar(Int64(1)))
+    vals.append(DFScalar(Int64(3)))
+    var values = Dict[String, List[DFScalar]]()
+    values["a"] = vals^
+    var r = df.isin(values^)
+    assert_true(r["a"].iloc(0)[Bool])
+    assert_false(r["a"].iloc(1)[Bool])
+    assert_true(r["a"].iloc(2)[Bool])
+
+
+fn test_isin_column_not_in_dict_is_all_false() raises:
+    var pd = Python.import_module("pandas")
+    var df = DataFrame(pd.DataFrame(Python.evaluate("{'a': [1, 2], 'b': [3, 4]}")))
+    var vals = List[DFScalar]()
+    vals.append(DFScalar(Int64(1)))
+    var values = Dict[String, List[DFScalar]]()
+    values["a"] = vals^
+    var r = df.isin(values^)
+    # 'b' is not in the dict, so all False
+    assert_false(r["b"].iloc(0)[Bool])
+    assert_false(r["b"].iloc(1)[Bool])
+
+
+# ------------------------------------------------------------------
+# combine_first
+# ------------------------------------------------------------------
+
+fn test_combine_first_fills_nulls() raises:
+    # self has nulls that other fills.
+    var pd = Python.import_module("pandas")
+    var df1 = DataFrame(pd.DataFrame(Python.evaluate("{'a': [1.0, None, 3.0]}")))
+    var df2 = DataFrame(pd.DataFrame(Python.evaluate("{'a': [10.0, 20.0, 30.0]}")))
+    var r = df1.combine_first(df2)
+    assert_true(r["a"].iloc(0)[Float64] == 1.0)
+    assert_true(r["a"].iloc(1)[Float64] == 20.0)
+    assert_true(r["a"].iloc(2)[Float64] == 3.0)
+
+
+fn test_combine_first_appends_other_only_columns() raises:
+    var pd = Python.import_module("pandas")
+    var df1 = DataFrame(pd.DataFrame(Python.evaluate("{'a': [1, 2]}")))
+    var df2 = DataFrame(pd.DataFrame(Python.evaluate("{'b': [10, 20]}")))
+    var r = df1.combine_first(df2)
+    assert_equal(r.shape()[1], 2)
+    assert_true(r.__contains__("a"))
+    assert_true(r.__contains__("b"))
+
+
+fn test_combine_first_self_wins_non_null() raises:
+    # Where self is non-null, self's value is kept.
+    var pd = Python.import_module("pandas")
+    var df1 = DataFrame(pd.DataFrame(Python.evaluate("{'a': [1.0, 2.0]}")))
+    var df2 = DataFrame(pd.DataFrame(Python.evaluate("{'a': [99.0, 99.0]}")))
+    var r = df1.combine_first(df2)
+    assert_true(r["a"].iloc(0)[Float64] == 1.0)
+    assert_true(r["a"].iloc(1)[Float64] == 2.0)
+
+
+# ------------------------------------------------------------------
+# update
+# ------------------------------------------------------------------
+
+fn test_update_other_wins_non_null() raises:
+    # other has non-null value; self gets overwritten.
+    var pd = Python.import_module("pandas")
+    var df1 = DataFrame(pd.DataFrame(Python.evaluate("{'a': [1.0, None]}")))
+    var df2 = DataFrame(pd.DataFrame(Python.evaluate("{'a': [99.0, 20.0]}")))
+    df1.update(df2)
+    # Row 0: df2 is non-null (99) → df1 gets 99.
+    assert_true(df1["a"].iloc(0)[Float64] == 99.0)
+    # Row 1: df1 was null, df2 is 20 → df1 gets 20.
+    assert_true(df1["a"].iloc(1)[Float64] == 20.0)
+
+
+fn test_update_ignores_other_only_columns() raises:
+    var pd = Python.import_module("pandas")
+    var df1 = DataFrame(pd.DataFrame(Python.evaluate("{'a': [1]}")))
+    var df2 = DataFrame(pd.DataFrame(Python.evaluate("{'b': [99]}")))
+    df1.update(df2)
+    assert_equal(df1.shape()[1], 1)
+    assert_false(df1.__contains__("b"))
+
+
+fn main() raises:
+    TestSuite.discover_tests[__functions_in_module()]().run()


### PR DESCRIPTION
## Summary

- Replaces all 15 stubs in the DataFrame structural group with native Mojo implementations: `drop`, `drop_duplicates`, `duplicated`, `assign`, `insert`, `pop`, `copy`, `astype`, `round`, `clip`, `where`, `mask`, `isin`, `combine_first`, `update`
- Adds `Column._fill_scalar`, `_CombineFirstVisitor`, and `Column._combine_first_col` helpers in `column.mojo`
- Adds 41-test suite in `tests/test_structural.mojo`
- Fixes stale stub test in `tests/test_reshaping.mojo` (drop_duplicates was expecting a raise)

Closes #9

## Test plan

- [x] `pixi run test` — 13/13 files pass, 0 failures
- [x] `pixi run update-compat` — compat table updated (DataFrame stubs: 69 → 54)