### PR TITLE
feat: implement DataFrame.merge, join, and append

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ In CI it runs after the test suite and the result is committed back to the branc
 <!-- COMPAT_TABLE_START -->
 | Category | Stubs | Implemented |
 |----------|-------|-------------|
-| DataFrame | 45 | 87 |
+| DataFrame | 42 | 90 |
 | Series | 11 | 86 |
 | GroupBy (DataFrame) | 16 | 1 |
 | GroupBy (Series) | 15 | 1 |
@@ -91,7 +91,7 @@ In CI it runs after the test suite and the result is committed back to the branc
 | Index | 0 | 14 |
 | IO | 5 | 6 |
 | Reshape | 0 | 1 |
-| **Total** | **109** | **218** |
+| **Total** | **106** | **221** |
 <!-- COMPAT_TABLE_END -->
 
 ## Known limitations

--- a/bison/_frame.mojo
+++ b/bison/_frame.mojo
@@ -3607,8 +3607,42 @@ struct DataFrame(Copyable, Movable):
         right_index: Bool = False,
         suffixes: Optional[List[String]] = None,
     ) raises -> DataFrame:
-        _not_implemented("DataFrame.merge")
-        return DataFrame()
+        var left_pd = self.to_pandas()
+        var right_pd = right.to_pandas()
+        var py_none = Python.evaluate("None")
+
+        var py_on: PythonObject = py_none
+        if on:
+            py_on = Python.evaluate("[]")
+            for k in range(len(on.value())):
+                _ = py_on.append(on.value()[k])
+
+        var py_left_on: PythonObject = py_none
+        if left_on:
+            py_left_on = Python.evaluate("[]")
+            for k in range(len(left_on.value())):
+                _ = py_left_on.append(left_on.value()[k])
+
+        var py_right_on: PythonObject = py_none
+        if right_on:
+            py_right_on = Python.evaluate("[]")
+            for k in range(len(right_on.value())):
+                _ = py_right_on.append(right_on.value()[k])
+
+        # Default suffixes match pandas defaults.
+        var py_suf: PythonObject = Python.evaluate("('_x', '_y')")
+        if suffixes:
+            var suf = suffixes.value().copy()
+            var to_tuple = Python.evaluate("lambda a, b: (a, b)")
+            py_suf = to_tuple(suf[0], suf[1])
+
+        var merge_fn = Python.evaluate(
+            "lambda l, r, how, on, lo, ro, li, ri, suf:"
+            " l.merge(r, how=how, on=on, left_on=lo, right_on=ro,"
+            " left_index=li, right_index=ri, suffixes=suf)"
+        )
+        var result = merge_fn(left_pd, right_pd, how, py_on, py_left_on, py_right_on, left_index, right_index, py_suf)
+        return DataFrame.from_pandas(result)
 
     def join(
         self,
@@ -3619,12 +3653,31 @@ struct DataFrame(Copyable, Movable):
         rsuffix: String = "",
         sort: Bool = False,
     ) raises -> DataFrame:
-        _not_implemented("DataFrame.join")
-        return DataFrame()
+        var left_pd = self.to_pandas()
+        var other_pd = other.to_pandas()
+        var py_none = Python.evaluate("None")
+
+        var py_on: PythonObject = py_none
+        if on:
+            py_on = Python.evaluate("[]")
+            for k in range(len(on.value())):
+                _ = py_on.append(on.value()[k])
+
+        var join_fn = Python.evaluate(
+            "lambda l, r, on, how, lsuf, rsuf, sort:"
+            " l.join(r, on=on, how=how, lsuffix=lsuf, rsuffix=rsuf, sort=sort)"
+        )
+        var result = join_fn(left_pd, other_pd, py_on, how, lsuffix, rsuffix, sort)
+        return DataFrame.from_pandas(result)
 
     def append(self, other: DataFrame, ignore_index: Bool = False) raises -> DataFrame:
-        _not_implemented("DataFrame.append")
-        return DataFrame()
+        var pd = Python.import_module("pandas")
+        var py_list = Python.evaluate("[]")
+        _ = py_list.append(self.to_pandas())
+        _ = py_list.append(other.to_pandas())
+        var concat_fn = Python.evaluate("lambda frames, ig: __import__('pandas').concat(frames, ignore_index=ig)")
+        var result = concat_fn(py_list, ignore_index)
+        return DataFrame.from_pandas(result)
 
     # ------------------------------------------------------------------
     # GroupBy

--- a/tests/test_combining.mojo
+++ b/tests/test_combining.mojo
@@ -1,45 +1,116 @@
-"""Tests that combining stubs raise 'not implemented'."""
+"""Tests for DataFrame combining methods: merge, join, append."""
 from std.python import Python
-from testing import assert_true, TestSuite
+from testing import assert_true, assert_equal, TestSuite
 from bison import DataFrame
 
 
-def test_merge_stub() raises:
+def test_merge_inner_on_key() raises:
+    var pd = Python.import_module("pandas")
+    var left = DataFrame(pd.DataFrame(Python.evaluate("{'key': [1, 2, 3], 'a': [10, 20, 30]}")))
+    var right = DataFrame(pd.DataFrame(Python.evaluate("{'key': [1, 2, 4], 'b': [100, 200, 400]}")))
+    var on = List[String]()
+    on.append("key")
+    var result = left.merge(right, on=on^)
+    # inner join on key: rows with key 1 and 2 match
+    assert_equal(result.shape()[0], 2)
+    assert_equal(result.shape()[1], 3)  # key, a, b
+    var a_col = result["a"]
+    assert_equal(a_col.iloc(0)[Int64], Int64(10))
+    assert_equal(a_col.iloc(1)[Int64], Int64(20))
+
+
+def test_merge_left_join() raises:
     var pd = Python.import_module("pandas")
     var left = DataFrame(pd.DataFrame(Python.evaluate("{'key': [1, 2], 'a': [10, 20]}")))
-    var right = DataFrame(pd.DataFrame(Python.evaluate("{'key': [1, 2], 'b': [30, 40]}")))
-    var raised = False
-    try:
-        var on = List[String]()
-        on.append("key")
-        _ = left.merge(right, on=on^)
-    except:
-        raised = True
-    assert_true(raised)
+    var right = DataFrame(pd.DataFrame(Python.evaluate("{'key': [1], 'b': [100]}")))
+    var on = List[String]()
+    on.append("key")
+    var result = left.merge(right, how="left", on=on^)
+    # left join: both left rows kept, right row 2 gets NaN for b
+    assert_equal(result.shape()[0], 2)
 
 
-def test_join_stub() raises:
+def test_merge_outer_join() raises:
+    var pd = Python.import_module("pandas")
+    var left = DataFrame(pd.DataFrame(Python.evaluate("{'key': [1, 2], 'a': [10, 20]}")))
+    var right = DataFrame(pd.DataFrame(Python.evaluate("{'key': [2, 3], 'b': [200, 300]}")))
+    var on = List[String]()
+    on.append("key")
+    var result = left.merge(right, how="outer", on=on^)
+    # outer join: keys 1, 2, 3
+    assert_equal(result.shape()[0], 3)
+
+
+def test_merge_suffixes() raises:
+    var pd = Python.import_module("pandas")
+    var left = DataFrame(pd.DataFrame(Python.evaluate("{'key': [1, 2], 'val': [10, 20]}")))
+    var right = DataFrame(pd.DataFrame(Python.evaluate("{'key': [1, 2], 'val': [100, 200]}")))
+    var on = List[String]()
+    on.append("key")
+    var suf = List[String]()
+    suf.append("_left")
+    suf.append("_right")
+    var result = left.merge(right, on=on^, suffixes=Optional[List[String]](suf^))
+    var cols = result.columns()
+    var found_left = False
+    var found_right = False
+    for i in range(len(cols)):
+        if cols[i] == "val_left":
+            found_left = True
+        if cols[i] == "val_right":
+            found_right = True
+    assert_true(found_left)
+    assert_true(found_right)
+
+
+def test_join_basic() raises:
     var pd = Python.import_module("pandas")
     var left = DataFrame(pd.DataFrame(Python.evaluate("{'a': [1, 2]}")))
     var right = DataFrame(pd.DataFrame(Python.evaluate("{'b': [3, 4]}")))
-    var raised = False
-    try:
-        _ = left.join(right)
-    except:
-        raised = True
-    assert_true(raised)
+    var result = left.join(right)
+    assert_equal(result.shape()[0], 2)
+    assert_equal(result.shape()[1], 2)
+    var a_col = result["a"]
+    var b_col = result["b"]
+    assert_equal(a_col.iloc(0)[Int64], Int64(1))
+    assert_equal(b_col.iloc(0)[Int64], Int64(3))
 
 
-def test_append_stub() raises:
+def test_join_lsuffix_rsuffix() raises:
     var pd = Python.import_module("pandas")
-    var df1 = DataFrame(pd.DataFrame(Python.evaluate("{'a': [1]}")))
-    var df2 = DataFrame(pd.DataFrame(Python.evaluate("{'a': [2]}")))
-    var raised = False
-    try:
-        _ = df1.append(df2)
-    except:
-        raised = True
-    assert_true(raised)
+    var left = DataFrame(pd.DataFrame(Python.evaluate("{'x': [1, 2]}")))
+    var right = DataFrame(pd.DataFrame(Python.evaluate("{'x': [3, 4]}")))
+    var result = left.join(right, lsuffix="_l", rsuffix="_r")
+    var cols = result.columns()
+    var found_l = False
+    var found_r = False
+    for i in range(len(cols)):
+        if cols[i] == "x_l":
+            found_l = True
+        if cols[i] == "x_r":
+            found_r = True
+    assert_true(found_l)
+    assert_true(found_r)
+
+
+def test_append_basic() raises:
+    var pd = Python.import_module("pandas")
+    var df1 = DataFrame(pd.DataFrame(Python.evaluate("{'a': [1, 2]}")))
+    var df2 = DataFrame(pd.DataFrame(Python.evaluate("{'a': [3, 4]}")))
+    var result = df1.append(df2)
+    assert_equal(result.shape()[0], 4)
+    assert_equal(result.shape()[1], 1)
+
+
+def test_append_ignore_index() raises:
+    var pd = Python.import_module("pandas")
+    var df1 = DataFrame(pd.DataFrame(Python.evaluate("{'n': [10]}")))
+    var df2 = DataFrame(pd.DataFrame(Python.evaluate("{'n': [20]}")))
+    var result = df1.append(df2, ignore_index=True)
+    assert_equal(result.shape()[0], 2)
+    var col = result["n"]
+    assert_equal(col.iloc(0)[Int64], Int64(10))
+    assert_equal(col.iloc(1)[Int64], Int64(20))
 
 
 def main() raises:


### PR DESCRIPTION
## Summary

- Implements `DataFrame.merge` (inner/left/right/outer joins on columns or index, with `on`/`left_on`/`right_on`/`suffixes`)
- Implements `DataFrame.join` (index-based join with `lsuffix`, `rsuffix`, `how`, `sort`)
- Implements `DataFrame.append` (row stacking with `ignore_index`, delegates to `pd.concat`)

All three use the pandas bridge (`to_pandas()` → pandas call → `from_pandas()`). Python lambda wrappers are used to pass keyword arguments since `**` dict unpacking is not yet supported in Mojo's Python interop.

Closes #11.

## Test plan

- [ ] `test_merge_inner_on_key` — inner join, checks row count and values
- [ ] `test_merge_left_join` — left join preserves all left rows
- [ ] `test_merge_outer_join` — outer join includes all keys
- [ ] `test_merge_suffixes` — custom suffixes appear in output columns
- [ ] `test_join_basic` — side-by-side column join
- [ ] `test_join_lsuffix_rsuffix` — conflicting column names disambiguated
- [ ] `test_append_basic` — rows stacked correctly
- [ ] `test_append_ignore_index` — reset index on append
- [ ] Full suite: `pixi run test` — 148/148 pass