### PR TITLE
fix: replace bare raise with _not_implemented in axis=1 aggregations

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ In CI it runs after the test suite and the result is committed back to the branc
 <!-- COMPAT_TABLE_START -->
 | Category | Stubs | Implemented |
 |----------|-------|-------------|
-| DataFrame | 33 | 89 |
+| DataFrame | 47 | 75 |
 | Series | 1 | 86 |
 | GroupBy (DataFrame) | 16 | 1 |
 | GroupBy (Series) | 15 | 1 |
@@ -91,7 +91,7 @@ In CI it runs after the test suite and the result is committed back to the branc
 | Index | 0 | 14 |
 | IO | 7 | 4 |
 | Reshape | 0 | 1 |
-| **Total** | **89** | **218** |
+| **Total** | **103** | **204** |
 <!-- COMPAT_TABLE_END -->
 
 ## Known limitations

--- a/bison/_frame.mojo
+++ b/bison/_frame.mojo
@@ -1858,7 +1858,7 @@ struct DataFrame(Copyable, Movable):
 
     def sum(self, axis: Int = 0, skipna: Bool = True) raises -> Series:
         if axis != 0:
-            raise Error("DataFrame.sum: axis=1 not yet implemented")
+            _not_implemented("DataFrame.sum")
         var values = List[Float64]()
         for i in range(len(self._cols)):
             values.append(self._cols[i].sum(skipna))
@@ -1869,7 +1869,7 @@ struct DataFrame(Copyable, Movable):
 
     def mean(self, axis: Int = 0, skipna: Bool = True) raises -> Series:
         if axis != 0:
-            raise Error("DataFrame.mean: axis=1 not yet implemented")
+            _not_implemented("DataFrame.mean")
         var values = List[Float64]()
         for i in range(len(self._cols)):
             values.append(self._cols[i].mean(skipna))
@@ -1880,7 +1880,7 @@ struct DataFrame(Copyable, Movable):
 
     def median(self, axis: Int = 0, skipna: Bool = True) raises -> Series:
         if axis != 0:
-            raise Error("DataFrame.median: axis=1 not yet implemented")
+            _not_implemented("DataFrame.median")
         var values = List[Float64]()
         for i in range(len(self._cols)):
             values.append(self._cols[i].median(skipna))
@@ -1891,7 +1891,7 @@ struct DataFrame(Copyable, Movable):
 
     def min(self, axis: Int = 0, skipna: Bool = True) raises -> Series:
         if axis != 0:
-            raise Error("DataFrame.min: axis=1 not yet implemented")
+            _not_implemented("DataFrame.min")
         var values = List[Float64]()
         for i in range(len(self._cols)):
             values.append(self._cols[i].min(skipna))
@@ -1902,7 +1902,7 @@ struct DataFrame(Copyable, Movable):
 
     def max(self, axis: Int = 0, skipna: Bool = True) raises -> Series:
         if axis != 0:
-            raise Error("DataFrame.max: axis=1 not yet implemented")
+            _not_implemented("DataFrame.max")
         var values = List[Float64]()
         for i in range(len(self._cols)):
             values.append(self._cols[i].max(skipna))
@@ -1913,7 +1913,7 @@ struct DataFrame(Copyable, Movable):
 
     def std(self, axis: Int = 0, ddof: Int = 1, skipna: Bool = True) raises -> Series:
         if axis != 0:
-            raise Error("DataFrame.std: axis=1 not yet implemented")
+            _not_implemented("DataFrame.std")
         var values = List[Float64]()
         for i in range(len(self._cols)):
             values.append(self._cols[i].std(ddof, skipna))
@@ -1924,7 +1924,7 @@ struct DataFrame(Copyable, Movable):
 
     def var(self, axis: Int = 0, ddof: Int = 1, skipna: Bool = True) raises -> Series:
         if axis != 0:
-            raise Error("DataFrame.var: axis=1 not yet implemented")
+            _not_implemented("DataFrame.var")
         var values = List[Float64]()
         for i in range(len(self._cols)):
             values.append(self._cols[i].var(ddof, skipna))
@@ -1935,7 +1935,7 @@ struct DataFrame(Copyable, Movable):
 
     def count(self, axis: Int = 0) raises -> Series:
         if axis != 0:
-            raise Error("DataFrame.count: axis=1 not yet implemented")
+            _not_implemented("DataFrame.count")
         var values = List[Float64]()
         for i in range(len(self._cols)):
             values.append(Float64(self._cols[i].count()))
@@ -1946,7 +1946,7 @@ struct DataFrame(Copyable, Movable):
 
     def nunique(self, axis: Int = 0) raises -> Series:
         if axis != 0:
-            raise Error("DataFrame.nunique: axis=1 not yet implemented")
+            _not_implemented("DataFrame.nunique")
         var values = List[Float64]()
         for i in range(len(self._cols)):
             values.append(Float64(self._cols[i].nunique()))
@@ -1961,7 +1961,7 @@ struct DataFrame(Copyable, Movable):
 
     def quantile(self, q: Float64 = 0.5, axis: Int = 0, skipna: Bool = True) raises -> Series:
         if axis != 0:
-            raise Error("DataFrame.quantile: axis=1 not yet implemented")
+            _not_implemented("DataFrame.quantile")
         var values = List[Float64]()
         for i in range(len(self._cols)):
             values.append(self._cols[i].quantile(q, skipna))
@@ -1976,7 +1976,7 @@ struct DataFrame(Copyable, Movable):
 
     def cumsum(self, axis: Int = 0, skipna: Bool = True) raises -> DataFrame:
         if axis != 0:
-            raise Error("DataFrame.cumsum: axis=1 not yet implemented")
+            _not_implemented("DataFrame.cumsum")
         var result_cols = List[Column]()
         for i in range(len(self._cols)):
             result_cols.append(self._cols[i].cumsum(skipna))
@@ -1984,7 +1984,7 @@ struct DataFrame(Copyable, Movable):
 
     def cumprod(self, axis: Int = 0, skipna: Bool = True) raises -> DataFrame:
         if axis != 0:
-            raise Error("DataFrame.cumprod: axis=1 not yet implemented")
+            _not_implemented("DataFrame.cumprod")
         var result_cols = List[Column]()
         for i in range(len(self._cols)):
             result_cols.append(self._cols[i].cumprod(skipna))
@@ -1992,7 +1992,7 @@ struct DataFrame(Copyable, Movable):
 
     def cummin(self, axis: Int = 0, skipna: Bool = True) raises -> DataFrame:
         if axis != 0:
-            raise Error("DataFrame.cummin: axis=1 not yet implemented")
+            _not_implemented("DataFrame.cummin")
         var result_cols = List[Column]()
         for i in range(len(self._cols)):
             result_cols.append(self._cols[i].cummin(skipna))
@@ -2000,7 +2000,7 @@ struct DataFrame(Copyable, Movable):
 
     def cummax(self, axis: Int = 0, skipna: Bool = True) raises -> DataFrame:
         if axis != 0:
-            raise Error("DataFrame.cummax: axis=1 not yet implemented")
+            _not_implemented("DataFrame.cummax")
         var result_cols = List[Column]()
         for i in range(len(self._cols)):
             result_cols.append(self._cols[i].cummax(skipna))

--- a/tests/test_aggregation.mojo
+++ b/tests/test_aggregation.mojo
@@ -442,5 +442,177 @@ def test_df_cummax() raises:
     assert_true(Float64(String(result_pd["a"].iloc[2])) == 5.0)
 
 
+# ---------------------------------------------------------------------------
+# axis=1 stubs — all must raise with "not implemented"
+# ---------------------------------------------------------------------------
+
+def test_df_sum_axis1_raises() raises:
+    var pd = Python.import_module("pandas")
+    var df = DataFrame(pd.DataFrame(Python.evaluate("{'a': [1, 2], 'b': [3, 4]}")))
+    var raised = False
+    try:
+        _ = df.sum(axis=1)
+    except:
+        raised = True
+    if not raised:
+        raise Error("DataFrame.sum axis=1 should have raised")
+
+
+def test_df_mean_axis1_raises() raises:
+    var pd = Python.import_module("pandas")
+    var df = DataFrame(pd.DataFrame(Python.evaluate("{'a': [1, 2], 'b': [3, 4]}")))
+    var raised = False
+    try:
+        _ = df.mean(axis=1)
+    except:
+        raised = True
+    if not raised:
+        raise Error("DataFrame.mean axis=1 should have raised")
+
+
+def test_df_median_axis1_raises() raises:
+    var pd = Python.import_module("pandas")
+    var df = DataFrame(pd.DataFrame(Python.evaluate("{'a': [1, 2], 'b': [3, 4]}")))
+    var raised = False
+    try:
+        _ = df.median(axis=1)
+    except:
+        raised = True
+    if not raised:
+        raise Error("DataFrame.median axis=1 should have raised")
+
+
+def test_df_min_axis1_raises() raises:
+    var pd = Python.import_module("pandas")
+    var df = DataFrame(pd.DataFrame(Python.evaluate("{'a': [1, 2], 'b': [3, 4]}")))
+    var raised = False
+    try:
+        _ = df.min(axis=1)
+    except:
+        raised = True
+    if not raised:
+        raise Error("DataFrame.min axis=1 should have raised")
+
+
+def test_df_max_axis1_raises() raises:
+    var pd = Python.import_module("pandas")
+    var df = DataFrame(pd.DataFrame(Python.evaluate("{'a': [1, 2], 'b': [3, 4]}")))
+    var raised = False
+    try:
+        _ = df.max(axis=1)
+    except:
+        raised = True
+    if not raised:
+        raise Error("DataFrame.max axis=1 should have raised")
+
+
+def test_df_std_axis1_raises() raises:
+    var pd = Python.import_module("pandas")
+    var df = DataFrame(pd.DataFrame(Python.evaluate("{'a': [1, 2], 'b': [3, 4]}")))
+    var raised = False
+    try:
+        _ = df.std(axis=1)
+    except:
+        raised = True
+    if not raised:
+        raise Error("DataFrame.std axis=1 should have raised")
+
+
+def test_df_var_axis1_raises() raises:
+    var pd = Python.import_module("pandas")
+    var df = DataFrame(pd.DataFrame(Python.evaluate("{'a': [1, 2], 'b': [3, 4]}")))
+    var raised = False
+    try:
+        _ = df.var(axis=1)
+    except:
+        raised = True
+    if not raised:
+        raise Error("DataFrame.var axis=1 should have raised")
+
+
+def test_df_count_axis1_raises() raises:
+    var pd = Python.import_module("pandas")
+    var df = DataFrame(pd.DataFrame(Python.evaluate("{'a': [1, 2], 'b': [3, 4]}")))
+    var raised = False
+    try:
+        _ = df.count(axis=1)
+    except:
+        raised = True
+    if not raised:
+        raise Error("DataFrame.count axis=1 should have raised")
+
+
+def test_df_nunique_axis1_raises() raises:
+    var pd = Python.import_module("pandas")
+    var df = DataFrame(pd.DataFrame(Python.evaluate("{'a': [1, 2], 'b': [3, 4]}")))
+    var raised = False
+    try:
+        _ = df.nunique(axis=1)
+    except:
+        raised = True
+    if not raised:
+        raise Error("DataFrame.nunique axis=1 should have raised")
+
+
+def test_df_quantile_axis1_raises() raises:
+    var pd = Python.import_module("pandas")
+    var df = DataFrame(pd.DataFrame(Python.evaluate("{'a': [1, 2], 'b': [3, 4]}")))
+    var raised = False
+    try:
+        _ = df.quantile(0.5, axis=1)
+    except:
+        raised = True
+    if not raised:
+        raise Error("DataFrame.quantile axis=1 should have raised")
+
+
+def test_df_cumsum_axis1_raises() raises:
+    var pd = Python.import_module("pandas")
+    var df = DataFrame(pd.DataFrame(Python.evaluate("{'a': [1, 2], 'b': [3, 4]}")))
+    var raised = False
+    try:
+        _ = df.cumsum(axis=1)
+    except:
+        raised = True
+    if not raised:
+        raise Error("DataFrame.cumsum axis=1 should have raised")
+
+
+def test_df_cumprod_axis1_raises() raises:
+    var pd = Python.import_module("pandas")
+    var df = DataFrame(pd.DataFrame(Python.evaluate("{'a': [1, 2], 'b': [3, 4]}")))
+    var raised = False
+    try:
+        _ = df.cumprod(axis=1)
+    except:
+        raised = True
+    if not raised:
+        raise Error("DataFrame.cumprod axis=1 should have raised")
+
+
+def test_df_cummin_axis1_raises() raises:
+    var pd = Python.import_module("pandas")
+    var df = DataFrame(pd.DataFrame(Python.evaluate("{'a': [1, 2], 'b': [3, 4]}")))
+    var raised = False
+    try:
+        _ = df.cummin(axis=1)
+    except:
+        raised = True
+    if not raised:
+        raise Error("DataFrame.cummin axis=1 should have raised")
+
+
+def test_df_cummax_axis1_raises() raises:
+    var pd = Python.import_module("pandas")
+    var df = DataFrame(pd.DataFrame(Python.evaluate("{'a': [1, 2], 'b': [3, 4]}")))
+    var raised = False
+    try:
+        _ = df.cummax(axis=1)
+    except:
+        raised = True
+    if not raised:
+        raise Error("DataFrame.cummax axis=1 should have raised")
+
+
 def main() raises:
     TestSuite.discover_tests[__functions_in_module()]().run()


### PR DESCRIPTION
## Summary

- 14 DataFrame aggregation methods (`sum`, `mean`, `median`, `min`, `max`, `std`, `var`, `count`, `nunique`, `quantile`, `cumsum`, `cumprod`, `cummin`, `cummax`) were raising bare `Error(...)` strings for `axis=1`, making them invisible to `scripts/update_compat.py`
- Replaced each with `_not_implemented("DataFrame.<method>")` so the compat table in README now reflects them correctly
- Added 14 "expect raise" tests covering all affected methods with `axis=1`

## Test plan

- [ ] `pixi run test` passes (148 tests + 14 new axis=1 raise tests)
- [ ] `pixi run update-compat` updates DataFrame stub count from 33 → 47

Closes #246