### PR TITLE
fix: DFScalar accepts Int without explicit Int64() cast

### DIFF
--- a/bison/column.mojo
+++ b/bison/column.mojo
@@ -29,7 +29,45 @@ comptime ColumnData = Variant[
 
 # Scalar type for a single cell in row-oriented input (from_records).
 # No PythonObject arm — record values must be explicitly typed.
-comptime DFScalar = Variant[Int64, Float64, Bool, String]
+#
+# Implemented as a thin struct rather than a bare Variant alias so that
+# Int (Mojo's native integer type) implicitly converts to Int64 at
+# construction time.  All four typed arms plus Int are accepted; Int is
+# normalised to Int64 immediately, so dispatch sites only ever see Int64.
+struct DFScalar(Copyable, Movable, ImplicitlyCopyable):
+    var _v: Variant[Int64, Float64, Bool, String]
+
+    @implicit
+    fn __init__(out self, value: Int64):
+        self._v = Variant[Int64, Float64, Bool, String](value)
+
+    @implicit
+    fn __init__(out self, value: Float64):
+        self._v = Variant[Int64, Float64, Bool, String](value)
+
+    @implicit
+    fn __init__(out self, value: Bool):
+        self._v = Variant[Int64, Float64, Bool, String](value)
+
+    @implicit
+    fn __init__(out self, value: String):
+        self._v = Variant[Int64, Float64, Bool, String](value)
+
+    @implicit
+    fn __init__(out self, value: Int):
+        self._v = Variant[Int64, Float64, Bool, String](Int64(value))
+
+    fn __copyinit__(out self, other: Self):
+        self._v = other._v
+
+    fn __moveinit__(out self, deinit other: Self):
+        self._v = other._v^
+
+    fn isa[T: Copyable & Movable](self) -> Bool:
+        return self._v.isa[T]()
+
+    fn __getitem__[T: Copyable & Movable](ref self) -> ref [self._v] T:
+        return self._v[T]
 
 # Scalar type returned by Series.iloc / Series.at.
 # Covers all five ColumnData arm types; the PythonObject arm is used only

--- a/tests/test_dataframe.mojo
+++ b/tests/test_dataframe.mojo
@@ -418,8 +418,8 @@ fn test_itertuples_name() raises:
 
 
 fn test_from_records_basic() raises:
-    var row0: Dict[String, DFScalar] = {"a": Int64(1), "b": Int64(10)}
-    var row1: Dict[String, DFScalar] = {"a": Int64(2), "b": Int64(20)}
+    var row0: Dict[String, DFScalar] = {"a": 1, "b": 10}
+    var row1: Dict[String, DFScalar] = {"a": 2, "b": 20}
     var records = List[Dict[String, DFScalar]]()
     records.append(row0^)
     records.append(row1^)
@@ -438,7 +438,7 @@ fn test_from_records_empty() raises:
 
 
 fn test_from_records_columns_param() raises:
-    var row0: Dict[String, DFScalar] = {"a": Int64(1), "b": Int64(2), "c": Int64(3)}
+    var row0: Dict[String, DFScalar] = {"a": 1, "b": 2, "c": 3}
     var records = List[Dict[String, DFScalar]]()
     records.append(row0^)
     var cols = List[String]()
@@ -451,8 +451,8 @@ fn test_from_records_columns_param() raises:
 
 
 fn test_from_records_mixed_types() raises:
-    var row0: Dict[String, DFScalar] = {"i": Int64(42), "s": "hello"}
-    var row1: Dict[String, DFScalar] = {"i": Int64(7), "s": "world"}
+    var row0: Dict[String, DFScalar] = {"i": 42, "s": "hello"}
+    var row1: Dict[String, DFScalar] = {"i": 7, "s": "world"}
     var records = List[Dict[String, DFScalar]]()
     records.append(row0^)
     records.append(row1^)
@@ -463,7 +463,7 @@ fn test_from_records_mixed_types() raises:
 
 fn test_from_records_int_float_mixed() raises:
     # First row has Int64, second row has Float64 — column should be promoted to float64
-    var row0: Dict[String, DFScalar] = {"x": Int64(1)}
+    var row0: Dict[String, DFScalar] = {"x": 1}
     var row1: Dict[String, DFScalar] = {"x": Float64(2.5)}
     var records = List[Dict[String, DFScalar]]()
     records.append(row0^)
@@ -481,7 +481,7 @@ fn test_from_records_int_float_mixed() raises:
 fn test_from_records_bool_int_mixed() raises:
     # First row has Bool, second row has Int64 — column should be promoted to int64
     var row0: Dict[String, DFScalar] = {"y": True}
-    var row1: Dict[String, DFScalar] = {"y": Int64(42)}
+    var row1: Dict[String, DFScalar] = {"y": 42}
     var records = List[Dict[String, DFScalar]]()
     records.append(row0^)
     records.append(row1^)
@@ -496,8 +496,8 @@ fn test_from_records_bool_int_mixed() raises:
 
 
 fn test_from_records_missing_key() raises:
-    var row0: Dict[String, DFScalar] = {"a": Int64(1), "b": Int64(10)}
-    var row1: Dict[String, DFScalar] = {"a": Int64(2)}
+    var row0: Dict[String, DFScalar] = {"a": 1, "b": 10}
+    var row1: Dict[String, DFScalar] = {"a": 2}
     # "b" is missing in row1
     var records = List[Dict[String, DFScalar]]()
     records.append(row0^)
@@ -513,7 +513,7 @@ fn test_from_records_missing_key() raises:
 fn test_from_records_column_order_deterministic() raises:
     # Column names should be sorted alphabetically when `columns` is not provided,
     # so the result is deterministic regardless of Dict iteration order.
-    var row0: Dict[String, DFScalar] = {"z": Int64(3), "a": Int64(1), "m": Int64(2)}
+    var row0: Dict[String, DFScalar] = {"z": 3, "a": 1, "m": 2}
     var records = List[Dict[String, DFScalar]]()
     records.append(row0^)
     var df = DataFrame.from_records(records)


### PR DESCRIPTION
## Summary

- Replaces the bare `Variant` type alias for `DFScalar` with a thin struct that adds `@implicit __init__(value: Int)`, normalising `Int` to `Int64` at construction time
- All four existing typed arms (`Int64`, `Float64`, `Bool`, `String`) get `@implicit` decorators so existing dict/list literal coercions continue to work unchanged
- Callers can now write `{"key": 42}` instead of `{"key": Int64(42)}`

## Test plan

- Updated all `test_from_records_*` tests to use plain integer literals instead of `Int64(...)` wrappers — these would fail to compile if the fix didn't work
- Full test suite: 123 tests run, 123 passed

Closes #205