### PR TITLE
fix: add explicit UInt8() casts in _parse_int_label() (closes #283)

### DIFF
--- a/bison/indexing.mojo
+++ b/bison/indexing.mojo
@@ -31,10 +31,10 @@ def _parse_int_label(label: String) raises -> Int:
     var bytes = label.as_bytes()
     var start = 0
     var negative = False
-    if bytes[0] == ord('-'):
+    if bytes[0] == UInt8(ord('-')):
         negative = True
         start = 1
-    elif bytes[0] == ord('+'):
+    elif bytes[0] == UInt8(ord('+')):
         start = 1
     if start >= n:
         raise Error("loc: invalid row label: " + label)


### PR DESCRIPTION
## Summary

- Adds `UInt8(ord('-'))` and `UInt8(ord('+'))` casts at lines 34 and 37 of `bison/indexing.mojo`
- Eliminates the deprecated implicit `Int → UInt8` narrowing warnings emitted by the Mojo compiler
- Closes #283

## Test plan

- [x] `pixi run test` — all 27 tests pass, 0 failed