### PR TITLE
refactor: add DataFrame._has_index() to encapsulate index presence check

### DIFF
--- a/bison/_frame.mojo
+++ b/bison/_frame.mojo
@@ -1877,7 +1877,7 @@ struct DataFrame(Copyable, Movable):
             if len(self._cols) == 0:
                 return self.copy()
             var n_rows = self._cols[0].__len__()
-            var has_index = self._cols[0]._index_len() > 0
+            var has_index = self._has_index()
             var keep_rows = List[Int]()
             for i in range(n_rows):
                 var label = self._cols[0]._index_label(i) if has_index else String(i)
@@ -2476,7 +2476,7 @@ struct DataFrame(Copyable, Movable):
             k -= 1
 
         # Reorder index labels (parallel to the data).
-        var has_index = self._cols[0]._index_len() > 0
+        var has_index = self._has_index()
         var new_idx: ColumnIndex
         if has_index:
             new_idx = self._cols[0]._index_reorder(perm)
@@ -2550,7 +2550,7 @@ struct DataFrame(Copyable, Movable):
             perm = self._cols[0]._sort_perm_by_index(ascending)
 
         # Reorder index labels and apply permutation to every column.
-        var has_index = self._cols[0]._index_len() > 0
+        var has_index = self._has_index()
         var new_idx: ColumnIndex
         if has_index:
             new_idx = self._cols[0]._index_reorder(perm)
@@ -2828,7 +2828,7 @@ struct DataFrame(Copyable, Movable):
             if ncols == 0:
                 return DataFrame()
             var nrows = self.shape()[0]
-            var has_index = self._cols[0]._index_len() > 0
+            var has_index = self._has_index()
             # Build label → row-position map.
             var label_to_row = Dict[String, Int]()
             for i in range(nrows):
@@ -2912,7 +2912,7 @@ struct DataFrame(Copyable, Movable):
         else:
             # Row drop: match drop_labels against the index.
             var nrows = self.shape()[0]
-            var has_index = ncols > 0 and self._cols[0]._index_len() > 0
+            var has_index = self._has_index()
             var drop_set = Dict[String, Bool]()
             for i in range(len(drop_labels)):
                 drop_set[drop_labels[i]] = True
@@ -3248,7 +3248,7 @@ struct DataFrame(Copyable, Movable):
         for r in range(nrows):
             # Determine row label.
             var row_label: PythonObject
-            if self._cols[0]._index_len() > 0:
+            if self._has_index():
                 row_label = PythonObject(self._cols[0]._index_label(r))
             else:
                 row_label = PythonObject(r)
@@ -3303,7 +3303,7 @@ struct DataFrame(Copyable, Movable):
         for r in range(nrows):
             # Result column name = original row-index label.
             var col_name: String
-            if self._cols[0]._index_len() > 0:
+            if self._has_index():
                 col_name = self._cols[0]._index_label(r)
             else:
                 col_name = String(r)
@@ -3921,7 +3921,7 @@ struct DataFrame(Copyable, Movable):
         var result = Dict[String, Dict[String, DFScalar]]()
         var nrows = self.__len__()
         var ncols = self._cols.__len__()
-        var has_index = self._cols.__len__() > 0 and self._cols[0]._index_len() > 0
+        var has_index = self._has_index()
         for ci in range(ncols):
             ref col = self._cols[ci]
             var inner = Dict[String, DFScalar]()
@@ -4205,6 +4205,10 @@ struct DataFrame(Copyable, Movable):
         if self._cols.__len__() == 0:
             return 0
         return self._cols[0].__len__()
+
+    def _has_index(self) -> Bool:
+        """Return ``True`` when the DataFrame carries an explicit row index."""
+        return self._cols.__len__() > 0 and self._cols[0]._index_len() > 0
 
     def __contains__(self, key: String) -> Bool:
         for i in range(self._cols.__len__()):


### PR DESCRIPTION
## Summary

- Added `DataFrame._has_index() -> Bool` that guards against an empty column list and checks `_cols[0]._index_len() > 0`
- Replaced 8 call sites across `filter`, `sort_values`, `loc`, `drop`, `pivot`, `transpose`, and `to_dict` with the new method
- Two remaining `_cols[0]._index_len()` accesses are left as-is: one uses `== 0` (the negation) and one stores the count for later arithmetic — neither is expressing "does an index exist"

Closes #289.

## Test plan

- [ ] `pixi run test` — 149 tests, 0 failed