### PR TITLE
fix: raise on index/column name collision in to_records

### DIFF
--- a/bison/_frame.mojo
+++ b/bison/_frame.mojo
@@ -4013,6 +4013,14 @@ struct DataFrame(Copyable, Movable):
         var result = List[Dict[String, DFScalar]]()
         var nrows = self.__len__()
         var ncols = self._cols.__len__()
+        if index:
+            for ci in range(ncols):
+                if self._cols[ci].name == "index":
+                    raise Error(
+                        "DataFrame.to_records: column named 'index' conflicts"
+                        " with the index key; pass index=False or rename the"
+                        " column"
+                    )
         for ri in range(nrows):
             var row = Dict[String, DFScalar]()
             if index:

--- a/tests/test_io.mojo
+++ b/tests/test_io.mojo
@@ -310,6 +310,24 @@ def test_to_records_no_index() raises:
     assert_equal(Int(records[0]["v"][Int64]), 1)
 
 
+def test_to_records_index_collision() raises:
+    """DataFrame.to_records raises when a column is named 'index' and index=True."""
+    var pd = Python.import_module("pandas")
+    var df = DataFrame(pd.DataFrame(Python.evaluate("{'a': [1], 'index': [99]}")))
+    # index=True (default) must raise
+    var raised = False
+    try:
+        _ = df.to_records()
+        raised = False
+    except:
+        raised = True
+    assert_true(raised)
+    # index=False must succeed and return the column value
+    var records = df.to_records(index=False)
+    assert_equal(len(records), 1)
+    assert_equal(Int(records[0]["index"][Int64]), 99)
+
+
 def test_to_numpy_int_float() raises:
     """DataFrame.to_numpy returns a row-major list of Float64 lists for numeric columns."""
     var pd = Python.import_module("pandas")


### PR DESCRIPTION
## Summary

- `to_records(index=True)` now raises `Error` when any column is named `"index"`, matching the `ValueError` pandas raises in the same situation
- `to_records(index=False)` is unaffected and returns the `"index"` column value normally
- Added `test_to_records_index_collision` to `tests/test_io.mojo`

Closes #290.

## Test plan

- [ ] `pixi run test` passes (149 tests, 0 failed)
- [ ] New test `test_to_records_index_collision` covers the raising path and the `index=False` path