### PR TITLE
feat: implement DataFrame.filter axis=0 row-label filtering

### DIFF
--- a/bison/_frame.mojo
+++ b/bison/_frame.mojo
@@ -1865,14 +1865,41 @@ struct DataFrame(Copyable, Movable):
         regex: String = "",
         axis: Int = 1,
     ) raises -> DataFrame:
-        """Select columns by label.
+        """Select columns (axis=1) or rows (axis=0) by label.
 
-        *items*: keep only columns whose name is in the list.
-        *like*:  keep columns whose name contains the substring.
-        *regex*: keep columns whose name matches the pattern (uses Python re).
+        *items*: keep only labels in the list.
+        *like*:  keep labels whose name contains the substring.
+        *regex*: keep labels whose name matches the pattern (uses Python re).
         """
-        if axis != 1:
-            raise Error("DataFrame.filter: axis=0 not yet implemented")
+        if axis == 0:
+            # Row filtering by index label.
+            if len(self._cols) == 0:
+                return self.copy()
+            var n_rows = self._cols[0].__len__()
+            var has_index = self._cols[0]._index_len() > 0
+            var keep_rows = List[Int]()
+            for i in range(n_rows):
+                var label = self._cols[0]._index_label(i) if has_index else String(i)
+                var keep = False
+                if items:
+                    ref items_list = items.value()
+                    for j in range(len(items_list)):
+                        if label == items_list[j]:
+                            keep = True
+                            break
+                elif like != "":
+                    keep = label.find(like) != -1
+                elif regex != "":
+                    var re_mod = Python.import_module("re")
+                    keep = Bool(re_mod.search(regex, label).__bool__())
+                else:
+                    keep = True
+                if keep:
+                    keep_rows.append(i)
+            var result_cols = List[Column]()
+            for ci in range(len(self._cols)):
+                result_cols.append(self._cols[ci].take(keep_rows))
+            return DataFrame(result_cols^)
         var result_cols = List[Column]()
         for i in range(len(self._cols)):
             var col_name = self._cols[i].name

--- a/tests/test_dataframe.mojo
+++ b/tests/test_dataframe.mojo
@@ -244,6 +244,43 @@ def test_filter_no_args_keeps_all() raises:
     assert_equal(result.shape()[1], 2)
 
 
+def test_filter_axis0_items() raises:
+    var pd = Python.import_module("pandas")
+    # DataFrame with a string index
+    var pdf = pd.DataFrame(
+        Python.evaluate("{'val': [10, 20, 30]}"),
+        index=Python.evaluate("['x', 'y', 'z']"),
+    )
+    var df = DataFrame(pdf)
+    var items = List[String]()
+    items.append("x")
+    items.append("z")
+    var result = df.filter(items=items^, axis=0)
+    assert_equal(result.shape()[0], 2)
+
+
+def test_filter_axis0_like() raises:
+    var pd = Python.import_module("pandas")
+    var pdf = pd.DataFrame(
+        Python.evaluate("{'val': [1, 2, 3]}"),
+        index=Python.evaluate("['foo_1', 'foo_2', 'bar']"),
+    )
+    var df = DataFrame(pdf)
+    var result = df.filter(like="foo", axis=0)
+    assert_equal(result.shape()[0], 2)
+
+
+def test_filter_axis0_regex() raises:
+    var pd = Python.import_module("pandas")
+    var pdf = pd.DataFrame(
+        Python.evaluate("{'val': [1, 2, 3]}"),
+        index=Python.evaluate("['a1', 'b2', 'c1']"),
+    )
+    var df = DataFrame(pdf)
+    var result = df.filter(regex=".*1$", axis=0)
+    assert_equal(result.shape()[0], 2)
+
+
 def test_select_dtypes_include() raises:
     var pd = Python.import_module("pandas")
     var df = DataFrame(pd.DataFrame(Python.evaluate("{'a': [1, 2], 'b': [1.0, 2.0]}")))


### PR DESCRIPTION
## Summary

- Implements `DataFrame.filter(axis=0)` natively: iterates the row index and applies `items`/`like`/`regex` filtering, then takes the matching rows via `Column.take`
- Replaces the bare `raise Error(...)` (which was invisible to the compat table) with actual working code
- Adds three new tests: `test_filter_axis0_items`, `test_filter_axis0_like`, `test_filter_axis0_regex`

Closes #244

## Test plan

- [ ] `pixi run test` — all 15 test files pass
- [ ] `test_filter_axis0_items` — filters rows by label list
- [ ] `test_filter_axis0_like` — filters rows by substring
- [ ] `test_filter_axis0_regex` — filters rows by regex pattern