### PR TITLE
fix: remove unused n_out variable in melt()

### DIFF
--- a/bison/_frame.mojo
+++ b/bison/_frame.mojo
@@ -3097,7 +3097,6 @@ struct DataFrame(Copyable, Movable):
                     val_names.append(self._cols[j].name)
 
         var n_val = len(val_names)
-        var n_out = nrows * n_val
         var result_cols = List[Column]()
 
         # ID columns: repeat each id column n_val times (interleaved by row).


### PR DESCRIPTION
## Summary
- Removes the dead `var n_out = nrows * n_val` variable from `DataFrame.melt()` in `bison/_frame.mojo`
- The value was computed but never read; all output sizing is handled implicitly by the loop logic

## Test plan
- [x] All 46 existing tests pass (`pixi run test`)

Closes #250