### PR TITLE
feat: implement DataFrame.from_records natively

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ In CI it runs after the test suite and the result is committed back to the branc
 <!-- COMPAT_TABLE_START -->
 | Category | Stubs | Implemented |
 |----------|-------|-------------|
-| DataFrame | 34 | 88 |
+| DataFrame | 33 | 89 |
 | Series | 7 | 80 |
 | GroupBy (DataFrame) | 16 | 1 |
 | GroupBy (Series) | 15 | 1 |
@@ -91,7 +91,7 @@ In CI it runs after the test suite and the result is committed back to the branc
 | Index | 0 | 14 |
 | IO | 10 | 2 |
 | Reshape | 0 | 1 |
-| **Total** | **99** | **209** |
+| **Total** | **98** | **210** |
 <!-- COMPAT_TABLE_END -->
 
 ## Known limitations

--- a/bison/dataframe.mojo
+++ b/bison/dataframe.mojo
@@ -126,10 +126,121 @@ struct DataFrame(Copyable, Movable):
         records: List[Dict[String, DFScalar]],
         columns: Optional[List[String]] = None,
     ) raises -> DataFrame:
-        """Create DataFrame from a list of row dicts."""
-        # TODO(#47): row-to-column transposition is non-trivial; implement natively.
-        _not_implemented("DataFrame.from_records")
-        return DataFrame()
+        """Create DataFrame from a list of row dicts (row-to-column transposition)."""
+        if len(records) == 0:
+            return DataFrame()
+
+        # Determine column names
+        var col_names = List[String]()
+        if columns:
+            col_names = columns.value().copy()
+        else:
+            for entry in records[0].items():
+                col_names.append(entry.key)
+
+        var cols = List[Column]()
+
+        for ci in range(len(col_names)):
+            var col_name = col_names[ci]
+            var null_mask = List[Bool]()
+
+            # Infer dtype from first record that has this key
+            var first_int = False
+            var first_float = False
+            var first_bool = False
+            var found = False
+            for ri in range(len(records)):
+                try:
+                    var v = records[ri][col_name]
+                    if v.isa[Int64]():
+                        first_int = True
+                    elif v.isa[Float64]():
+                        first_float = True
+                    elif v.isa[Bool]():
+                        first_bool = True
+                    # else String
+                    found = True
+                    break
+                except:
+                    pass
+
+            if not found:
+                # All rows missing this key — object column, all null
+                var data = List[PythonObject]()
+                var py_none = Python.evaluate("None")
+                for _ in range(len(records)):
+                    data.append(py_none)
+                    null_mask.append(True)
+                var col = Column(col_name, ColumnData(data^), object_)
+                col._null_mask = null_mask^
+                cols.append(col^)
+                continue
+
+            if first_int:
+                var data = List[Int64]()
+                var has_nulls = False
+                for ri in range(len(records)):
+                    try:
+                        var v = records[ri][col_name]
+                        data.append(v[Int64])
+                        null_mask.append(False)
+                    except:
+                        data.append(Int64(0))
+                        null_mask.append(True)
+                        has_nulls = True
+                if has_nulls:
+                    # Promote to float64 so NaN can be represented (mirrors pandas behavior)
+                    var fdata = List[Float64]()
+                    for i in range(len(data)):
+                        fdata.append(Float64(data[i]))
+                    var col = Column(col_name, ColumnData(fdata^), float64)
+                    col._null_mask = null_mask^
+                    cols.append(col^)
+                    continue
+                var col = Column(col_name, ColumnData(data^), int64)
+                col._null_mask = null_mask^
+                cols.append(col^)
+            elif first_float:
+                var data = List[Float64]()
+                for ri in range(len(records)):
+                    try:
+                        var v = records[ri][col_name]
+                        data.append(v[Float64])
+                        null_mask.append(False)
+                    except:
+                        data.append(Float64(0.0))
+                        null_mask.append(True)
+                var col = Column(col_name, ColumnData(data^), float64)
+                col._null_mask = null_mask^
+                cols.append(col^)
+            elif first_bool:
+                var data = List[Bool]()
+                for ri in range(len(records)):
+                    try:
+                        var v = records[ri][col_name]
+                        data.append(v[Bool])
+                        null_mask.append(False)
+                    except:
+                        data.append(False)
+                        null_mask.append(True)
+                var col = Column(col_name, ColumnData(data^), bool_)
+                col._null_mask = null_mask^
+                cols.append(col^)
+            else:  # String
+                var data = List[String]()
+                for ri in range(len(records)):
+                    try:
+                        var v = records[ri][col_name]
+                        data.append(v[String])
+                        null_mask.append(False)
+                    except:
+                        data.append(String(""))
+                        null_mask.append(True)
+                var col = Column(col_name, ColumnData(data^), object_)
+                col._null_mask = null_mask^
+                cols.append(col^)
+
+        return DataFrame(cols^)
 
     # ------------------------------------------------------------------
     # Attributes

--- a/tests/test_dataframe.mojo
+++ b/tests/test_dataframe.mojo
@@ -2,7 +2,7 @@
 from std.python import Python, PythonObject
 from std.collections import Dict
 from testing import assert_equal, assert_true, assert_false, TestSuite
-from bison import DataFrame, ColumnData, Series
+from bison import DataFrame, ColumnData, DFScalar, Series
 
 
 fn test_shape_from_pandas() raises:
@@ -415,6 +415,65 @@ fn test_itertuples_name() raises:
     var df = DataFrame(pd.DataFrame(Python.evaluate("{'a': [1]}")))
     var tuples = df.itertuples(index=True, name="Row")
     assert_equal(tuples[0].name, "Row")
+
+
+fn test_from_records_basic() raises:
+    var row0: Dict[String, DFScalar] = {"a": DFScalar(Int64(1)), "b": DFScalar(Int64(10))}
+    var row1: Dict[String, DFScalar] = {"a": DFScalar(Int64(2)), "b": DFScalar(Int64(20))}
+    var records = List[Dict[String, DFScalar]]()
+    records.append(row0^)
+    records.append(row1^)
+    var df = DataFrame.from_records(records)
+    assert_equal(df.shape()[0], 2)
+    assert_equal(df.shape()[1], 2)
+    assert_equal(df.columns()[0], "a")
+    assert_equal(df.columns()[1], "b")
+
+
+fn test_from_records_empty() raises:
+    var records = List[Dict[String, DFScalar]]()
+    var df = DataFrame.from_records(records)
+    assert_equal(df.shape()[0], 0)
+    assert_equal(df.shape()[1], 0)
+
+
+fn test_from_records_columns_param() raises:
+    var row0: Dict[String, DFScalar] = {"a": DFScalar(Int64(1)), "b": DFScalar(Int64(2)), "c": DFScalar(Int64(3))}
+    var records = List[Dict[String, DFScalar]]()
+    records.append(row0^)
+    var cols = List[String]()
+    cols.append("a")
+    cols.append("c")
+    var df = DataFrame.from_records(records, cols^)
+    assert_equal(df.shape()[1], 2)
+    assert_equal(df.columns()[0], "a")
+    assert_equal(df.columns()[1], "c")
+
+
+fn test_from_records_mixed_types() raises:
+    var row0: Dict[String, DFScalar] = {"i": DFScalar(Int64(42)), "s": DFScalar(String("hello"))}
+    var row1: Dict[String, DFScalar] = {"i": DFScalar(Int64(7)), "s": DFScalar(String("world"))}
+    var records = List[Dict[String, DFScalar]]()
+    records.append(row0^)
+    records.append(row1^)
+    var df = DataFrame.from_records(records)
+    assert_equal(df.shape()[0], 2)
+    assert_equal(df.shape()[1], 2)
+
+
+fn test_from_records_missing_key() raises:
+    var row0: Dict[String, DFScalar] = {"a": DFScalar(Int64(1)), "b": DFScalar(Int64(10))}
+    var row1: Dict[String, DFScalar] = {"a": DFScalar(Int64(2))}
+    # "b" is missing in row1
+    var records = List[Dict[String, DFScalar]]()
+    records.append(row0^)
+    records.append(row1^)
+    var df = DataFrame.from_records(records)
+    assert_equal(df.shape()[0], 2)
+    assert_equal(df.shape()[1], 2)
+    # verify via pandas that the missing value is NaN
+    var pd_df = df.to_pandas()
+    assert_true(Bool(pd_df["b"].isna()[1]))
 
 
 fn main() raises:


### PR DESCRIPTION
## Summary

- Replaces the `_not_implemented` stub in `DataFrame.from_records` with native row-to-column transposition
- Infers column dtype from the first non-null value per column (Int64 / Float64 / Bool / String)
- Int columns with any missing keys are promoted to float64 so NaN can be represented, mirroring pandas behaviour
- Adds five test cases: basic construction, empty input, `columns` parameter filtering, mixed types, and missing-key null propagation

Closes #67

## Test plan

- [x] `pixi run test` — 14 test files, 0 failures
- [x] `pixi run update-compat` — compat table updated, `DataFrame.from_records` removed from stub list
- [ ] Review: column order non-determinism when `columns` param is omitted (tracked in SESSION.md as a follow-up bug)