### PR TITLE
fix: add _Null sentinel arm to DFScalar, eliminating null ambiguity

### DIFF
--- a/bison/_frame.mojo
+++ b/bison/_frame.mojo
@@ -3,7 +3,7 @@ from std.collections import Optional, Dict
 from ._errors import _not_implemented
 from .dtypes import BisonDtype, object_, bool_, int64, float64, dtype_from_string
 from .index import Index, ColumnIndex
-from .column import Column, ColumnData, DFScalar, SeriesScalar, FloatTransformFn, _csv_quote_field, _col_cell_str, _col_cell_pyobj
+from .column import Column, ColumnData, DFScalar, SeriesScalar, _Null, FloatTransformFn, _csv_quote_field, _col_cell_str, _col_cell_pyobj
 from .accessors.str_accessor import StringMethods
 from .accessors.dt_accessor import DatetimeMethods
 
@@ -1147,9 +1147,8 @@ struct Series(Copyable, Movable):
     def to_list(self) raises -> List[DFScalar]:
         """Return the Series values as a ``List[DFScalar]``.
 
-        Null values are represented as the zero-like default for the dtype
-        (``0`` for integers, ``NaN`` for floats, ``False`` for bools,
-        ``""`` for strings).  Object-dtype columns raise ``Error``.
+        Null values are represented as ``DFScalar.null()``.
+        Object-dtype columns raise ``Error``.
         """
         var result = List[DFScalar]()
         ref col = self._col
@@ -1159,29 +1158,28 @@ struct Series(Copyable, Movable):
             ref data = col._data[List[Int64]]
             for i in range(n):
                 if has_mask and col._null_mask[i]:
-                    result.append(DFScalar(Int64(0)))
+                    result.append(DFScalar.null())
                 else:
                     result.append(DFScalar(data[i]))
         elif col._data.isa[List[Float64]]():
-            var nan = Float64(0) / Float64(0)
             ref data = col._data[List[Float64]]
             for i in range(n):
                 if has_mask and col._null_mask[i]:
-                    result.append(DFScalar(nan))
+                    result.append(DFScalar.null())
                 else:
                     result.append(DFScalar(data[i]))
         elif col._data.isa[List[Bool]]():
             ref data = col._data[List[Bool]]
             for i in range(n):
                 if has_mask and col._null_mask[i]:
-                    result.append(DFScalar(False))
+                    result.append(DFScalar.null())
                 else:
                     result.append(DFScalar(data[i]))
         elif col._data.isa[List[String]]():
             ref data = col._data[List[String]]
             for i in range(n):
                 if has_mask and col._null_mask[i]:
-                    result.append(DFScalar(String("")))
+                    result.append(DFScalar.null())
                 else:
                     result.append(DFScalar(data[i]))
         else:
@@ -1247,8 +1245,8 @@ struct Series(Copyable, Movable):
     def to_dict(self) raises -> Dict[String, DFScalar]:
         """Return the Series as a ``Dict`` mapping index label → value.
 
-        Index labels are stringified.  Null values follow the same zero-like
-        defaults as ``to_list``.  Object-dtype columns raise ``Error``.
+        Index labels are stringified.  Null values are represented as
+        ``DFScalar.null()``.  Object-dtype columns raise ``Error``.
         """
         var result = Dict[String, DFScalar]()
         ref col = self._col
@@ -1260,16 +1258,15 @@ struct Series(Copyable, Movable):
             for i in range(n):
                 var key = col._index_label(i) if has_index else String(i)
                 if has_mask and col._null_mask[i]:
-                    result[key] = DFScalar(Int64(0))
+                    result[key] = DFScalar.null()
                 else:
                     result[key] = DFScalar(data[i])
         elif col._data.isa[List[Float64]]():
-            var nan = Float64(0) / Float64(0)
             ref data = col._data[List[Float64]]
             for i in range(n):
                 var key = col._index_label(i) if has_index else String(i)
                 if has_mask and col._null_mask[i]:
-                    result[key] = DFScalar(nan)
+                    result[key] = DFScalar.null()
                 else:
                     result[key] = DFScalar(data[i])
         elif col._data.isa[List[Bool]]():
@@ -1277,7 +1274,7 @@ struct Series(Copyable, Movable):
             for i in range(n):
                 var key = col._index_label(i) if has_index else String(i)
                 if has_mask and col._null_mask[i]:
-                    result[key] = DFScalar(False)
+                    result[key] = DFScalar.null()
                 else:
                     result[key] = DFScalar(data[i])
         elif col._data.isa[List[String]]():
@@ -1285,7 +1282,7 @@ struct Series(Copyable, Movable):
             for i in range(n):
                 var key = col._index_label(i) if has_index else String(i)
                 if has_mask and col._null_mask[i]:
-                    result[key] = DFScalar(String(""))
+                    result[key] = DFScalar.null()
                 else:
                     result[key] = DFScalar(data[i])
         else:
@@ -1545,8 +1542,9 @@ struct DataFrame(Copyable, Movable):
                         has_float = True
                     elif v.isa[Bool]():
                         has_bool = True
-                    else:  # String
+                    elif v.isa[String]():
                         has_string = True
+                    # _Null arm: contributes no type info, but row exists
                     found = True
                 except:
                     pass
@@ -1569,6 +1567,10 @@ struct DataFrame(Copyable, Movable):
                 for ri in range(len(records)):
                     try:
                         var v = records[ri][col_name]
+                        if v.is_null():
+                            data.append(String(""))
+                            null_mask.append(True)
+                            continue
                         var val: String
                         if v.isa[String]():
                             val = v[String]
@@ -1592,6 +1594,10 @@ struct DataFrame(Copyable, Movable):
                 for ri in range(len(records)):
                     try:
                         var v = records[ri][col_name]
+                        if v.is_null():
+                            data.append(Float64(0.0))
+                            null_mask.append(True)
+                            continue
                         var val: Float64
                         if v.isa[Float64]():
                             val = v[Float64]
@@ -1614,6 +1620,11 @@ struct DataFrame(Copyable, Movable):
                 for ri in range(len(records)):
                     try:
                         var v = records[ri][col_name]
+                        if v.is_null():
+                            data.append(Int64(0))
+                            null_mask.append(True)
+                            has_nulls = True
+                            continue
                         var val: Int64
                         if v.isa[Int64]():
                             val = v[Int64]
@@ -1643,6 +1654,11 @@ struct DataFrame(Copyable, Movable):
                 for ri in range(len(records)):
                     try:
                         var v = records[ri][col_name]
+                        if v.is_null():
+                            data.append(False)
+                            null_mask.append(True)
+                            has_nulls = True
+                            continue
                         data.append(v[Bool])
                         null_mask.append(False)
                     except:
@@ -3935,7 +3951,6 @@ struct DataFrame(Copyable, Movable):
         var result = Dict[String, List[DFScalar]]()
         var nrows = self.__len__()
         var ncols = self._cols.__len__()
-        var nan = Float64(0) / Float64(0)
         for ci in range(ncols):
             ref col = self._cols[ci]
             var values = List[DFScalar]()
@@ -3944,35 +3959,35 @@ struct DataFrame(Copyable, Movable):
                 ref data = col._data[List[Int64]]
                 for i in range(nrows):
                     if has_mask and col._null_mask[i]:
-                        values.append(DFScalar(Int64(0)))
+                        values.append(DFScalar.null())
                     else:
                         values.append(DFScalar(data[i]))
             elif col._data.isa[List[Float64]]():
                 ref data = col._data[List[Float64]]
                 for i in range(nrows):
                     if has_mask and col._null_mask[i]:
-                        values.append(DFScalar(nan))
+                        values.append(DFScalar.null())
                     else:
                         values.append(DFScalar(data[i]))
             elif col._data.isa[List[Bool]]():
                 ref data = col._data[List[Bool]]
                 for i in range(nrows):
                     if has_mask and col._null_mask[i]:
-                        values.append(DFScalar(False))
+                        values.append(DFScalar.null())
                     else:
                         values.append(DFScalar(data[i]))
             elif col._data.isa[List[String]]():
                 ref data = col._data[List[String]]
                 for i in range(nrows):
                     if has_mask and col._null_mask[i]:
-                        values.append(DFScalar(String("")))
+                        values.append(DFScalar.null())
                     else:
                         values.append(DFScalar(data[i]))
             else:
                 ref data = col._data[List[PythonObject]]
                 for i in range(nrows):
                     if has_mask and col._null_mask[i]:
-                        values.append(DFScalar(String("")))
+                        values.append(DFScalar.null())
                     else:
                         values.append(DFScalar(String(data[i])))
             result[col.name] = values^
@@ -3992,7 +4007,6 @@ struct DataFrame(Copyable, Movable):
         var result = List[Dict[String, DFScalar]]()
         var nrows = self.__len__()
         var ncols = self._cols.__len__()
-        var nan = Float64(0) / Float64(0)
         for ri in range(nrows):
             var row = Dict[String, DFScalar]()
             if index:
@@ -4001,14 +4015,7 @@ struct DataFrame(Copyable, Movable):
                 ref col = self._cols[ci]
                 var has_mask = len(col._null_mask) > 0
                 if has_mask and ri < len(col._null_mask) and col._null_mask[ri]:
-                    if col._data.isa[List[Int64]]():
-                        row[col.name] = DFScalar(Int64(0))
-                    elif col._data.isa[List[Float64]]():
-                        row[col.name] = DFScalar(nan)
-                    elif col._data.isa[List[Bool]]():
-                        row[col.name] = DFScalar(False)
-                    else:
-                        row[col.name] = DFScalar(String(""))
+                    row[col.name] = DFScalar.null()
                 elif col._data.isa[List[Int64]]():
                     row[col.name] = DFScalar(col._data[List[Int64]][ri])
                 elif col._data.isa[List[Float64]]():

--- a/bison/column.mojo
+++ b/bison/column.mojo
@@ -28,41 +28,62 @@ comptime ColumnData = Variant[
     List[PythonObject],
 ]
 
+# Sentinel type for a null / missing cell in DFScalar.
+struct _Null(Copyable, Movable, ImplicitlyCopyable):
+    """Sentinel for a missing / null cell in DFScalar."""
+
+    def __init__(out self):
+        pass
+
 # Scalar type for a single cell in row-oriented input (from_records).
 # No PythonObject arm — record values must be explicitly typed.
 #
 # Implemented as a thin struct rather than a bare Variant alias so that
 # Int (Mojo's native integer type) implicitly converts to Int64 at
-# construction time.  All four typed arms plus Int are accepted; Int is
-# normalised to Int64 immediately, so dispatch sites only ever see Int64.
+# construction time.  All four typed arms plus Int and _Null are accepted;
+# Int is normalised to Int64 immediately, so dispatch sites only ever see
+# Int64.  Use DFScalar.null() / is_null() to represent missing values.
 struct DFScalar(Copyable, Movable, ImplicitlyCopyable):
-    var _v: Variant[Int64, Float64, Bool, String]
+    var _v: Variant[Int64, Float64, Bool, String, _Null]
 
     @implicit
     def __init__(out self, value: Int64):
-        self._v = Variant[Int64, Float64, Bool, String](value)
+        self._v = Variant[Int64, Float64, Bool, String, _Null](value)
 
     @implicit
     def __init__(out self, value: Float64):
-        self._v = Variant[Int64, Float64, Bool, String](value)
+        self._v = Variant[Int64, Float64, Bool, String, _Null](value)
 
     @implicit
     def __init__(out self, value: Bool):
-        self._v = Variant[Int64, Float64, Bool, String](value)
+        self._v = Variant[Int64, Float64, Bool, String, _Null](value)
 
     @implicit
     def __init__(out self, value: String):
-        self._v = Variant[Int64, Float64, Bool, String](value)
+        self._v = Variant[Int64, Float64, Bool, String, _Null](value)
 
     @implicit
     def __init__(out self, value: Int):
-        self._v = Variant[Int64, Float64, Bool, String](Int64(value))
+        self._v = Variant[Int64, Float64, Bool, String, _Null](Int64(value))
+
+    @implicit
+    def __init__(out self, value: _Null):
+        self._v = Variant[Int64, Float64, Bool, String, _Null](value)
 
     def __init__(out self, *, copy: Self):
         self._v = copy._v
 
     def __init__(out self, *, deinit take: Self):
         self._v = take._v^
+
+    @staticmethod
+    def null() -> Self:
+        """Return a null sentinel scalar."""
+        return Self(_Null())
+
+    def is_null(self) -> Bool:
+        """Return True if this scalar represents a missing / null value."""
+        return self._v.isa[_Null]()
 
     def isa[T: Copyable & Movable](self) -> Bool:
         return self._v.isa[T]()

--- a/tests/test_io.mojo
+++ b/tests/test_io.mojo
@@ -394,5 +394,56 @@ def test_to_markdown_structure() raises:
     assert_true(m.find("3") >= 0)
 
 
+def test_null_sentinel_to_records() raises:
+    """Null cells in to_records produce DFScalar.null(), not zero-like defaults."""
+    var pd = Python.import_module("pandas")
+    var py = Python.evaluate("{'a': [1, None, 3], 'b': ['x', 'y', None]}")
+    var df = DataFrame(pd.DataFrame(py))
+    var records = df.to_records(index=False)
+    assert_equal(len(records), 3)
+    # Non-null cells have values
+    assert_true(not records[0]["a"].is_null())
+    assert_true(not records[2]["a"].is_null())
+    assert_true(not records[0]["b"].is_null())
+    assert_true(not records[1]["b"].is_null())
+    # Null cells must report is_null() == True (not zero/empty string)
+    assert_true(records[1]["a"].is_null())
+    assert_true(records[2]["b"].is_null())
+
+
+def test_null_sentinel_to_dict() raises:
+    """Null cells in DataFrame.to_dict produce DFScalar.null(), not zero-like defaults."""
+    var pd = Python.import_module("pandas")
+    var py = Python.evaluate("{'v': [10, None, 30]}")
+    var df = DataFrame(pd.DataFrame(py))
+    var d = df.to_dict()
+    var values = d["v"].copy()
+    assert_true(not values[0].is_null())
+    assert_true(values[1].is_null())
+    assert_true(not values[2].is_null())
+
+
+def test_null_roundtrip_records() raises:
+    """Nulls survive a to_records -> from_records round-trip."""
+    var pd = Python.import_module("pandas")
+    var py = Python.evaluate("{'a': [1, None, 3], 'b': ['x', None, 'z']}")
+    var df = DataFrame(pd.DataFrame(py))
+    var records = df.to_records(index=False)
+    var df2 = DataFrame.from_records(records)
+    # Shape is preserved
+    var shape = df2.shape()
+    assert_equal(shape[0], 3)
+    assert_equal(shape[1], 2)
+    # Null mask is propagated: isna() should match the original
+    var isna_a = df2["a"].isna()
+    assert_true(not isna_a.iloc(0)[Bool])
+    assert_true(isna_a.iloc(1)[Bool])
+    assert_true(not isna_a.iloc(2)[Bool])
+    var isna_b = df2["b"].isna()
+    assert_true(not isna_b.iloc(0)[Bool])
+    assert_true(isna_b.iloc(1)[Bool])
+    assert_true(not isna_b.iloc(2)[Bool])
+
+
 def main() raises:
     TestSuite.discover_tests[__functions_in_module()]().run()

--- a/tests/test_series.mojo
+++ b/tests/test_series.mojo
@@ -1249,13 +1249,12 @@ def test_to_list_string() raises:
 
 def test_to_list_null_float() raises:
     var pd = Python.import_module("pandas")
-    # null becomes NaN for float columns
+    # null becomes DFScalar.null() — not a NaN float
     var s = Series(pd.Series(Python.evaluate("[1.0, None, 3.0]")))
     var lst = s.to_list()
     assert_equal(len(lst), 3)
     assert_true(lst[0][Float64] == 1.0)
-    # NaN != NaN is the standard IEEE test
-    assert_true(lst[1][Float64] != lst[1][Float64])
+    assert_true(lst[1].is_null())
     assert_true(lst[2][Float64] == 3.0)
 
 


### PR DESCRIPTION
## Summary

- Adds `struct _Null` as a 5th arm of `DFScalar` so null cells are unambiguously distinguishable from real zero/false/empty values
- `DFScalar.null()` / `is_null()` are the public API; the `_Null` type stays internal
- `Series.to_list`, `Series.to_dict`, `DataFrame.to_dict`, `DataFrame.to_records` now emit `DFScalar.null()` for masked cells instead of `Int64(0)`, `False`, `""`, or `NaN`
- `DataFrame.from_records` recognises the `_Null` arm and builds proper null masks, making `to_records → from_records` a lossless round-trip

Closes #258

## Test plan

- [ ] `test_null_sentinel_to_records` — null cells in `to_records` produce `is_null() == True`
- [ ] `test_null_sentinel_to_dict` — null cells in `to_dict` produce `is_null() == True`
- [ ] `test_null_roundtrip_records` — `to_records → from_records` preserves null masks for int and string columns
- [ ] Updated `test_to_list_null_float` — null float is now `DFScalar.null()`, not NaN
- [ ] Full suite: `pixi run test` — 16 files, 0 failures