### PR TITLE
feat: implement DataFrame functional methods (#3)

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ In CI it runs after the test suite and the result is committed back to the branc
 <!-- COMPAT_TABLE_START -->
 | Category | Stubs | Implemented |
 |----------|-------|-------------|
-| DataFrame | 42 | 90 |
+| DataFrame | 39 | 93 |
 | Series | 11 | 86 |
 | GroupBy (DataFrame) | 16 | 1 |
 | GroupBy (Series) | 15 | 1 |
@@ -91,7 +91,7 @@ In CI it runs after the test suite and the result is committed back to the branc
 | Index | 0 | 14 |
 | IO | 5 | 6 |
 | Reshape | 0 | 1 |
-| **Total** | **106** | **221** |
+| **Total** | **103** | **224** |
 <!-- COMPAT_TABLE_END -->
 
 ## Known limitations

--- a/bison/_frame.mojo
+++ b/bison/_frame.mojo
@@ -2086,8 +2086,10 @@ struct DataFrame(Copyable, Movable):
         return Series(result_col^)
 
     def abs(self) raises -> DataFrame:
-        _not_implemented("DataFrame.abs")
-        return DataFrame()
+        var result_cols = List[Column]()
+        for i in range(len(self._cols)):
+            result_cols.append(self._cols[i]._abs())
+        return DataFrame(result_cols^)
 
     def cumsum(self, axis: Int = 0, skipna: Bool = True) raises -> DataFrame:
         if axis != 0:
@@ -2162,14 +2164,41 @@ struct DataFrame(Copyable, Movable):
         return DataFrame()
 
     def agg(self, func: String, axis: Int = 0) raises -> Series:
-        _not_implemented("DataFrame.agg")
-        return Series()
+        if axis != 0:
+            _not_implemented("DataFrame.agg")
+        if func == "sum":
+            return self.sum()
+        elif func == "mean":
+            return self.mean()
+        elif func == "median":
+            return self.median()
+        elif func == "min":
+            return self.min()
+        elif func == "max":
+            return self.max()
+        elif func == "std":
+            return self.std()
+        elif func == "var":
+            return self.var()
+        elif func == "count":
+            return self.count()
+        elif func == "nunique":
+            return self.nunique()
+        else:
+            raise Error(
+                "DataFrame.agg: unsupported aggregation '" + func
+                + "'. Supported: sum, mean, median, min, max, std, var, count, nunique"
+            )
 
     def aggregate(self, func: String, axis: Int = 0) raises -> Series:
-        _not_implemented("DataFrame.aggregate")
-        return Series()
+        return self.agg(func, axis)
 
     def apply(self, func: String, axis: Int = 0) raises -> DataFrame:
+        if axis == 0:
+            raise Error(
+                "DataFrame.apply: axis=0 string aggregation returns a Series — "
+                "use DataFrame.agg(func) instead"
+            )
         _not_implemented("DataFrame.apply")
         return DataFrame()
 
@@ -2178,16 +2207,36 @@ struct DataFrame(Copyable, Movable):
         return DataFrame()
 
     def transform(self, func: String, axis: Int = 0) raises -> DataFrame:
+        if axis != 0:
+            _not_implemented("DataFrame.transform")
+        if func == "abs":
+            return self.abs()
         _not_implemented("DataFrame.transform")
         return DataFrame()
 
     def eval(self, expr: String) raises -> Series:
-        _not_implemented("DataFrame.eval")
-        return Series()
+        var pd_df = self.to_pandas()
+        # Use module-level pd.eval() with an explicit local_dict so that pandas
+        # skips its sys._getframe() caller-scope resolution, which fails when
+        # called from Mojo's shallow Python call stack.
+        var eval_fn = Python.evaluate(
+            "lambda df, e: __import__('pandas').eval("
+            "e, local_dict={c: df[c] for c in df.columns}, engine='python')"
+        )
+        var result = eval_fn(pd_df, expr)
+        return Series.from_pandas(result)
 
     def query(self, expr: String) raises -> DataFrame:
-        _not_implemented("DataFrame.query")
-        return DataFrame()
+        var pd_df = self.to_pandas()
+        # Filter via module-level pd.eval() with explicit local_dict to avoid
+        # sys._getframe() failures when called from Mojo's shallow call stack.
+        var query_fn = Python.evaluate(
+            "lambda df, e: df.loc["
+            "__import__('pandas').eval("
+            "e, local_dict={c: df[c] for c in df.columns}, engine='python')]"
+        )
+        var result = query_fn(pd_df, expr)
+        return DataFrame.from_pandas(result)
 
     def pipe(self, func: String) raises -> DataFrame:
         _not_implemented("DataFrame.pipe")

--- a/tests/test_functional.mojo
+++ b/tests/test_functional.mojo
@@ -1,0 +1,208 @@
+"""Tests functional methods: abs, agg, aggregate, apply, transform, eval, query, pipe, applymap."""
+from std.python import Python
+from testing import assert_true, TestSuite
+from bison import DataFrame, Series
+
+
+# ---------------------------------------------------------------------------
+# abs
+# ---------------------------------------------------------------------------
+
+def test_df_abs() raises:
+    var pd = Python.import_module("pandas")
+    var testing = Python.import_module("pandas.testing")
+    var pd_df = pd.DataFrame(Python.evaluate("{'a': [-1, -2, 3], 'b': [4.0, -5.0, -6.0]}"))
+    var df = DataFrame(pd_df)
+    var result_pd = df.abs().to_pandas()
+    var expected_pd = pd_df.abs()
+    testing.assert_frame_equal(result_pd, expected_pd)
+
+
+# ---------------------------------------------------------------------------
+# agg / aggregate
+# ---------------------------------------------------------------------------
+
+def test_df_agg_sum() raises:
+    var pd = Python.import_module("pandas")
+    var pd_df = pd.DataFrame(Python.evaluate("{'a': [1, 2, 3], 'b': [4, 5, 6]}"))
+    var df = DataFrame(pd_df)
+    var result_pd = df.agg("sum").to_pandas()
+    assert_true(Float64(String(result_pd.iloc[0])) == 6.0)
+    assert_true(Float64(String(result_pd.iloc[1])) == 15.0)
+
+
+def test_df_agg_mean() raises:
+    var pd = Python.import_module("pandas")
+    var pd_df = pd.DataFrame(Python.evaluate("{'a': [1.0, 2.0, 3.0], 'b': [4.0, 5.0, 6.0]}"))
+    var df = DataFrame(pd_df)
+    var result_pd = df.agg("mean").to_pandas()
+    assert_true(Float64(String(result_pd.iloc[0])) == 2.0)
+    assert_true(Float64(String(result_pd.iloc[1])) == 5.0)
+
+
+def test_df_agg_min() raises:
+    var pd = Python.import_module("pandas")
+    var pd_df = pd.DataFrame(Python.evaluate("{'a': [3, 1, 2]}"))
+    var df = DataFrame(pd_df)
+    var result_pd = df.agg("min").to_pandas()
+    assert_true(Float64(String(result_pd.iloc[0])) == 1.0)
+
+
+def test_df_agg_max() raises:
+    var pd = Python.import_module("pandas")
+    var pd_df = pd.DataFrame(Python.evaluate("{'a': [3, 1, 2]}"))
+    var df = DataFrame(pd_df)
+    var result_pd = df.agg("max").to_pandas()
+    assert_true(Float64(String(result_pd.iloc[0])) == 3.0)
+
+
+def test_df_agg_count() raises:
+    var pd = Python.import_module("pandas")
+    var pd_df = pd.DataFrame(Python.evaluate("{'a': [1, 2, 3], 'b': [4, 5, 6]}"))
+    var df = DataFrame(pd_df)
+    var result_pd = df.agg("count").to_pandas()
+    assert_true(Float64(String(result_pd.iloc[0])) == 3.0)
+    assert_true(Float64(String(result_pd.iloc[1])) == 3.0)
+
+
+def test_df_agg_unknown_raises() raises:
+    var pd = Python.import_module("pandas")
+    var df = DataFrame(pd.DataFrame(Python.evaluate("{'a': [1, 2, 3]}")))
+    var raised = False
+    try:
+        _ = df.agg("foo")
+    except:
+        raised = True
+    if not raised:
+        raise Error("DataFrame.agg with unknown func should have raised")
+
+
+def test_df_aggregate_delegates() raises:
+    var pd = Python.import_module("pandas")
+    var testing = Python.import_module("pandas.testing")
+    var pd_df = pd.DataFrame(Python.evaluate("{'a': [1, 2, 3], 'b': [4, 5, 6]}"))
+    var df = DataFrame(pd_df)
+    var agg_pd = df.agg("sum").to_pandas()
+    var aggregate_pd = df.aggregate("sum").to_pandas()
+    testing.assert_series_equal(agg_pd, aggregate_pd)
+
+
+# ---------------------------------------------------------------------------
+# apply
+# ---------------------------------------------------------------------------
+
+def test_df_apply_axis0_raises_redirect() raises:
+    var pd = Python.import_module("pandas")
+    var df = DataFrame(pd.DataFrame(Python.evaluate("{'a': [1, 2, 3]}")))
+    var raised = False
+    var msg = String("")
+    try:
+        _ = df.apply("sum", axis=0)
+    except e:
+        raised = True
+        msg = String(e)
+    if not raised:
+        raise Error("DataFrame.apply axis=0 should have raised")
+    assert_true("agg" in msg)
+
+
+def test_df_apply_axis1_not_implemented() raises:
+    var pd = Python.import_module("pandas")
+    var df = DataFrame(pd.DataFrame(Python.evaluate("{'a': [1, 2, 3]}")))
+    var raised = False
+    try:
+        _ = df.apply("sum", axis=1)
+    except:
+        raised = True
+    if not raised:
+        raise Error("DataFrame.apply axis=1 should have raised")
+
+
+# ---------------------------------------------------------------------------
+# transform
+# ---------------------------------------------------------------------------
+
+def test_df_transform_abs() raises:
+    var pd = Python.import_module("pandas")
+    var testing = Python.import_module("pandas.testing")
+    var pd_df = pd.DataFrame(Python.evaluate("{'a': [-1, -2, 3], 'b': [4.0, -5.0, -6.0]}"))
+    var df = DataFrame(pd_df)
+    var result_pd = df.transform("abs").to_pandas()
+    var expected_pd = pd_df.abs()
+    testing.assert_frame_equal(result_pd, expected_pd)
+
+
+def test_df_transform_unknown_raises() raises:
+    var pd = Python.import_module("pandas")
+    var df = DataFrame(pd.DataFrame(Python.evaluate("{'a': [1.0, 2.0, 3.0]}")))
+    var raised = False
+    try:
+        _ = df.transform("log")
+    except:
+        raised = True
+    if not raised:
+        raise Error("DataFrame.transform with unsupported func should have raised")
+
+
+# ---------------------------------------------------------------------------
+# eval
+# ---------------------------------------------------------------------------
+
+def test_df_eval_simple() raises:
+    var pd = Python.import_module("pandas")
+    var pd_df = pd.DataFrame(Python.evaluate("{'a': [1, 2, 3], 'b': [10, 20, 30]}"))
+    var df = DataFrame(pd_df)
+    var result = df.eval("a + b")
+    # Expected: element-wise sum a+b = [11, 22, 33]
+    assert_true(Float64(String(result.to_pandas().iloc[0])) == 11.0)
+    assert_true(Float64(String(result.to_pandas().iloc[1])) == 22.0)
+    assert_true(Float64(String(result.to_pandas().iloc[2])) == 33.0)
+
+
+# ---------------------------------------------------------------------------
+# query
+# ---------------------------------------------------------------------------
+
+def test_df_query_simple() raises:
+    var pd = Python.import_module("pandas")
+    var pd_df = pd.DataFrame(Python.evaluate("{'a': [1, 2, 3, 4], 'b': [10, 20, 30, 40]}"))
+    var df = DataFrame(pd_df)
+    var result = df.query("a > 2")
+    # Expected: rows where a > 2, i.e., a=[3,4] and b=[30,40]
+    assert_true(result.shape()[0] == 2)
+    assert_true(result.shape()[1] == 2)
+    var a_col_pd = result["a"].to_pandas()
+    assert_true(Float64(String(a_col_pd.iloc[0])) == 3.0)
+    assert_true(Float64(String(a_col_pd.iloc[1])) == 4.0)
+
+
+# ---------------------------------------------------------------------------
+# pipe / applymap — still stubs
+# ---------------------------------------------------------------------------
+
+def test_df_pipe_raises() raises:
+    var pd = Python.import_module("pandas")
+    var df = DataFrame(pd.DataFrame(Python.evaluate("{'a': [1, 2, 3]}")))
+    var raised = False
+    try:
+        _ = df.pipe("some_fn")
+    except:
+        raised = True
+    if not raised:
+        raise Error("DataFrame.pipe should have raised")
+
+
+def test_df_applymap_raises() raises:
+    var pd = Python.import_module("pandas")
+    var df = DataFrame(pd.DataFrame(Python.evaluate("{'a': [1, 2, 3]}")))
+    var raised = False
+    try:
+        _ = df.applymap("str")
+    except:
+        raised = True
+    if not raised:
+        raise Error("DataFrame.applymap should have raised")
+
+
+def main() raises:
+    TestSuite.discover_tests[__functions_in_module()]().run()


### PR DESCRIPTION
## Summary

- **`DataFrame.abs`** — fixed a lingering stub; delegates to `Column._abs()` following the `cumsum` pattern
- **`DataFrame.agg` / `aggregate`** — native string dispatch over 9 aggregation functions (sum, mean, median, min, max, std, var, count, nunique); unknown strings raise with a helpful list; `aggregate` is a one-liner delegate
- **`DataFrame.apply`** — axis=0 raises a redirect to `agg` (return-type mismatch tracked in #266); axis=1 keeps `_not_implemented`
- **`DataFrame.transform`** — "abs" delegates to `self.abs()`; all other strings remain `_not_implemented`
- **`DataFrame.eval`** — pandas bridge via module-level `pd.eval()` with an explicit `local_dict` dict comprehension, avoiding `sys._getframe()` failures from Mojo's shallow Python call stack (see #267)
- **`DataFrame.query`** — same bridge approach using `df.loc[pd.eval(...)]`
- **`DataFrame.pipe`, `applymap`** — kept as stubs (`func: String` has no viable runtime callable mapping in Mojo)
- **`tests/test_functional.mojo`** — new test file; 16 tests, all passing

## Test plan

- [ ] `mojo run tests/test_functional.mojo` — 16/16 pass
- [ ] `pixi run test` — 148/148 pass across all 16 test files
- [ ] `pixi run update-compat` — README table updated (DataFrame stubs: 39 → previously higher)

Closes #3