### PR TITLE
feat: extend DataFrame.transform to support cumsum, cumprod, cummin, cummax

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ In CI it runs after the test suite and the result is committed back to the branc
 <!-- COMPAT_TABLE_START -->
 | Category | Stubs | Implemented |
 |----------|-------|-------------|
-| DataFrame | 40 | 95 |
+| DataFrame | 39 | 96 |
 | Series | 11 | 86 |
 | GroupBy (DataFrame) | 16 | 1 |
 | GroupBy (Series) | 15 | 1 |
@@ -91,7 +91,7 @@ In CI it runs after the test suite and the result is committed back to the branc
 | Index | 0 | 14 |
 | IO | 5 | 6 |
 | Reshape | 1 | 0 |
-| **Total** | **105** | **225** |
+| **Total** | **104** | **226** |
 <!-- COMPAT_TABLE_END -->
 
 ## Known limitations

--- a/bison/_frame.mojo
+++ b/bison/_frame.mojo
@@ -2204,8 +2204,20 @@ struct DataFrame(Copyable, Movable):
             _not_implemented("DataFrame.transform")
         if func == "abs":
             return self.abs()
-        _not_implemented("DataFrame.transform")
-        return DataFrame()
+        elif func == "cumsum":
+            return self.cumsum()
+        elif func == "cumprod":
+            return self.cumprod()
+        elif func == "cummin":
+            return self.cummin()
+        elif func == "cummax":
+            return self.cummax()
+        else:
+            raise Error(
+                "DataFrame.transform: unsupported func '"
+                + func
+                + "'. Supported: abs, cumsum, cumprod, cummin, cummax"
+            )
 
     def eval(self, expr: String) raises -> Series:
         var pd_df = self.to_pandas()

--- a/tests/test_functional.mojo
+++ b/tests/test_functional.mojo
@@ -144,6 +144,46 @@ def test_df_transform_unknown_raises() raises:
         raise Error("DataFrame.transform with unsupported func should have raised")
 
 
+def test_df_transform_cumsum() raises:
+    var pd = Python.import_module("pandas")
+    var testing = Python.import_module("pandas.testing")
+    var pd_df = pd.DataFrame(Python.evaluate("{'a': [1.0, 2.0, 3.0], 'b': [4.0, 5.0, 6.0]}"))
+    var df = DataFrame(pd_df)
+    var result_pd = df.transform("cumsum").to_pandas()
+    var expected_pd = pd_df.transform("cumsum")
+    testing.assert_frame_equal(result_pd, expected_pd)
+
+
+def test_df_transform_cumprod() raises:
+    var pd = Python.import_module("pandas")
+    var testing = Python.import_module("pandas.testing")
+    var pd_df = pd.DataFrame(Python.evaluate("{'a': [1.0, 2.0, 3.0], 'b': [4.0, 5.0, 6.0]}"))
+    var df = DataFrame(pd_df)
+    var result_pd = df.transform("cumprod").to_pandas()
+    var expected_pd = pd_df.transform("cumprod")
+    testing.assert_frame_equal(result_pd, expected_pd)
+
+
+def test_df_transform_cummin() raises:
+    var pd = Python.import_module("pandas")
+    var testing = Python.import_module("pandas.testing")
+    var pd_df = pd.DataFrame(Python.evaluate("{'a': [3.0, 1.0, 2.0], 'b': [6.0, 4.0, 5.0]}"))
+    var df = DataFrame(pd_df)
+    var result_pd = df.transform("cummin").to_pandas()
+    var expected_pd = pd_df.transform("cummin")
+    testing.assert_frame_equal(result_pd, expected_pd)
+
+
+def test_df_transform_cummax() raises:
+    var pd = Python.import_module("pandas")
+    var testing = Python.import_module("pandas.testing")
+    var pd_df = pd.DataFrame(Python.evaluate("{'a': [1.0, 3.0, 2.0], 'b': [4.0, 6.0, 5.0]}"))
+    var df = DataFrame(pd_df)
+    var result_pd = df.transform("cummax").to_pandas()
+    var expected_pd = pd_df.transform("cummax")
+    testing.assert_frame_equal(result_pd, expected_pd)
+
+
 # ---------------------------------------------------------------------------
 # eval
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Extends `DataFrame.transform(func)` to dispatch `"cumsum"`, `"cumprod"`, `"cummin"`, and `"cummax"` to the existing native implementations
- Replaces the final `_not_implemented()` fallthrough with a descriptive `raise Error(...)` that lists supported functions
- Adds four pandas-comparison tests (one per new function)

Closes #273.

## Test plan

- [ ] `pixi run test` — all 16 test files pass
- [ ] `test_df_transform_cumsum`, `test_df_transform_cumprod`, `test_df_transform_cummin`, `test_df_transform_cummax` all pass
- [ ] `test_df_transform_unknown_raises` still passes (unsupported func raises with a useful message)