### PR TITLE
feat: add Claude Code session-start hook and settings

### DIFF
--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+set -euo pipefail
+
+# Only run in Claude Code remote (web) environments
+if [ "${CLAUDE_CODE_REMOTE:-}" != "true" ]; then
+  exit 0
+fi
+
+cd "$CLAUDE_PROJECT_DIR"
+
+# Install pixi if not already present
+if ! command -v pixi &>/dev/null; then
+  echo "Installing pixi..."
+  curl -fsSL https://pixi.sh/install.sh | sh
+  export PATH="$HOME/.pixi/bin:$PATH"
+fi
+
+# Install all project dependencies (MAX + pandas + numpy)
+echo "Running pixi install..."
+pixi install
+
+# Install pre-commit and its git hooks (mirrors CI setup)
+echo "Installing pre-commit..."
+pip install --quiet pre-commit
+pre-commit install
+
+# Generate _version.mojo from pixi.toml (required before tests or imports)
+echo "Generating version file..."
+pixi run gen-version
+
+echo "Session start complete."

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,23 @@
+{
+  "mcpServers": {
+    "github": {
+      "command": "npx",
+      "args": ["-y", "@modelcontextprotocol/server-github"],
+      "env": {
+        "GITHUB_PERSONAL_ACCESS_TOKEN": "${GITHUB_TOKEN}"
+      }
+    }
+  },
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/session-start.sh"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,6 @@
 __pycache__/
 *.pyc
 .CLAUDE
-.claude/
 SESSION.md
 *.mojopkg
 .bison-cache/


### PR DESCRIPTION
- Removes .claude/ from .gitignore so config is shared with the repo
- .claude/hooks/session-start.sh installs pixi, pre-commit, and generates
  _version.mojo on every remote web session (mirrors CI setup steps)
- .claude/settings.json registers the hook and configures the GitHub MCP
  server for reading issues (uses GITHUB_TOKEN env var)

https://claude.ai/code/session_01JwrXRozm7LPqtc9aUnoaSx