### PR TITLE
fix: guard fillna and _fill_scalar against DFScalar.null()

### DIFF
--- a/bison/_frame.mojo
+++ b/bison/_frame.mojo
@@ -317,6 +317,8 @@ struct Series(Copyable, Movable):
 
     def fillna(self, value: DFScalar) raises -> Series:
         """Return a copy of the Series with null/NaN values replaced by *value*."""
+        if value.is_null():
+            raise Error("fillna: fill value cannot be null")
         var has_mask = len(self._col._null_mask) > 0
         if not has_mask:
             return Series(self._col.copy())

--- a/bison/column.mojo
+++ b/bison/column.mojo
@@ -3375,12 +3375,14 @@ struct Column(Copyable, Movable, Sized):
         return c^
 
     @staticmethod
-    def _fill_scalar(name: String, value: DFScalar, n: Int, index: ColumnIndex) -> Column:
+    def _fill_scalar(name: String, value: DFScalar, n: Int, index: ColumnIndex) raises -> Column:
         """Create a Column of length *n* with every element equal to *value*.
 
         The dtype is inferred from the DFScalar arm: Int64 → int64, Float64 → float64,
         Bool → bool, String → object (matching pandas string storage).
         """
+        if value.is_null():
+            raise Error("_fill_scalar: fill value cannot be null")
         if value.isa[Int64]():
             var v = value[Int64]
             var data = List[Int64]()

--- a/tests/test_dataframe.mojo
+++ b/tests/test_dataframe.mojo
@@ -580,5 +580,16 @@ def test_from_records_bool_with_nulls() raises:
     assert_true(Bool(pd_df["flag"][2] == False))
 
 
+def test_fillna_null_raises() raises:
+    var pd = Python.import_module("pandas")
+    var df = DataFrame(pd.DataFrame(Python.evaluate("{'a': [1.0, None, 3.0]}")))
+    var raised = False
+    try:
+        _ = df.fillna(DFScalar.null())
+    except e:
+        raised = "null" in String(e)
+    assert_true(raised)
+
+
 def main() raises:
     TestSuite.discover_tests[__functions_in_module()]().run()

--- a/tests/test_series.mojo
+++ b/tests/test_series.mojo
@@ -471,6 +471,17 @@ def test_fillna_int() raises:
     assert_true(Float64(String(rp.iloc[1])) == 9.0)
 
 
+def test_fillna_null_raises() raises:
+    var pd = Python.import_module("pandas")
+    var s = Series(pd.Series(Python.evaluate("[1.0, None, 3.0]")))
+    var raised = False
+    try:
+        _ = s.fillna(DFScalar.null())
+    except e:
+        raised = "null" in String(e)
+    assert_true(raised)
+
+
 def test_dropna() raises:
     var pd = Python.import_module("pandas")
     var s = Series(pd.Series(Python.evaluate("[1.0, None, 3.0]")))


### PR DESCRIPTION
## Summary

- Closes #276
- `Series.fillna(DFScalar.null())` previously ABORTed at runtime: the String-column branch fell through to `value[Bool]` on a `_Null` variant after the 5th arm was added in #258
- Added a single `is_null()` guard at the top of `Series.fillna` (covers all four column-type branches)
- Added the same guard to `Column._fill_scalar`, promoting its signature to `raises`

## Test plan

- [ ] `test_fillna_null_raises` in `test_series.mojo` — confirms `Series.fillna(DFScalar.null())` raises with "null" in the message
- [ ] `test_fillna_null_raises` in `test_dataframe.mojo` — confirms `DataFrame.fillna(DFScalar.null())` raises (delegates to Series)
- [ ] All existing `test_fillna*` tests continue to pass