### PR TITLE
Implement DataFrame index operations (#8)

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ In CI it runs after the test suite and the result is committed back to the branc
 <!-- COMPAT_TABLE_START -->
 | Category | Stubs | Implemented |
 |----------|-------|-------------|
-| DataFrame | 53 | 65 |
+| DataFrame | 48 | 70 |
 | Series | 7 | 80 |
 | GroupBy (DataFrame) | 16 | 1 |
 | GroupBy (Series) | 15 | 1 |
@@ -91,7 +91,7 @@ In CI it runs after the test suite and the result is committed back to the branc
 | Index | 0 | 14 |
 | IO | 10 | 2 |
 | Reshape | 0 | 1 |
-| **Total** | **118** | **186** |
+| **Total** | **113** | **191** |
 <!-- COMPAT_TABLE_END -->
 
 ## Known limitations

--- a/bison/column.mojo
+++ b/bison/column.mojo
@@ -1381,6 +1381,153 @@ struct _BinOpInputs(Movable):
         self.has_b_mask = has_b_mask
 
 
+struct _ReindexRowsVisitor(ColumnDataVisitorRaises, Copyable, Movable):
+    """Select/insert rows by a pre-built index list.
+
+    ``indices[i] >= 0``  → take that row from the source data.
+    ``indices[i] == -1`` → insert a null row, or a fill row if *fill_value* is set.
+
+    The parallel ``src_null_mask`` carries the source column's null mask so that
+    nulls from existing rows are propagated correctly.
+    """
+
+    var indices: List[Int]
+    var fill_value: Optional[DFScalar]
+    var src_null_mask: List[Bool]
+    var col_data: ColumnData
+    var result_mask: List[Bool]
+    var has_any_null: Bool
+
+    fn __init__(out self, indices: List[Int], fill_value: Optional[DFScalar],
+                src_null_mask: List[Bool]):
+        self.indices = indices.copy()
+        self.fill_value = fill_value
+        self.src_null_mask = src_null_mask.copy()
+        self.col_data = ColumnData(List[PythonObject]())
+        self.result_mask = List[Bool]()
+        self.has_any_null = False
+
+    fn on_int64(mut self, data: List[Int64]) raises:
+        var fill: Int64 = 0
+        var is_null_fill: Bool = True
+        if self.fill_value:
+            var fv = self.fill_value.value()
+            if fv.isa[Int64]():
+                fill = fv[Int64]; is_null_fill = False
+            elif fv.isa[Float64]():
+                fill = Int64(Int(fv[Float64])); is_null_fill = False
+            elif fv.isa[Bool]():
+                fill = Int64(1) if fv[Bool] else Int64(0); is_null_fill = False
+        var has_src_mask = len(self.src_null_mask) > 0
+        var result = List[Int64]()
+        for i in range(len(self.indices)):
+            var idx = self.indices[i]
+            if idx >= 0:
+                result.append(data[idx])
+                var is_null = has_src_mask and self.src_null_mask[idx]
+                self.result_mask.append(is_null)
+                if is_null:
+                    self.has_any_null = True
+            else:
+                result.append(fill)
+                self.result_mask.append(is_null_fill)
+                if is_null_fill:
+                    self.has_any_null = True
+        self.col_data = ColumnData(result^)
+
+    fn on_float64(mut self, data: List[Float64]) raises:
+        var fill: Float64 = Float64(0) / Float64(0)  # NaN
+        var is_null_fill: Bool = True
+        if self.fill_value:
+            var fv = self.fill_value.value()
+            if fv.isa[Float64]():
+                fill = fv[Float64]; is_null_fill = False
+            elif fv.isa[Int64]():
+                fill = Float64(fv[Int64]); is_null_fill = False
+            elif fv.isa[Bool]():
+                fill = 1.0 if fv[Bool] else 0.0; is_null_fill = False
+        var has_src_mask = len(self.src_null_mask) > 0
+        var result = List[Float64]()
+        for i in range(len(self.indices)):
+            var idx = self.indices[i]
+            if idx >= 0:
+                result.append(data[idx])
+                var is_null = has_src_mask and self.src_null_mask[idx]
+                self.result_mask.append(is_null)
+                if is_null:
+                    self.has_any_null = True
+            else:
+                result.append(fill)
+                self.result_mask.append(is_null_fill)
+                if is_null_fill:
+                    self.has_any_null = True
+        self.col_data = ColumnData(result^)
+
+    fn on_bool(mut self, data: List[Bool]) raises:
+        var fill: Bool = False
+        var is_null_fill: Bool = True
+        if self.fill_value:
+            var fv = self.fill_value.value()
+            if fv.isa[Bool]():
+                fill = fv[Bool]; is_null_fill = False
+            elif fv.isa[Int64]():
+                fill = fv[Int64] != 0; is_null_fill = False
+        var has_src_mask = len(self.src_null_mask) > 0
+        var result = List[Bool]()
+        for i in range(len(self.indices)):
+            var idx = self.indices[i]
+            if idx >= 0:
+                result.append(data[idx])
+                var is_null = has_src_mask and self.src_null_mask[idx]
+                self.result_mask.append(is_null)
+                if is_null:
+                    self.has_any_null = True
+            else:
+                result.append(fill)
+                self.result_mask.append(is_null_fill)
+                if is_null_fill:
+                    self.has_any_null = True
+        self.col_data = ColumnData(result^)
+
+    fn on_str(mut self, data: List[String]) raises:
+        var fill: String = ""
+        var is_null_fill: Bool = True
+        if self.fill_value:
+            var fv = self.fill_value.value()
+            if fv.isa[String]():
+                fill = fv[String]; is_null_fill = False
+        var has_src_mask = len(self.src_null_mask) > 0
+        var result = List[String]()
+        for i in range(len(self.indices)):
+            var idx = self.indices[i]
+            if idx >= 0:
+                result.append(data[idx])
+                var is_null = has_src_mask and self.src_null_mask[idx]
+                self.result_mask.append(is_null)
+                if is_null:
+                    self.has_any_null = True
+            else:
+                result.append(fill)
+                self.result_mask.append(is_null_fill)
+                if is_null_fill:
+                    self.has_any_null = True
+        self.col_data = ColumnData(result^)
+
+    fn on_obj(mut self, data: List[PythonObject]) raises:
+        var py_none = Python.evaluate("None")
+        var result = List[PythonObject]()
+        for i in range(len(self.indices)):
+            var idx = self.indices[i]
+            if idx >= 0:
+                result.append(data[idx])
+                self.result_mask.append(False)
+            else:
+                result.append(py_none)
+                self.result_mask.append(True)
+                self.has_any_null = True
+        self.col_data = ColumnData(result^)
+
+
 struct Column(Copyable, Movable, Sized):
     """A single typed array representing one column of a DataFrame or a Series.
 
@@ -2255,6 +2402,37 @@ struct Column(Copyable, Movable, Sized):
         var c = self.copy()
         c._index = List[PythonObject]()
         return c^
+
+    fn _to_pyobj_index(self) raises -> List[PythonObject]:
+        """Extract column values as a List[PythonObject] for use as a row index.
+
+        Converts each typed value to its Python equivalent using the
+        ``_ToPandasVisitor`` pattern so that the result can be stored in
+        ``Column._index`` of other columns.
+        """
+        var py_list = Python.evaluate("[]")
+        var py_none = Python.evaluate("None")
+        var empty_mask = List[Bool]()
+        var visitor = _ToPandasVisitor(py_list, py_none, empty_mask)
+        visit_col_data_raises(visitor, self._data)
+        var n = Int(py_list.__len__())
+        var result = List[PythonObject]()
+        for i in range(n):
+            result.append(py_list[i])
+        return result^
+
+    fn _reindex_rows(self, indices: List[Int],
+                     fill_value: Optional[DFScalar]) raises -> Column:
+        """Return a new Column with rows selected or inserted according to *indices*.
+
+        ``indices[i] >= 0``  → take that row from self.
+        ``indices[i] == -1`` → insert a null row, or a fill row when *fill_value*
+                                is provided.
+        Existing null mask entries are propagated for taken rows.
+        """
+        var visitor = _ReindexRowsVisitor(indices, fill_value, self._null_mask)
+        visit_col_data_raises(visitor, self._data)
+        return self._build_result_col(visitor.col_data.copy(), visitor.result_mask.copy(), visitor.has_any_null)
 
     # ------------------------------------------------------------------
     # Cumulative operations

--- a/bison/dataframe.mojo
+++ b/bison/dataframe.mojo
@@ -2,7 +2,7 @@ from std.python import Python, PythonObject
 from std.collections import Optional, Dict
 from ._errors import _not_implemented
 from .column import Column, ColumnData, DFScalar
-from .dtypes import BisonDtype, dtype_from_string, bool_ as _bool_, float64 as _float64
+from .dtypes import BisonDtype, dtype_from_string, bool_ as _bool_, float64 as _float64, object_ as _object_
 from .series import Series
 from .groupby import DataFrameGroupBy
 
@@ -858,24 +858,187 @@ struct DataFrame(Copyable, Movable):
         return DataFrame(new_cols^)
 
     fn reset_index(self, drop: Bool = False) raises -> DataFrame:
-        _not_implemented("DataFrame.reset_index")
-        return DataFrame()
+        """Replace the row index with a default RangeIndex.
+
+        When ``drop=True`` the existing index labels are discarded.
+        When ``drop=False`` (default) the existing index is promoted to a new
+        column named ``"index"`` prepended to the result, and the row index is
+        then cleared to a default RangeIndex.  On a DataFrame that already has
+        a default RangeIndex, both modes simply return an identical copy.
+        """
+        var ncols = len(self._cols)
+        if ncols == 0:
+            return DataFrame()
+        var has_index = len(self._cols[0]._index) > 0
+        var new_cols = List[Column]()
+        if not drop and has_index:
+            # Promote the index to a PythonObject column called "index".
+            var idx_data = List[PythonObject]()
+            for i in range(len(self._cols[0]._index)):
+                idx_data.append(self._cols[0]._index[i])
+            var empty_idx = List[PythonObject]()
+            new_cols.append(Column("index", ColumnData(idx_data^), _object_, empty_idx^))
+        for i in range(ncols):
+            var c = self._cols[i].copy()
+            c._index = List[PythonObject]()
+            new_cols.append(c^)
+        return DataFrame(new_cols^)
 
     fn set_index(self, keys: List[String], drop: Bool = True) raises -> DataFrame:
-        _not_implemented("DataFrame.set_index")
-        return DataFrame()
+        """Promote one column to the row index.
+
+        ``keys`` must contain exactly one column name; multi-key (MultiIndex)
+        is not yet supported and raises.  When ``drop=True`` (default) the key
+        column is removed from the result columns.
+        """
+        if len(keys) == 0:
+            raise Error("DataFrame.set_index: keys must not be empty")
+        if len(keys) > 1:
+            raise Error(
+                "DataFrame.set_index: MultiIndex not yet supported; "
+                + "pass a single key"
+            )
+        var key = keys[0]
+        # Find the key column.
+        var key_col_idx: Int = -1
+        for i in range(len(self._cols)):
+            if self._cols[i].name == key:
+                key_col_idx = i
+                break
+        if key_col_idx == -1:
+            raise Error("DataFrame.set_index: column not found: " + key)
+        # Extract the key column's values as the new index.
+        var new_idx = self._cols[key_col_idx]._to_pyobj_index()
+        # Build result columns (skip key column when drop=True).
+        var new_cols = List[Column]()
+        for i in range(len(self._cols)):
+            if drop and i == key_col_idx:
+                continue
+            var c = self._cols[i].copy()
+            c._index = new_idx.copy()
+            new_cols.append(c^)
+        return DataFrame(new_cols^)
 
     fn rename(self, columns: Optional[Dict[String, String]] = None, index: Optional[Dict[String, String]] = None) raises -> DataFrame:
-        _not_implemented("DataFrame.rename")
-        return DataFrame()
+        """Rename column labels and/or row index labels.
+
+        ``columns`` maps old column names to new ones; missing keys are left
+        unchanged.  ``index`` maps old index label strings to new ones; missing
+        keys are left unchanged.  Both can be applied in the same call.
+        """
+        var new_cols = List[Column]()
+        for i in range(len(self._cols)):
+            var c = self._cols[i].copy()
+            if columns:
+                ref col_map = columns.value()
+                if c.name in col_map:
+                    c.name = col_map[c.name]
+            if index and len(c._index) > 0:
+                ref idx_map = index.value()
+                var builtins = Python.import_module("builtins")
+                for k in range(len(c._index)):
+                    var lbl = String(c._index[k])
+                    if lbl in idx_map:
+                        c._index[k] = builtins.str(idx_map[lbl])
+            new_cols.append(c^)
+        return DataFrame(new_cols^)
 
     fn rename_axis(self, mapper: Optional[String] = None, axis: Int = 0) raises -> DataFrame:
-        _not_implemented("DataFrame.rename_axis")
-        return DataFrame()
+        """Return a copy with the axis name set to *mapper*.
+
+        Note: bison does not currently store axis names (the ``Index.name``
+        field is not wired into ``Column._index`` storage).  This method
+        returns a deep copy and silently ignores *mapper*.  The limitation is
+        tracked in SESSION.md as a tech-debt item.
+        """
+        return self._deep_copy()
 
     fn reindex(self, labels: Optional[List[String]] = None, axis: Int = 0, fill_value: Optional[DFScalar] = None) raises -> DataFrame:
-        _not_implemented("DataFrame.reindex")
-        return DataFrame()
+        """Conform the DataFrame to a new set of labels along an axis.
+
+        ``axis=1`` reorders/selects columns; missing columns are filled with
+        *fill_value* (null when *fill_value* is not provided).
+        ``axis=0`` reorders/selects rows by index label; missing labels produce
+        null rows (or rows filled with *fill_value*).
+
+        Returns an identical copy when ``labels`` is not provided.
+        """
+        if not labels:
+            return self._deep_copy()
+        ref new_labels = labels.value()
+        var ncols = len(self._cols)
+        if axis == 1:
+            # Column reindex: reorder and/or fill new columns.
+            var nrows = self.shape()[0]
+            # Build a name→col_index lookup.
+            var col_map = Dict[String, Int]()
+            for i in range(ncols):
+                col_map[self._cols[i].name] = i
+            # Determine the shared index for the result.
+            var shared_idx = List[PythonObject]()
+            if ncols > 0:
+                shared_idx = self._cols[0]._index.copy()
+            var new_cols = List[Column]()
+            for k in range(len(new_labels)):
+                var lbl = new_labels[k]
+                if lbl in col_map:
+                    var c = self._cols[col_map[lbl]].copy()
+                    new_cols.append(c^)
+                else:
+                    # Insert a fill/null column.
+                    if fill_value:
+                        var c = Column._fill_scalar(lbl, fill_value.value(), nrows, shared_idx.copy())
+                        new_cols.append(c^)
+                    else:
+                        # Null Float64 column: all-null mask.
+                        var null_data = List[Float64]()
+                        for r in range(nrows):
+                            null_data.append(Float64(0) / Float64(0))
+                        var null_mask = List[Bool]()
+                        for r in range(nrows):
+                            null_mask.append(True)
+                        var c = Column(lbl, ColumnData(null_data^), _float64, shared_idx.copy())
+                        c._null_mask = null_mask^
+                        new_cols.append(c^)
+            return DataFrame(new_cols^)
+        else:
+            # Row reindex: reorder and/or fill new rows.
+            if ncols == 0:
+                return DataFrame()
+            var nrows = self.shape()[0]
+            var has_index = len(self._cols[0]._index) > 0
+            # Build label → row-position map.
+            var label_to_row = Dict[String, Int]()
+            for i in range(nrows):
+                var key: String
+                if has_index:
+                    key = String(self._cols[0]._index[i])
+                else:
+                    key = String(i)
+                label_to_row[key] = i
+            # Build the per-output-row index list (row_indices) and new _index.
+            var row_indices = List[Int]()
+            var new_pyidx = List[PythonObject]()
+            var builtins = Python.import_module("builtins")
+            for k in range(len(new_labels)):
+                var lbl = new_labels[k]
+                if lbl in label_to_row:
+                    var src_row = label_to_row[lbl]
+                    row_indices.append(src_row)
+                    if has_index:
+                        new_pyidx.append(self._cols[0]._index[src_row])
+                    else:
+                        new_pyidx.append(builtins.int(src_row))
+                else:
+                    row_indices.append(-1)
+                    new_pyidx.append(builtins.str(lbl))
+            # Reindex each column.
+            var new_cols = List[Column]()
+            for i in range(ncols):
+                var c = self._cols[i]._reindex_rows(row_indices, fill_value)
+                c._index = new_pyidx.copy()
+                new_cols.append(c^)
+            return DataFrame(new_cols^)
 
     fn drop(self, labels: Optional[List[String]] = None, axis: Int = 0, columns: Optional[List[String]] = None) raises -> DataFrame:
         """Drop columns (axis=1 / columns kwarg) or rows (axis=0) by label.

--- a/tests/test_reshaping.mojo
+++ b/tests/test_reshaping.mojo
@@ -1,7 +1,8 @@
 """Tests for reshaping operations."""
 from std.python import Python
+from std.collections import Dict, Optional
 from testing import assert_true, assert_equal, TestSuite
-from bison import DataFrame, Series, SeriesScalar
+from bison import DataFrame, Series, SeriesScalar, DFScalar
 
 
 fn test_sort_values_ascending_int() raises:
@@ -187,6 +188,202 @@ fn test_series_sort_values() raises:
     assert_true(r.iloc(0)[Int64] == 1)
     assert_true(r.iloc(1)[Int64] == 2)
     assert_true(r.iloc(2)[Int64] == 3)
+
+
+# ------------------------------------------------------------------
+# rename
+# ------------------------------------------------------------------
+
+fn test_rename_columns() raises:
+    var pd = Python.import_module("pandas")
+    var df = DataFrame(pd.DataFrame(Python.evaluate("{'a': [1, 2, 3]}")))
+    var cols_map = Dict[String, String]()
+    cols_map["a"] = "x"
+    var r = df.rename(columns=Optional[Dict[String, String]](cols_map^))
+    assert_equal(r.shape()[1], 1)
+    assert_true(r["x"].iloc(0)[Int64] == 1)
+    assert_true(r["x"].iloc(1)[Int64] == 2)
+
+
+fn test_rename_columns_partial() raises:
+    var pd = Python.import_module("pandas")
+    var df = DataFrame(pd.DataFrame(Python.evaluate("{'a': [1], 'b': [2]}")))
+    var cols_map = Dict[String, String]()
+    cols_map["a"] = "x"
+    var r = df.rename(columns=Optional[Dict[String, String]](cols_map^))
+    assert_equal(r.shape()[1], 2)
+    assert_true(r["x"].iloc(0)[Int64] == 1)
+    assert_true(r["b"].iloc(0)[Int64] == 2)
+
+
+fn test_rename_index() raises:
+    # Rename index label 'i' → 'z'; sort_index ascending gives j, k, z.
+    var pd = Python.import_module("pandas")
+    var df = DataFrame(pd.DataFrame(Python.evaluate("{'a': [10, 20, 30]}"), index=Python.evaluate("['i', 'j', 'k']")))
+    var idx_map = Dict[String, String]()
+    idx_map["i"] = "z"
+    var r = df.rename(index=Optional[Dict[String, String]](idx_map^))
+    assert_equal(r.shape()[0], 3)
+    var s = r.sort_index()
+    # Sorted order: 'j'=20, 'k'=30, 'z'=10 (formerly 'i')
+    assert_true(s["a"].iloc(0)[Int64] == 20)
+    assert_true(s["a"].iloc(2)[Int64] == 10)
+
+
+# ------------------------------------------------------------------
+# reset_index
+# ------------------------------------------------------------------
+
+fn test_reset_index_drop_true() raises:
+    var pd = Python.import_module("pandas")
+    var df = DataFrame(pd.DataFrame(Python.evaluate("{'a': [1, 2]}"), index=Python.evaluate("['x', 'y']")))
+    var r = df.reset_index(drop=True)
+    assert_equal(r.shape()[0], 2)
+    assert_equal(r.shape()[1], 1)
+    assert_true(r["a"].iloc(0)[Int64] == 1)
+    assert_true(r["a"].iloc(1)[Int64] == 2)
+
+
+fn test_reset_index_drop_false() raises:
+    # Index promoted to a new "index" column prepended to the result.
+    var pd = Python.import_module("pandas")
+    var df = DataFrame(pd.DataFrame(Python.evaluate("{'a': [1, 2]}"), index=Python.evaluate("['x', 'y']")))
+    var r = df.reset_index()  # drop=False by default
+    assert_equal(r.shape()[0], 2)
+    assert_equal(r.shape()[1], 2)  # "index" column + "a" column
+    assert_true(r["a"].iloc(0)[Int64] == 1)
+
+
+fn test_reset_index_range_index() raises:
+    # On a default RangeIndex, reset_index is a copy.
+    var pd = Python.import_module("pandas")
+    var df = DataFrame(pd.DataFrame(Python.evaluate("{'a': [1, 2, 3]}")))
+    var r = df.reset_index(drop=True)
+    assert_equal(r.shape()[0], 3)
+    assert_equal(r.shape()[1], 1)
+    assert_true(r["a"].iloc(0)[Int64] == 1)
+
+
+# ------------------------------------------------------------------
+# set_index
+# ------------------------------------------------------------------
+
+fn test_set_index_single_drop_true() raises:
+    var pd = Python.import_module("pandas")
+    var df = DataFrame(pd.DataFrame(Python.evaluate("{'a': ['x', 'y'], 'b': [10, 20]}")))
+    var keys = List[String]()
+    keys.append("a")
+    var r = df.set_index(keys)  # drop=True by default
+    assert_equal(r.shape()[1], 1)  # "a" removed, only "b" remains
+    assert_true(r["b"].iloc(0)[Int64] == 10)
+    assert_true(r["b"].iloc(1)[Int64] == 20)
+
+
+fn test_set_index_single_drop_false() raises:
+    var pd = Python.import_module("pandas")
+    var df = DataFrame(pd.DataFrame(Python.evaluate("{'a': ['x', 'y'], 'b': [10, 20]}")))
+    var keys = List[String]()
+    keys.append("a")
+    var r = df.set_index(keys, drop=False)
+    assert_equal(r.shape()[1], 2)  # "a" kept as column and as index
+    assert_true(r["b"].iloc(0)[Int64] == 10)
+
+
+fn test_set_index_multi_raises() raises:
+    var pd = Python.import_module("pandas")
+    var df = DataFrame(pd.DataFrame(Python.evaluate("{'a': [1, 2], 'b': [3, 4]}")))
+    var keys = List[String]()
+    keys.append("a")
+    keys.append("b")
+    var raised = False
+    try:
+        _ = df.set_index(keys)
+    except:
+        raised = True
+    assert_true(raised)
+
+
+# ------------------------------------------------------------------
+# rename_axis
+# ------------------------------------------------------------------
+
+fn test_rename_axis_is_copy() raises:
+    var pd = Python.import_module("pandas")
+    var df = DataFrame(pd.DataFrame(Python.evaluate("{'a': [1, 2], 'b': [3, 4]}")))
+    var r = df.rename_axis(mapper=Optional[String]("rows"))
+    assert_equal(r.shape()[0], 2)
+    assert_equal(r.shape()[1], 2)
+    assert_true(r["a"].iloc(0)[Int64] == 1)
+
+
+# ------------------------------------------------------------------
+# reindex
+# ------------------------------------------------------------------
+
+fn test_reindex_axis1_reorder() raises:
+    var pd = Python.import_module("pandas")
+    var df = DataFrame(pd.DataFrame(Python.evaluate("{'a': [1], 'b': [2], 'c': [3]}")))
+    var lbls = List[String]()
+    lbls.append("c")
+    lbls.append("a")
+    lbls.append("b")
+    var r = df.reindex(labels=Optional[List[String]](lbls^), axis=1)
+    assert_equal(r.shape()[1], 3)
+    assert_true(r["c"].iloc(0)[Int64] == 3)
+    assert_true(r["a"].iloc(0)[Int64] == 1)
+    assert_true(r["b"].iloc(0)[Int64] == 2)
+
+
+fn test_reindex_axis1_fill() raises:
+    var pd = Python.import_module("pandas")
+    var df = DataFrame(pd.DataFrame(Python.evaluate("{'a': [1, 2]}")))
+    var lbls = List[String]()
+    lbls.append("a")
+    lbls.append("x")
+    var fv = Optional[DFScalar](DFScalar(Int64(99)))
+    var r = df.reindex(labels=Optional[List[String]](lbls^), axis=1, fill_value=fv)
+    assert_equal(r.shape()[1], 2)
+    assert_true(r["a"].iloc(0)[Int64] == 1)
+    assert_true(r["x"].iloc(0)[Int64] == 99)
+
+
+fn test_reindex_axis1_null_fill() raises:
+    var pd = Python.import_module("pandas")
+    var df = DataFrame(pd.DataFrame(Python.evaluate("{'a': [1, 2]}")))
+    var lbls = List[String]()
+    lbls.append("a")
+    lbls.append("x")
+    var r = df.reindex(labels=Optional[List[String]](lbls^), axis=1)
+    assert_equal(r.shape()[1], 2)
+    assert_equal(r.shape()[0], 2)
+
+
+fn test_reindex_axis0_reorder() raises:
+    # index=['c', 'a', 'b'], values=[10, 20, 30]. Reindex to ['a', 'b', 'c'].
+    var pd = Python.import_module("pandas")
+    var df = DataFrame(pd.DataFrame(Python.evaluate("{'a': [10, 20, 30]}"), index=Python.evaluate("['c', 'a', 'b']")))
+    var lbls = List[String]()
+    lbls.append("a")
+    lbls.append("b")
+    lbls.append("c")
+    var r = df.reindex(labels=Optional[List[String]](lbls^))  # axis=0 default
+    assert_equal(r.shape()[0], 3)
+    assert_true(r["a"].iloc(0)[Int64] == 20)  # row 'a' had value 20
+    assert_true(r["a"].iloc(1)[Int64] == 30)  # row 'b' had value 30
+    assert_true(r["a"].iloc(2)[Int64] == 10)  # row 'c' had value 10
+
+
+fn test_reindex_axis0_fill() raises:
+    var pd = Python.import_module("pandas")
+    var df = DataFrame(pd.DataFrame(Python.evaluate("{'a': [10]}"), index=Python.evaluate("['x']")))
+    var lbls = List[String]()
+    lbls.append("x")
+    lbls.append("z")
+    var fv = Optional[DFScalar](DFScalar(Int64(0)))
+    var r = df.reindex(labels=Optional[List[String]](lbls^), fill_value=fv)
+    assert_equal(r.shape()[0], 2)
+    assert_true(r["a"].iloc(0)[Int64] == 10)
+    assert_true(r["a"].iloc(1)[Int64] == 0)
 
 
 fn main() raises:


### PR DESCRIPTION
Closes #8

## Summary

- Implements `reset_index`, `set_index`, `rename`, `rename_axis`, and `reindex` on `DataFrame` — all were previously `_not_implemented` stubs
- Adds `_ReindexRowsVisitor`, `Column._to_pyobj_index`, and `Column._reindex_rows` in `column.mojo` to support row reindexing with null/fill insertion
- Adds 15 tests to `tests/test_reshaping.mojo` (31 total)

## Limitations noted (tracked in SESSION.md)

- `rename_axis` silently ignores `mapper` — `Column._index` has no axis-name field
- `set_index` raises for `len(keys) > 1` (MultiIndex not yet supported)
- `_to_pyobj_index` ignores the source null mask (null cells promoted as placeholder values)
- `reindex` axis=1 missing columns always inserted as Float64

## Test plan

- [x] `mojo run tests/test_reshaping.mojo` — 31/31 pass
- [x] `pixi run test` — 366/366 pass across all 13 test files
- [x] `pixi run update-compat` — README compat table updated (DataFrame stubs: 53 → 48)
- [x] `pixi run lint` — all pre-commit hooks pass