### PR TITLE
feat: add Column.len() convenience method

### DIFF
--- a/bison/column.mojo
+++ b/bison/column.mojo
@@ -2209,6 +2209,10 @@ struct Column(Copyable, Movable, Sized):
         visit_col_data(visitor, self._data)
         return visitor.result
 
+    def len(self) -> Int:
+        """Return the number of elements in this column."""
+        return self.__len__()
+
     # ------------------------------------------------------------------
     # Row selection helpers
     # ------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Adds a `.len()` alias on `Column` that delegates to `.__len__()`
- Resolves the Dispensables / Incomplete Library Class tech debt noted in #255
- No behaviour changes; all 149 existing tests pass

Closes #255