### PR TITLE
fix: DataFrame.to_dict returns nested dict (orient='dict' semantics)

### DIFF
--- a/bison/_frame.mojo
+++ b/bison/_frame.mojo
@@ -3931,68 +3931,72 @@ struct DataFrame(Copyable, Movable):
         var pd_df = self.to_pandas()
         pd_df.to_excel(excel_writer, sheet_name=sheet_name, index=index)
 
-    def to_dict(self, orient: String = "dict") raises -> Dict[String, List[DFScalar]]:
-        """Return the DataFrame as a ``Dict`` mapping column names to value lists.
+    def to_dict(self, orient: String = "dict") raises -> Dict[String, Dict[String, DFScalar]]:
+        """Return the DataFrame as a nested ``Dict`` mapping column names to
+        index-label → value dicts.
 
-        Both ``orient="dict"`` (the pandas default) and ``orient="list"``
-        produce the same ``{column: [v1, v2, ...]}`` layout because bison's
-        native ``Dict`` type does not support nested dicts.  All other orient
-        values raise ``Error``.
+        Matches pandas ``orient="dict"`` semantics: the outer key is the
+        column name and the inner key is the stringified row-index label
+        (e.g. ``"0"``, ``"1"`` for the default integer index).
+
+        All other orient values raise ``Error``.  For row-oriented output use
+        ``to_records()`` (equivalent to ``orient="records"``).
 
         Parameters
         ----------
-        orient : Serialisation orientation.  Only ``"dict"`` and ``"list"``
-                 are supported.
+        orient : Serialisation orientation.  Only ``"dict"`` is supported.
         """
-        if orient != "dict" and orient != "list":
-            raise Error(
-                "DataFrame.to_dict: orient '"
-                + orient
-                + "' is not supported; use 'list' or 'dict'"
-            )
-        var result = Dict[String, List[DFScalar]]()
+        if orient != "dict":
+            _not_implemented("DataFrame.to_dict with orient='" + orient + "'")
+        var result = Dict[String, Dict[String, DFScalar]]()
         var nrows = self.__len__()
         var ncols = self._cols.__len__()
+        var has_index = self._cols.__len__() > 0 and self._cols[0]._index_len() > 0
         for ci in range(ncols):
             ref col = self._cols[ci]
-            var values = List[DFScalar]()
+            var inner = Dict[String, DFScalar]()
             var has_mask = len(col._null_mask) > 0
             if col._data.isa[List[Int64]]():
                 ref data = col._data[List[Int64]]
                 for i in range(nrows):
+                    var key = col._index_label(i) if has_index else String(i)
                     if has_mask and col._null_mask[i]:
-                        values.append(DFScalar.null())
+                        inner[key] = DFScalar.null()
                     else:
-                        values.append(DFScalar(data[i]))
+                        inner[key] = DFScalar(data[i])
             elif col._data.isa[List[Float64]]():
                 ref data = col._data[List[Float64]]
                 for i in range(nrows):
+                    var key = col._index_label(i) if has_index else String(i)
                     if has_mask and col._null_mask[i]:
-                        values.append(DFScalar.null())
+                        inner[key] = DFScalar.null()
                     else:
-                        values.append(DFScalar(data[i]))
+                        inner[key] = DFScalar(data[i])
             elif col._data.isa[List[Bool]]():
                 ref data = col._data[List[Bool]]
                 for i in range(nrows):
+                    var key = col._index_label(i) if has_index else String(i)
                     if has_mask and col._null_mask[i]:
-                        values.append(DFScalar.null())
+                        inner[key] = DFScalar.null()
                     else:
-                        values.append(DFScalar(data[i]))
+                        inner[key] = DFScalar(data[i])
             elif col._data.isa[List[String]]():
                 ref data = col._data[List[String]]
                 for i in range(nrows):
+                    var key = col._index_label(i) if has_index else String(i)
                     if has_mask and col._null_mask[i]:
-                        values.append(DFScalar.null())
+                        inner[key] = DFScalar.null()
                     else:
-                        values.append(DFScalar(data[i]))
+                        inner[key] = DFScalar(data[i])
             else:
                 ref data = col._data[List[PythonObject]]
                 for i in range(nrows):
+                    var key = col._index_label(i) if has_index else String(i)
                     if has_mask and col._null_mask[i]:
-                        values.append(DFScalar.null())
+                        inner[key] = DFScalar.null()
                     else:
-                        values.append(DFScalar(String(data[i])))
-            result[col.name] = values^
+                        inner[key] = DFScalar(String(data[i]))
+            result[col.name] = inner^
         return result^
 
     def to_records(self, index: Bool = True) raises -> List[Dict[String, DFScalar]]:

--- a/tests/test_io.mojo
+++ b/tests/test_io.mojo
@@ -241,31 +241,33 @@ def test_to_excel_writes_file() raises:
 
 
 def test_to_dict_int_columns() raises:
-    """DataFrame.to_dict returns a dict mapping column name to list of values (int)."""
+    """DataFrame.to_dict returns a nested dict {col: {index_label: value}}."""
     var pd = Python.import_module("pandas")
     var df = DataFrame(pd.DataFrame(Python.evaluate("{'a': [1, 2, 3], 'b': [4, 5, 6]}")))
     var d = df.to_dict()
-    # Column 'a' should have 3 entries
+    # Each column maps to an inner dict keyed by stringified row index
     assert_equal(len(d["a"]), 3)
     assert_equal(len(d["b"]), 3)
-    assert_true(d["a"][0].isa[Int64]())
-    assert_equal(Int(d["a"][0][Int64]), 1)
-    assert_equal(Int(d["a"][1][Int64]), 2)
-    assert_equal(Int(d["b"][0][Int64]), 4)
+    assert_true(d["a"]["0"].isa[Int64]())
+    assert_equal(Int(d["a"]["0"][Int64]), 1)
+    assert_equal(Int(d["a"]["1"][Int64]), 2)
+    assert_equal(Int(d["b"]["0"][Int64]), 4)
 
 
 def test_to_dict_list_orient() raises:
-    """DataFrame.to_dict with orient='list' produces the same result as the default."""
+    """DataFrame.to_dict raises for orient='list' (unsupported; use to_records)."""
     var pd = Python.import_module("pandas")
     var df = DataFrame(pd.DataFrame(Python.evaluate("{'x': [10, 20]}")))
-    var d = df.to_dict(orient="list")
-    assert_equal(len(d["x"]), 2)
-    assert_equal(Int(d["x"][0][Int64]), 10)
-    assert_equal(Int(d["x"][1][Int64]), 20)
+    var raised = False
+    try:
+        _ = df.to_dict(orient="list")
+    except:
+        raised = True
+    assert_true(raised)
 
 
 def test_to_dict_unsupported_orient() raises:
-    """DataFrame.to_dict raises for orient values other than 'dict' and 'list'."""
+    """DataFrame.to_dict raises for orient values other than 'dict'."""
     var pd = Python.import_module("pandas")
     var df = DataFrame(pd.DataFrame(Python.evaluate("{'a': [1]}")))
     var raised = False
@@ -417,10 +419,10 @@ def test_null_sentinel_to_dict() raises:
     var py = Python.evaluate("{'v': [10, None, 30]}")
     var df = DataFrame(pd.DataFrame(py))
     var d = df.to_dict()
-    var values = d["v"].copy()
-    assert_true(not values[0].is_null())
-    assert_true(values[1].is_null())
-    assert_true(not values[2].is_null())
+    # Inner dict is keyed by stringified row index
+    assert_true(not d["v"]["0"].is_null())
+    assert_true(d["v"]["1"].is_null())
+    assert_true(not d["v"]["2"].is_null())
 
 
 def test_null_roundtrip_records() raises:


### PR DESCRIPTION
## Summary

- Fixes return type mismatch in `DataFrame.to_dict` (closes #259)
- Return type changed from `Dict[String, List[DFScalar]]` → `Dict[String, Dict[String, DFScalar]]`
- Default `orient="dict"` now produces `{col: {index_label: value}}`, matching pandas semantics
- `orient="list"` and all other unsupported modes now raise via `_not_implemented()`
- `to_records()` remains the canonical way to get row-oriented (`orient="records"`) output

## Test plan

- [x] `test_to_dict_int_columns` — verifies nested dict structure with string index keys
- [x] `test_to_dict_list_orient` — verifies `orient="list"` raises (unsupported)
- [x] `test_to_dict_unsupported_orient` — verifies `orient="records"` raises
- [x] `test_null_sentinel_to_dict` — verifies nulls produce `DFScalar.null()` via string key access
- [x] Full suite: 32/32 tests pass in `test_io.mojo`, 16/16 test files green