### PR TITLE
fix: replace bare raise Error() stubs with _not_implemented() (#256)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,3 +7,11 @@ repos:
       - id: check-yaml
       - id: check-toml
       - id: check-merge-conflict
+  - repo: local
+    hooks:
+      - id: no-bare-raise-stubs
+        name: "no bare raise Error() stubs (use _not_implemented)"
+        language: pygrep
+        entry: 'raise Error\([^)]*not.yet.implemented[^)]*\)'
+        files: ^bison/.*\.mojo$
+        types: [file]

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ In CI it runs after the test suite and the result is committed back to the branc
 <!-- COMPAT_TABLE_START -->
 | Category | Stubs | Implemented |
 |----------|-------|-------------|
-| DataFrame | 39 | 93 |
+| DataFrame | 40 | 92 |
 | Series | 11 | 86 |
 | GroupBy (DataFrame) | 16 | 1 |
 | GroupBy (Series) | 15 | 1 |
@@ -90,8 +90,8 @@ In CI it runs after the test suite and the result is committed back to the branc
 | Datetime accessor | 17 | 1 |
 | Index | 0 | 14 |
 | IO | 5 | 6 |
-| Reshape | 0 | 1 |
-| **Total** | **103** | **224** |
+| Reshape | 1 | 0 |
+| **Total** | **105** | **222** |
 <!-- COMPAT_TABLE_END -->
 
 ## Known limitations

--- a/bison/_frame.mojo
+++ b/bison/_frame.mojo
@@ -2194,11 +2194,6 @@ struct DataFrame(Copyable, Movable):
         return self.agg(func, axis)
 
     def apply(self, func: String, axis: Int = 0) raises -> DataFrame:
-        if axis == 0:
-            raise Error(
-                "DataFrame.apply: axis=0 string aggregation returns a Series — "
-                "use DataFrame.agg(func) instead"
-            )
         _not_implemented("DataFrame.apply")
         return DataFrame()
 
@@ -3491,11 +3486,7 @@ struct DataFrame(Copyable, Movable):
         deep copy.
         """
         if not deep:
-            raise Error(
-                "DataFrame.copy: deep=False is not yet supported; Mojo's"
-                " ownership model requires reference-counted storage for"
-                " shallow copies"
-            )
+            _not_implemented("DataFrame.copy")
         return self._deep_copy()
 
     def assign(self, cols: Dict[String, Series]) raises -> DataFrame:

--- a/bison/reshape/_concat.mojo
+++ b/bison/reshape/_concat.mojo
@@ -3,6 +3,7 @@ from std.collections import Optional
 from ..dataframe import DataFrame, _sort_col_names
 from ..column import Column, ColumnData
 from ..dtypes import BisonDtype, int64, float64, bool_, object_
+from .._errors import _not_implemented
 
 
 # ------------------------------------------------------------------
@@ -379,7 +380,7 @@ def concat(
         return DataFrame()
 
     if keys:
-        raise Error("concat: the 'keys' parameter (hierarchical index) is not yet implemented")
+        _not_implemented("concat")
 
     if axis == 1:
         return _concat_axis1(objs, join, ignore_index, sort)

--- a/tests/test_functional.mojo
+++ b/tests/test_functional.mojo
@@ -103,7 +103,7 @@ def test_df_apply_axis0_raises_redirect() raises:
         msg = String(e)
     if not raised:
         raise Error("DataFrame.apply axis=0 should have raised")
-    assert_true("agg" in msg)
+    assert_true("not implemented" in msg)
 
 
 def test_df_apply_axis1_not_implemented() raises:


### PR DESCRIPTION
## Summary

- Three stub branches (`DataFrame.apply` axis=0, `DataFrame.copy` deep=False, `concat` keys) used raw `raise Error()` and were invisible to `update_compat.py`
- Replaced each with `_not_implemented()` and added the missing import in `_concat.mojo`
- Added a `pygrep` pre-commit hook to catch future regressions

## Changes

- `bison/_frame.mojo` — `DataFrame.apply` axis=0 and `DataFrame.copy` deep=False now use `_not_implemented()`
- `bison/reshape/_concat.mojo` — import added; `concat` keys branch uses `_not_implemented("concat")`
- `tests/test_functional.mojo` — apply axis=0 test updated to assert `"not implemented"` in error message
- `.pre-commit-config.yaml` — new `no-bare-raise-stubs` pygrep hook
- `README.md` — compat table regenerated (Reshape now shows 1 stub)

Closes #256

## Test plan

- [x] `pixi run test` — 16/16 passed, 0 failed
- [x] `pixi run update-compat` — table updated cleanly