### PR TITLE
refactor: consolidate _scalar_from_col and eliminate serialization duplication

### DIFF
--- a/bison/_frame.mojo
+++ b/bison/_frame.mojo
@@ -3,7 +3,7 @@ from std.collections import Optional, Dict
 from ._errors import _not_implemented
 from .dtypes import BisonDtype, object_, bool_, int64, float64, dtype_from_string
 from .index import Index, ColumnIndex
-from .column import Column, ColumnData, DFScalar, SeriesScalar, _Null, FloatTransformFn, _csv_quote_field, _col_cell_str, _col_cell_pyobj
+from .column import Column, ColumnData, DFScalar, SeriesScalar, _Null, FloatTransformFn, _csv_quote_field, _col_cell_str, _col_cell_pyobj, _scalar_from_col
 from .accessors.str_accessor import StringMethods
 from .accessors.dt_accessor import DatetimeMethods
 
@@ -1252,43 +1252,13 @@ struct Series(Copyable, Movable):
         """
         var result = Dict[String, DFScalar]()
         ref col = self._col
-        var has_mask = len(col._null_mask) > 0
         var has_index = col._index_len() > 0
         var n = col.__len__()
-        if col._data.isa[List[Int64]]():
-            ref data = col._data[List[Int64]]
-            for i in range(n):
-                var key = col._index_label(i) if has_index else String(i)
-                if has_mask and col._null_mask[i]:
-                    result[key] = DFScalar.null()
-                else:
-                    result[key] = DFScalar(data[i])
-        elif col._data.isa[List[Float64]]():
-            ref data = col._data[List[Float64]]
-            for i in range(n):
-                var key = col._index_label(i) if has_index else String(i)
-                if has_mask and col._null_mask[i]:
-                    result[key] = DFScalar.null()
-                else:
-                    result[key] = DFScalar(data[i])
-        elif col._data.isa[List[Bool]]():
-            ref data = col._data[List[Bool]]
-            for i in range(n):
-                var key = col._index_label(i) if has_index else String(i)
-                if has_mask and col._null_mask[i]:
-                    result[key] = DFScalar.null()
-                else:
-                    result[key] = DFScalar(data[i])
-        elif col._data.isa[List[String]]():
-            ref data = col._data[List[String]]
-            for i in range(n):
-                var key = col._index_label(i) if has_index else String(i)
-                if has_mask and col._null_mask[i]:
-                    result[key] = DFScalar.null()
-                else:
-                    result[key] = DFScalar(data[i])
-        else:
+        if col._data.isa[List[PythonObject]]():
             raise Error("Series.to_dict: object dtype is not supported")
+        for i in range(n):
+            var key = col._index_label(i) if has_index else String(i)
+            result[key] = _scalar_from_col(col, i)
         return result^
 
     def to_csv(self, path: String = "") raises -> String:
@@ -3955,47 +3925,17 @@ struct DataFrame(Copyable, Movable):
         for ci in range(ncols):
             ref col = self._cols[ci]
             var inner = Dict[String, DFScalar]()
-            var has_mask = len(col._null_mask) > 0
-            if col._data.isa[List[Int64]]():
-                ref data = col._data[List[Int64]]
-                for i in range(nrows):
-                    var key = col._index_label(i) if has_index else String(i)
+            var is_object = col._data.isa[List[PythonObject]]()
+            for i in range(nrows):
+                var key = col._index_label(i) if has_index else String(i)
+                if is_object:
+                    var has_mask = len(col._null_mask) > 0
                     if has_mask and col._null_mask[i]:
                         inner[key] = DFScalar.null()
                     else:
-                        inner[key] = DFScalar(data[i])
-            elif col._data.isa[List[Float64]]():
-                ref data = col._data[List[Float64]]
-                for i in range(nrows):
-                    var key = col._index_label(i) if has_index else String(i)
-                    if has_mask and col._null_mask[i]:
-                        inner[key] = DFScalar.null()
-                    else:
-                        inner[key] = DFScalar(data[i])
-            elif col._data.isa[List[Bool]]():
-                ref data = col._data[List[Bool]]
-                for i in range(nrows):
-                    var key = col._index_label(i) if has_index else String(i)
-                    if has_mask and col._null_mask[i]:
-                        inner[key] = DFScalar.null()
-                    else:
-                        inner[key] = DFScalar(data[i])
-            elif col._data.isa[List[String]]():
-                ref data = col._data[List[String]]
-                for i in range(nrows):
-                    var key = col._index_label(i) if has_index else String(i)
-                    if has_mask and col._null_mask[i]:
-                        inner[key] = DFScalar.null()
-                    else:
-                        inner[key] = DFScalar(data[i])
-            else:
-                ref data = col._data[List[PythonObject]]
-                for i in range(nrows):
-                    var key = col._index_label(i) if has_index else String(i)
-                    if has_mask and col._null_mask[i]:
-                        inner[key] = DFScalar.null()
-                    else:
-                        inner[key] = DFScalar(String(data[i]))
+                        inner[key] = DFScalar(String(col._data[List[PythonObject]][i]))
+                else:
+                    inner[key] = _scalar_from_col(col, i)
             result[col.name] = inner^
         return result^
 
@@ -4019,21 +3959,16 @@ struct DataFrame(Copyable, Movable):
                 row["index"] = DFScalar(Int64(ri))
             for ci in range(ncols):
                 ref col = self._cols[ci]
-                var has_mask = len(col._null_mask) > 0
-                if has_mask and ri < len(col._null_mask) and col._null_mask[ri]:
-                    row[col.name] = DFScalar.null()
-                elif col._data.isa[List[Int64]]():
-                    row[col.name] = DFScalar(col._data[List[Int64]][ri])
-                elif col._data.isa[List[Float64]]():
-                    row[col.name] = DFScalar(col._data[List[Float64]][ri])
-                elif col._data.isa[List[Bool]]():
-                    row[col.name] = DFScalar(col._data[List[Bool]][ri])
-                elif col._data.isa[List[String]]():
-                    row[col.name] = DFScalar(col._data[List[String]][ri])
+                if col._data.isa[List[PythonObject]]():
+                    var has_mask = len(col._null_mask) > 0
+                    if has_mask and col._null_mask[ri]:
+                        row[col.name] = DFScalar.null()
+                    else:
+                        row[col.name] = DFScalar(
+                            String(col._data[List[PythonObject]][ri])
+                        )
                 else:
-                    row[col.name] = DFScalar(
-                        String(col._data[List[PythonObject]][ri])
-                    )
+                    row[col.name] = _scalar_from_col(col, ri)
             result.append(row^)
         return result^
 

--- a/bison/column.mojo
+++ b/bison/column.mojo
@@ -3608,6 +3608,27 @@ def _col_cell_pyobj(col: Column, row: Int) raises -> PythonObject:
         return col._data[List[PythonObject]][row]
 
 
+def _scalar_from_col(col: Column, row: Int) raises -> DFScalar:
+    """Extract cell (*row*) from *col* as a ``DFScalar``.
+
+    Returns ``DFScalar.null()`` when the cell is masked.  Raises for
+    ``List[PythonObject]`` columns (object / datetime) since ``DFScalar``
+    has no ``PythonObject`` arm.
+    """
+    if len(col._null_mask) > 0 and col._null_mask[row]:
+        return DFScalar.null()
+    if col._data.isa[List[Int64]]():
+        return DFScalar(col._data[List[Int64]][row])
+    elif col._data.isa[List[Float64]]():
+        return DFScalar(col._data[List[Float64]][row])
+    elif col._data.isa[List[Bool]]():
+        return DFScalar(col._data[List[Bool]][row])
+    elif col._data.isa[List[String]]():
+        return DFScalar(col._data[List[String]][row])
+    else:
+        raise Error("scalar access not supported for object/datetime columns")
+
+
 def _col_cell_str(col: Column, row: Int) raises -> String:
     """Return the string representation of cell *row* in *col*.
 

--- a/bison/indexing.mojo
+++ b/bison/indexing.mojo
@@ -1,6 +1,6 @@
 from std.python import PythonObject
 from std.memory import UnsafePointer
-from .column import Column, ColumnData, DFScalar, SeriesScalar
+from .column import Column, ColumnData, DFScalar, SeriesScalar, _scalar_from_col
 from .index import ColumnIndex
 from .dtypes import object_
 from .series import Series
@@ -75,22 +75,6 @@ def _df_row_index(df: DataFrame, label: String) raises -> Int:
     return row
 
 
-def _scalar_from_col(col: Column, row: Int) raises -> DFScalar:
-    """Extract cell (*row*) from *col* as a ``DFScalar``.
-
-    Raises for ``List[PythonObject]`` columns (object / datetime) since
-    ``DFScalar`` has no ``PythonObject`` arm.
-    """
-    if col._data.isa[List[Int64]]():
-        return DFScalar(col._data[List[Int64]][row])
-    elif col._data.isa[List[Float64]]():
-        return DFScalar(col._data[List[Float64]][row])
-    elif col._data.isa[List[Bool]]():
-        return DFScalar(col._data[List[Bool]][row])
-    elif col._data.isa[List[String]]():
-        return DFScalar(col._data[List[String]][row])
-    else:
-        raise Error("scalar access not supported for object/datetime columns")
 
 
 def _set_scalar_in_col(mut col: Column, row: Int, value: DFScalar) raises:


### PR DESCRIPTION
## Summary

- Moved `_scalar_from_col` from `indexing.mojo` to `column.mojo` — the only file both `indexing.mojo` and `_frame.mojo` can import without a circular dependency
- Extended it to return `DFScalar.null()` for masked cells (null mask check was previously duplicated at every call site)
- Replaced the duplicated 4-arm `isa` dispatch in `Series.to_dict`, `DataFrame.to_dict`, and `DataFrame.to_records` with calls to the shared helper
- `PythonObject` columns retain a local stringify branch at each call site (tracked in #288)
- Net: **-104 / +44 lines**, 0 new tests needed (existing 149 all pass)

Closes #287.

## Test plan

- [ ] `pixi run test` — 149 tests, 0 failed