### PR TITLE
feat: add stubs for shift/diff/pct_change and sem/skew/kurt/idxmin/idxmax/corr/cov

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,8 +82,8 @@ In CI it runs after the test suite and the result is committed back to the branc
 <!-- COMPAT_TABLE_START -->
 | Category | Stubs | Implemented |
 |----------|-------|-------------|
-| DataFrame | 47 | 75 |
-| Series | 1 | 86 |
+| DataFrame | 57 | 75 |
+| Series | 11 | 86 |
 | GroupBy (DataFrame) | 16 | 1 |
 | GroupBy (Series) | 15 | 1 |
 | String accessor | 0 | 21 |
@@ -91,7 +91,7 @@ In CI it runs after the test suite and the result is committed back to the branc
 | Index | 0 | 14 |
 | IO | 7 | 4 |
 | Reshape | 0 | 1 |
-| **Total** | **103** | **204** |
+| **Total** | **123** | **204** |
 <!-- COMPAT_TABLE_END -->
 
 ## Known limitations

--- a/bison/_frame.mojo
+++ b/bison/_frame.mojo
@@ -241,6 +241,46 @@ struct Series(Copyable, Movable):
     def cummax(self, skipna: Bool = True) raises -> Series:
         return Series(self._col.cummax(skipna))
 
+    def sem(self, ddof: Int = 1, skipna: Bool = True) raises -> Float64:
+        _not_implemented("Series.sem")
+        return 0.0
+
+    def skew(self, skipna: Bool = True) raises -> Float64:
+        _not_implemented("Series.skew")
+        return 0.0
+
+    def kurt(self, skipna: Bool = True) raises -> Float64:
+        _not_implemented("Series.kurt")
+        return 0.0
+
+    def idxmin(self, skipna: Bool = True) raises -> Int:
+        _not_implemented("Series.idxmin")
+        return 0
+
+    def idxmax(self, skipna: Bool = True) raises -> Int:
+        _not_implemented("Series.idxmax")
+        return 0
+
+    def corr(self, other: Series) raises -> Float64:
+        _not_implemented("Series.corr")
+        return 0.0
+
+    def cov(self, other: Series, ddof: Int = 1) raises -> Float64:
+        _not_implemented("Series.cov")
+        return 0.0
+
+    def shift(self, periods: Int = 1) raises -> Series:
+        _not_implemented("Series.shift")
+        return Series()
+
+    def diff(self, periods: Int = 1) raises -> Series:
+        _not_implemented("Series.diff")
+        return Series()
+
+    def pct_change(self, periods: Int = 1) raises -> Series:
+        _not_implemented("Series.pct_change")
+        return Series()
+
     # ------------------------------------------------------------------
     # Missing data
     # ------------------------------------------------------------------
@@ -2005,6 +2045,46 @@ struct DataFrame(Copyable, Movable):
         for i in range(len(self._cols)):
             result_cols.append(self._cols[i].cummax(skipna))
         return DataFrame(result_cols^)
+
+    def sem(self, axis: Int = 0, ddof: Int = 1, skipna: Bool = True) raises -> Series:
+        _not_implemented("DataFrame.sem")
+        return Series()
+
+    def skew(self, axis: Int = 0, skipna: Bool = True) raises -> Series:
+        _not_implemented("DataFrame.skew")
+        return Series()
+
+    def kurt(self, axis: Int = 0, skipna: Bool = True) raises -> Series:
+        _not_implemented("DataFrame.kurt")
+        return Series()
+
+    def idxmin(self, axis: Int = 0, skipna: Bool = True) raises -> Series:
+        _not_implemented("DataFrame.idxmin")
+        return Series()
+
+    def idxmax(self, axis: Int = 0, skipna: Bool = True) raises -> Series:
+        _not_implemented("DataFrame.idxmax")
+        return Series()
+
+    def corr(self, method: String = "pearson", min_periods: Int = 1) raises -> DataFrame:
+        _not_implemented("DataFrame.corr")
+        return DataFrame()
+
+    def cov(self, min_periods: Int = 1, ddof: Int = 1) raises -> DataFrame:
+        _not_implemented("DataFrame.cov")
+        return DataFrame()
+
+    def shift(self, periods: Int = 1, axis: Int = 0) raises -> DataFrame:
+        _not_implemented("DataFrame.shift")
+        return DataFrame()
+
+    def diff(self, periods: Int = 1, axis: Int = 0) raises -> DataFrame:
+        _not_implemented("DataFrame.diff")
+        return DataFrame()
+
+    def pct_change(self, periods: Int = 1, axis: Int = 0) raises -> DataFrame:
+        _not_implemented("DataFrame.pct_change")
+        return DataFrame()
 
     def agg(self, func: String, axis: Int = 0) raises -> Series:
         _not_implemented("DataFrame.agg")

--- a/tests/test_aggregation.mojo
+++ b/tests/test_aggregation.mojo
@@ -614,5 +614,195 @@ def test_df_cummax_axis1_raises() raises:
         raise Error("DataFrame.cummax axis=1 should have raised")
 
 
+# ---------------------------------------------------------------------------
+# sem — stub
+# ---------------------------------------------------------------------------
+
+def test_series_sem_raises() raises:
+    var pd = Python.import_module("pandas")
+    var s = Series(pd.Series(Python.evaluate("[1.0, 2.0, 3.0]")))
+    var raised = False
+    try:
+        _ = s.sem()
+    except:
+        raised = True
+    if not raised:
+        raise Error("Series.sem should have raised")
+
+
+def test_df_sem_raises() raises:
+    var pd = Python.import_module("pandas")
+    var df = DataFrame(pd.DataFrame(Python.evaluate("{'a': [1.0, 2.0, 3.0]}")))
+    var raised = False
+    try:
+        _ = df.sem()
+    except:
+        raised = True
+    if not raised:
+        raise Error("DataFrame.sem should have raised")
+
+
+# ---------------------------------------------------------------------------
+# skew — stub
+# ---------------------------------------------------------------------------
+
+def test_series_skew_raises() raises:
+    var pd = Python.import_module("pandas")
+    var s = Series(pd.Series(Python.evaluate("[1.0, 2.0, 3.0]")))
+    var raised = False
+    try:
+        _ = s.skew()
+    except:
+        raised = True
+    if not raised:
+        raise Error("Series.skew should have raised")
+
+
+def test_df_skew_raises() raises:
+    var pd = Python.import_module("pandas")
+    var df = DataFrame(pd.DataFrame(Python.evaluate("{'a': [1.0, 2.0, 3.0]}")))
+    var raised = False
+    try:
+        _ = df.skew()
+    except:
+        raised = True
+    if not raised:
+        raise Error("DataFrame.skew should have raised")
+
+
+# ---------------------------------------------------------------------------
+# kurt — stub
+# ---------------------------------------------------------------------------
+
+def test_series_kurt_raises() raises:
+    var pd = Python.import_module("pandas")
+    var s = Series(pd.Series(Python.evaluate("[1.0, 2.0, 3.0]")))
+    var raised = False
+    try:
+        _ = s.kurt()
+    except:
+        raised = True
+    if not raised:
+        raise Error("Series.kurt should have raised")
+
+
+def test_df_kurt_raises() raises:
+    var pd = Python.import_module("pandas")
+    var df = DataFrame(pd.DataFrame(Python.evaluate("{'a': [1.0, 2.0, 3.0]}")))
+    var raised = False
+    try:
+        _ = df.kurt()
+    except:
+        raised = True
+    if not raised:
+        raise Error("DataFrame.kurt should have raised")
+
+
+# ---------------------------------------------------------------------------
+# idxmin / idxmax — stubs
+# ---------------------------------------------------------------------------
+
+def test_series_idxmin_raises() raises:
+    var pd = Python.import_module("pandas")
+    var s = Series(pd.Series(Python.evaluate("[3.0, 1.0, 2.0]")))
+    var raised = False
+    try:
+        _ = s.idxmin()
+    except:
+        raised = True
+    if not raised:
+        raise Error("Series.idxmin should have raised")
+
+
+def test_series_idxmax_raises() raises:
+    var pd = Python.import_module("pandas")
+    var s = Series(pd.Series(Python.evaluate("[3.0, 1.0, 2.0]")))
+    var raised = False
+    try:
+        _ = s.idxmax()
+    except:
+        raised = True
+    if not raised:
+        raise Error("Series.idxmax should have raised")
+
+
+def test_df_idxmin_raises() raises:
+    var pd = Python.import_module("pandas")
+    var df = DataFrame(pd.DataFrame(Python.evaluate("{'a': [3.0, 1.0, 2.0]}")))
+    var raised = False
+    try:
+        _ = df.idxmin()
+    except:
+        raised = True
+    if not raised:
+        raise Error("DataFrame.idxmin should have raised")
+
+
+def test_df_idxmax_raises() raises:
+    var pd = Python.import_module("pandas")
+    var df = DataFrame(pd.DataFrame(Python.evaluate("{'a': [3.0, 1.0, 2.0]}")))
+    var raised = False
+    try:
+        _ = df.idxmax()
+    except:
+        raised = True
+    if not raised:
+        raise Error("DataFrame.idxmax should have raised")
+
+
+# ---------------------------------------------------------------------------
+# corr / cov — stubs
+# ---------------------------------------------------------------------------
+
+def test_series_corr_raises() raises:
+    var pd = Python.import_module("pandas")
+    var s1 = Series(pd.Series(Python.evaluate("[1.0, 2.0, 3.0]")))
+    var s2 = Series(pd.Series(Python.evaluate("[4.0, 5.0, 6.0]")))
+    var raised = False
+    try:
+        _ = s1.corr(s2)
+    except:
+        raised = True
+    if not raised:
+        raise Error("Series.corr should have raised")
+
+
+def test_series_cov_raises() raises:
+    var pd = Python.import_module("pandas")
+    var s1 = Series(pd.Series(Python.evaluate("[1.0, 2.0, 3.0]")))
+    var s2 = Series(pd.Series(Python.evaluate("[4.0, 5.0, 6.0]")))
+    var raised = False
+    try:
+        _ = s1.cov(s2)
+    except:
+        raised = True
+    if not raised:
+        raise Error("Series.cov should have raised")
+
+
+def test_df_corr_raises() raises:
+    var pd = Python.import_module("pandas")
+    var df = DataFrame(pd.DataFrame(Python.evaluate("{'a': [1.0, 2.0, 3.0], 'b': [4.0, 5.0, 6.0]}")))
+    var raised = False
+    try:
+        _ = df.corr()
+    except:
+        raised = True
+    if not raised:
+        raise Error("DataFrame.corr should have raised")
+
+
+def test_df_cov_raises() raises:
+    var pd = Python.import_module("pandas")
+    var df = DataFrame(pd.DataFrame(Python.evaluate("{'a': [1.0, 2.0, 3.0], 'b': [4.0, 5.0, 6.0]}")))
+    var raised = False
+    try:
+        _ = df.cov()
+    except:
+        raised = True
+    if not raised:
+        raise Error("DataFrame.cov should have raised")
+
+
 def main() raises:
     TestSuite.discover_tests[__functions_in_module()]().run()

--- a/tests/test_transform.mojo
+++ b/tests/test_transform.mojo
@@ -1,0 +1,92 @@
+"""Tests transformation methods: shift, diff, pct_change."""
+from std.python import Python
+from testing import assert_true, TestSuite
+from bison import DataFrame, Series
+
+
+# ---------------------------------------------------------------------------
+# shift — stub
+# ---------------------------------------------------------------------------
+
+def test_series_shift_raises() raises:
+    var pd = Python.import_module("pandas")
+    var s = Series(pd.Series(Python.evaluate("[1.0, 2.0, 3.0]")))
+    var raised = False
+    try:
+        _ = s.shift()
+    except:
+        raised = True
+    if not raised:
+        raise Error("Series.shift should have raised")
+
+
+def test_df_shift_raises() raises:
+    var pd = Python.import_module("pandas")
+    var df = DataFrame(pd.DataFrame(Python.evaluate("{'a': [1.0, 2.0, 3.0]}")))
+    var raised = False
+    try:
+        _ = df.shift()
+    except:
+        raised = True
+    if not raised:
+        raise Error("DataFrame.shift should have raised")
+
+
+# ---------------------------------------------------------------------------
+# diff — stub
+# ---------------------------------------------------------------------------
+
+def test_series_diff_raises() raises:
+    var pd = Python.import_module("pandas")
+    var s = Series(pd.Series(Python.evaluate("[1.0, 2.0, 3.0]")))
+    var raised = False
+    try:
+        _ = s.diff()
+    except:
+        raised = True
+    if not raised:
+        raise Error("Series.diff should have raised")
+
+
+def test_df_diff_raises() raises:
+    var pd = Python.import_module("pandas")
+    var df = DataFrame(pd.DataFrame(Python.evaluate("{'a': [1.0, 2.0, 3.0]}")))
+    var raised = False
+    try:
+        _ = df.diff()
+    except:
+        raised = True
+    if not raised:
+        raise Error("DataFrame.diff should have raised")
+
+
+# ---------------------------------------------------------------------------
+# pct_change — stub
+# ---------------------------------------------------------------------------
+
+def test_series_pct_change_raises() raises:
+    var pd = Python.import_module("pandas")
+    var s = Series(pd.Series(Python.evaluate("[1.0, 2.0, 4.0]")))
+    var raised = False
+    try:
+        _ = s.pct_change()
+    except:
+        raised = True
+    if not raised:
+        raise Error("Series.pct_change should have raised")
+
+
+def test_df_pct_change_raises() raises:
+    var pd = Python.import_module("pandas")
+    var df = DataFrame(pd.DataFrame(Python.evaluate("{'a': [1.0, 2.0, 4.0]}")))
+    var raised = False
+    try:
+        _ = df.pct_change()
+    except:
+        raised = True
+    if not raised:
+        raise Error("DataFrame.pct_change should have raised")
+
+
+def main() raises:
+    TestSuite.discover_tests[__functions_in_module()]().run()


### PR DESCRIPTION
Closes #239, #240

## Summary

- Add `_not_implemented` stubs for `shift`, `diff`, `pct_change` on `Series` and `DataFrame` (issue #239)
- Add `_not_implemented` stubs for `sem`, `skew`, `kurt`, `idxmin`, `idxmax`, `corr`, `cov` on `Series` and `DataFrame` (issue #240)
- Add stub-raises tests in `test_aggregation.mojo` (stats methods) and a new `test_transform.mojo` (transformation methods)
- Regenerate compat table

## Test plan

- [ ] `pixi run test` — all 15 test files pass (365 new lines, 0 failures)
- [ ] `pixi run update-compat` — table regenerated