### PR TITLE
Implement Series.dt datetime accessor methods (closes #27)

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,11 +87,11 @@ In CI it runs after the test suite and the result is committed back to the branc
 | GroupBy (DataFrame) | 16 | 1 |
 | GroupBy (Series) | 15 | 1 |
 | String accessor | 0 | 21 |
-| Datetime accessor | 17 | 1 |
+| Datetime accessor | 0 | 20 |
 | Index | 0 | 14 |
 | IO | 5 | 6 |
 | Reshape | 1 | 0 |
-| **Total** | **104** | **226** |
+| **Total** | **87** | **245** |
 <!-- COMPAT_TABLE_END -->
 
 ## Known limitations

--- a/bison/_frame.mojo
+++ b/bison/_frame.mojo
@@ -1,7 +1,7 @@
 from std.python import Python, PythonObject
 from std.collections import Optional, Dict
 from ._errors import _not_implemented
-from .dtypes import BisonDtype, object_, bool_, int64, float64, dtype_from_string
+from .dtypes import BisonDtype, object_, bool_, int64, float64, dtype_from_string, datetime64_ns
 from .index import Index, ColumnIndex
 from .column import Column, ColumnData, DFScalar, SeriesScalar, _Null, FloatTransformFn, _csv_quote_field, _col_cell_str, _col_cell_pyobj, _scalar_from_col
 from .accessors.str_accessor import StringMethods
@@ -1323,8 +1323,12 @@ struct Series(Copyable, Movable):
         return StringMethods(data^, null_mask^, self._col.name)
 
     def dt(self) raises -> DatetimeMethods:
-        _not_implemented("Series.dt")
-        return DatetimeMethods()
+        if not self._col.dtype.name.startswith("datetime64"):
+            raise Error("Series.dt: accessor requires a datetime Series")
+        ref d = self._col._data[List[PythonObject]]
+        var data = d.copy()
+        var null_mask = self._col._null_mask.copy()
+        return DatetimeMethods(data^, null_mask^, self._col.name)
 
     # ------------------------------------------------------------------
     # Repr

--- a/bison/accessors/dt_accessor.mojo
+++ b/bison/accessors/dt_accessor.mojo
@@ -1,73 +1,264 @@
-from .._errors import _not_implemented
-from ..column import Column
+from std.python import Python, PythonObject
+from ..column import Column, ColumnData
+from ..dtypes import int64, object_, datetime64_ns
 
 
 struct DatetimeMethods:
     """Accessor for datetime properties on a Series (.dt accessor)."""
 
+    var _data: List[PythonObject]
+    var _null_mask: List[Bool]
+    var _name: String
+
     def __init__(out self):
-        pass
+        self._data = List[PythonObject]()
+        self._null_mask = List[Bool]()
+        self._name = ""
+
+    def __init__(out self, var data: List[PythonObject], var null_mask: List[Bool], name: String):
+        self._data = data^
+        self._null_mask = null_mask^
+        self._name = name
+
+    # ------------------------------------------------------------------
+    # Helpers
+    # ------------------------------------------------------------------
+
+    def _is_null(self, i: Int) -> Bool:
+        return len(self._null_mask) > i and self._null_mask[i]
+
+    # ------------------------------------------------------------------
+    # Integer properties
+    # ------------------------------------------------------------------
 
     def year(self) raises -> Column:
-        _not_implemented("Series.dt.year")
-        return Column()
+        var result = List[Int64]()
+        var new_mask = List[Bool]()
+        for i in range(len(self._data)):
+            if self._is_null(i):
+                result.append(Int64(0))
+                new_mask.append(True)
+            else:
+                result.append(Int64(Int(py=self._data[i].year)))
+                new_mask.append(False)
+        var col = Column(self._name, ColumnData(result^), int64)
+        col._null_mask = new_mask^
+        return col^
 
     def month(self) raises -> Column:
-        _not_implemented("Series.dt.month")
-        return Column()
+        var result = List[Int64]()
+        var new_mask = List[Bool]()
+        for i in range(len(self._data)):
+            if self._is_null(i):
+                result.append(Int64(0))
+                new_mask.append(True)
+            else:
+                result.append(Int64(Int(py=self._data[i].month)))
+                new_mask.append(False)
+        var col = Column(self._name, ColumnData(result^), int64)
+        col._null_mask = new_mask^
+        return col^
 
     def day(self) raises -> Column:
-        _not_implemented("Series.dt.day")
-        return Column()
+        var result = List[Int64]()
+        var new_mask = List[Bool]()
+        for i in range(len(self._data)):
+            if self._is_null(i):
+                result.append(Int64(0))
+                new_mask.append(True)
+            else:
+                result.append(Int64(Int(py=self._data[i].day)))
+                new_mask.append(False)
+        var col = Column(self._name, ColumnData(result^), int64)
+        col._null_mask = new_mask^
+        return col^
 
     def hour(self) raises -> Column:
-        _not_implemented("Series.dt.hour")
-        return Column()
+        var result = List[Int64]()
+        var new_mask = List[Bool]()
+        for i in range(len(self._data)):
+            if self._is_null(i):
+                result.append(Int64(0))
+                new_mask.append(True)
+            else:
+                result.append(Int64(Int(py=self._data[i].hour)))
+                new_mask.append(False)
+        var col = Column(self._name, ColumnData(result^), int64)
+        col._null_mask = new_mask^
+        return col^
 
     def minute(self) raises -> Column:
-        _not_implemented("Series.dt.minute")
-        return Column()
+        var result = List[Int64]()
+        var new_mask = List[Bool]()
+        for i in range(len(self._data)):
+            if self._is_null(i):
+                result.append(Int64(0))
+                new_mask.append(True)
+            else:
+                result.append(Int64(Int(py=self._data[i].minute)))
+                new_mask.append(False)
+        var col = Column(self._name, ColumnData(result^), int64)
+        col._null_mask = new_mask^
+        return col^
 
     def second(self) raises -> Column:
-        _not_implemented("Series.dt.second")
-        return Column()
+        var result = List[Int64]()
+        var new_mask = List[Bool]()
+        for i in range(len(self._data)):
+            if self._is_null(i):
+                result.append(Int64(0))
+                new_mask.append(True)
+            else:
+                result.append(Int64(Int(py=self._data[i].second)))
+                new_mask.append(False)
+        var col = Column(self._name, ColumnData(result^), int64)
+        col._null_mask = new_mask^
+        return col^
 
     def dayofweek(self) raises -> Column:
-        _not_implemented("Series.dt.dayofweek")
-        return Column()
+        var result = List[Int64]()
+        var new_mask = List[Bool]()
+        for i in range(len(self._data)):
+            if self._is_null(i):
+                result.append(Int64(0))
+                new_mask.append(True)
+            else:
+                result.append(Int64(Int(py=self._data[i].dayofweek)))
+                new_mask.append(False)
+        var col = Column(self._name, ColumnData(result^), int64)
+        col._null_mask = new_mask^
+        return col^
 
     def dayofyear(self) raises -> Column:
-        _not_implemented("Series.dt.dayofyear")
-        return Column()
+        var result = List[Int64]()
+        var new_mask = List[Bool]()
+        for i in range(len(self._data)):
+            if self._is_null(i):
+                result.append(Int64(0))
+                new_mask.append(True)
+            else:
+                result.append(Int64(Int(py=self._data[i].dayofyear)))
+                new_mask.append(False)
+        var col = Column(self._name, ColumnData(result^), int64)
+        col._null_mask = new_mask^
+        return col^
 
     def quarter(self) raises -> Column:
-        _not_implemented("Series.dt.quarter")
-        return Column()
+        var result = List[Int64]()
+        var new_mask = List[Bool]()
+        for i in range(len(self._data)):
+            if self._is_null(i):
+                result.append(Int64(0))
+                new_mask.append(True)
+            else:
+                result.append(Int64(Int(py=self._data[i].quarter)))
+                new_mask.append(False)
+        var col = Column(self._name, ColumnData(result^), int64)
+        col._null_mask = new_mask^
+        return col^
+
+    # ------------------------------------------------------------------
+    # Object-returning properties
+    # ------------------------------------------------------------------
 
     def date(self) raises -> Column:
-        _not_implemented("Series.dt.date")
-        return Column()
+        var result = List[PythonObject]()
+        var new_mask = List[Bool]()
+        for i in range(len(self._data)):
+            if self._is_null(i):
+                result.append(PythonObject(None))
+                new_mask.append(True)
+            else:
+                result.append(self._data[i].date())
+                new_mask.append(False)
+        var col = Column(self._name, ColumnData(result^), object_)
+        col._null_mask = new_mask^
+        return col^
 
     def time(self) raises -> Column:
-        _not_implemented("Series.dt.time")
-        return Column()
+        var result = List[PythonObject]()
+        var new_mask = List[Bool]()
+        for i in range(len(self._data)):
+            if self._is_null(i):
+                result.append(PythonObject(None))
+                new_mask.append(True)
+            else:
+                result.append(self._data[i].time())
+                new_mask.append(False)
+        var col = Column(self._name, ColumnData(result^), object_)
+        col._null_mask = new_mask^
+        return col^
+
+    # ------------------------------------------------------------------
+    # Timezone / rounding — return datetime columns
+    # ------------------------------------------------------------------
 
     def tz_localize(self, tz: String) raises -> Column:
-        _not_implemented("Series.dt.tz_localize")
-        return Column()
+        var result = List[PythonObject]()
+        var new_mask = List[Bool]()
+        for i in range(len(self._data)):
+            if self._is_null(i):
+                result.append(PythonObject(None))
+                new_mask.append(True)
+            else:
+                result.append(self._data[i].tz_localize(tz))
+                new_mask.append(False)
+        var col = Column(self._name, ColumnData(result^), datetime64_ns)
+        col._null_mask = new_mask^
+        return col^
 
     def tz_convert(self, tz: String) raises -> Column:
-        _not_implemented("Series.dt.tz_convert")
-        return Column()
+        var result = List[PythonObject]()
+        var new_mask = List[Bool]()
+        for i in range(len(self._data)):
+            if self._is_null(i):
+                result.append(PythonObject(None))
+                new_mask.append(True)
+            else:
+                result.append(self._data[i].tz_convert(tz))
+                new_mask.append(False)
+        var col = Column(self._name, ColumnData(result^), datetime64_ns)
+        col._null_mask = new_mask^
+        return col^
 
     def floor(self, freq: String) raises -> Column:
-        _not_implemented("Series.dt.floor")
-        return Column()
+        var result = List[PythonObject]()
+        var new_mask = List[Bool]()
+        for i in range(len(self._data)):
+            if self._is_null(i):
+                result.append(PythonObject(None))
+                new_mask.append(True)
+            else:
+                result.append(self._data[i].floor(freq))
+                new_mask.append(False)
+        var col = Column(self._name, ColumnData(result^), datetime64_ns)
+        col._null_mask = new_mask^
+        return col^
 
     def ceil(self, freq: String) raises -> Column:
-        _not_implemented("Series.dt.ceil")
-        return Column()
+        var result = List[PythonObject]()
+        var new_mask = List[Bool]()
+        for i in range(len(self._data)):
+            if self._is_null(i):
+                result.append(PythonObject(None))
+                new_mask.append(True)
+            else:
+                result.append(self._data[i].ceil(freq))
+                new_mask.append(False)
+        var col = Column(self._name, ColumnData(result^), datetime64_ns)
+        col._null_mask = new_mask^
+        return col^
 
     def round(self, freq: String) raises -> Column:
-        _not_implemented("Series.dt.round")
-        return Column()
+        var result = List[PythonObject]()
+        var new_mask = List[Bool]()
+        for i in range(len(self._data)):
+            if self._is_null(i):
+                result.append(PythonObject(None))
+                new_mask.append(True)
+            else:
+                result.append(self._data[i].round(freq))
+                new_mask.append(False)
+        var col = Column(self._name, ColumnData(result^), datetime64_ns)
+        col._null_mask = new_mask^
+        return col^

--- a/tests/test_accessors.mojo
+++ b/tests/test_accessors.mojo
@@ -1,5 +1,5 @@
 """Tests for .str string accessor methods and .dt accessor stubs."""
-from std.python import Python
+from std.python import Python, PythonObject
 from std.testing import assert_true, assert_false, assert_equal, TestSuite
 from bison import Series
 
@@ -180,28 +180,144 @@ def test_str_split() raises:
     assert_equal(len(result[1]), 2)
 
 
-def test_dt_year_stub() raises:
+def test_dt_year() raises:
     var pd = Python.import_module("pandas")
-    var s = Series(pd.Series(pd.to_datetime(Python.evaluate("['2020-01-01', '2021-06-15']"))))
-    var raised = False
-    try:
-        var acc = s.dt()
-        _ = acc.year()
-    except:
-        raised = True
-    assert_true(raised)
+    var s = Series(pd.Series(pd.to_datetime(Python.evaluate("['2020-01-15', '2021-06-30']"))))
+    var result = Series(s.dt().year())
+    assert_equal(result.iloc(0)[Int64], Int64(2020))
+    assert_equal(result.iloc(1)[Int64], Int64(2021))
 
 
-def test_dt_month_stub() raises:
+def test_dt_month() raises:
     var pd = Python.import_module("pandas")
-    var s = Series(pd.Series(pd.to_datetime(Python.evaluate("['2020-01-01']"))))
-    var raised = False
-    try:
-        var acc = s.dt()
-        _ = acc.month()
-    except:
-        raised = True
-    assert_true(raised)
+    var s = Series(pd.Series(pd.to_datetime(Python.evaluate("['2020-01-15', '2021-06-30']"))))
+    var result = Series(s.dt().month())
+    assert_equal(result.iloc(0)[Int64], Int64(1))
+    assert_equal(result.iloc(1)[Int64], Int64(6))
+
+
+def test_dt_day() raises:
+    var pd = Python.import_module("pandas")
+    var s = Series(pd.Series(pd.to_datetime(Python.evaluate("['2020-01-15', '2021-06-30']"))))
+    var result = Series(s.dt().day())
+    assert_equal(result.iloc(0)[Int64], Int64(15))
+    assert_equal(result.iloc(1)[Int64], Int64(30))
+
+
+def test_dt_hour() raises:
+    var pd = Python.import_module("pandas")
+    var s = Series(pd.Series(pd.to_datetime(Python.evaluate("['2020-01-15 08:30:00', '2021-06-30 23:00:00']"))))
+    var result = Series(s.dt().hour())
+    assert_equal(result.iloc(0)[Int64], Int64(8))
+    assert_equal(result.iloc(1)[Int64], Int64(23))
+
+
+def test_dt_minute() raises:
+    var pd = Python.import_module("pandas")
+    var s = Series(pd.Series(pd.to_datetime(Python.evaluate("['2020-01-15 08:30:00', '2021-06-30 23:45:00']"))))
+    var result = Series(s.dt().minute())
+    assert_equal(result.iloc(0)[Int64], Int64(30))
+    assert_equal(result.iloc(1)[Int64], Int64(45))
+
+
+def test_dt_second() raises:
+    var pd = Python.import_module("pandas")
+    var s = Series(pd.Series(pd.to_datetime(Python.evaluate("['2020-01-15 08:30:15', '2021-06-30 23:45:59']"))))
+    var result = Series(s.dt().second())
+    assert_equal(result.iloc(0)[Int64], Int64(15))
+    assert_equal(result.iloc(1)[Int64], Int64(59))
+
+
+def test_dt_dayofweek() raises:
+    var pd = Python.import_module("pandas")
+    # 2020-01-06 is Monday (0), 2020-01-12 is Sunday (6)
+    var s = Series(pd.Series(pd.to_datetime(Python.evaluate("['2020-01-06', '2020-01-12']"))))
+    var result = Series(s.dt().dayofweek())
+    assert_equal(result.iloc(0)[Int64], Int64(0))
+    assert_equal(result.iloc(1)[Int64], Int64(6))
+
+
+def test_dt_dayofyear() raises:
+    var pd = Python.import_module("pandas")
+    # 2020-01-01 is day 1, 2020-12-31 is day 366 (2020 is a leap year)
+    var s = Series(pd.Series(pd.to_datetime(Python.evaluate("['2020-01-01', '2020-12-31']"))))
+    var result = Series(s.dt().dayofyear())
+    assert_equal(result.iloc(0)[Int64], Int64(1))
+    assert_equal(result.iloc(1)[Int64], Int64(366))
+
+
+def test_dt_quarter() raises:
+    var pd = Python.import_module("pandas")
+    var s = Series(pd.Series(pd.to_datetime(Python.evaluate("['2020-01-15', '2020-07-01']"))))
+    var result = Series(s.dt().quarter())
+    assert_equal(result.iloc(0)[Int64], Int64(1))
+    assert_equal(result.iloc(1)[Int64], Int64(3))
+
+
+def test_dt_date() raises:
+    var pd = Python.import_module("pandas")
+    var s = Series(pd.Series(pd.to_datetime(Python.evaluate("['2020-01-15', '2021-06-30']"))))
+    var acc = s.dt()
+    var col = acc.date()
+    # date() returns a PythonObject column; verify against pandas
+    var pd_result = pd.Series(pd.to_datetime(Python.evaluate("['2020-01-15', '2021-06-30']"))).dt.date
+    assert_equal(String(col._data[List[PythonObject]][0].__str__()), String(pd_result[0].__str__()))
+    assert_equal(String(col._data[List[PythonObject]][1].__str__()), String(pd_result[1].__str__()))
+
+
+def test_dt_time() raises:
+    var pd = Python.import_module("pandas")
+    var s = Series(pd.Series(pd.to_datetime(Python.evaluate("['2020-01-15 08:30:15', '2021-06-30 23:45:59']"))))
+    var acc = s.dt()
+    var col = acc.time()
+    var pd_result = pd.Series(pd.to_datetime(Python.evaluate("['2020-01-15 08:30:15', '2021-06-30 23:45:59']"))).dt.time
+    assert_equal(String(col._data[List[PythonObject]][0].__str__()), String(pd_result[0].__str__()))
+    assert_equal(String(col._data[List[PythonObject]][1].__str__()), String(pd_result[1].__str__()))
+
+
+def test_dt_floor() raises:
+    var pd = Python.import_module("pandas")
+    var s = Series(pd.Series(pd.to_datetime(Python.evaluate("['2020-01-15 08:37:00', '2021-06-30 23:45:00']"))))
+    var col = s.dt().floor("h")
+    var pd_result = pd.Series(pd.to_datetime(Python.evaluate("['2020-01-15 08:37:00', '2021-06-30 23:45:00']"))).dt.floor("h")
+    assert_equal(String(col._data[List[PythonObject]][0].__str__()), String(pd_result[0].__str__()))
+    assert_equal(String(col._data[List[PythonObject]][1].__str__()), String(pd_result[1].__str__()))
+
+
+def test_dt_ceil() raises:
+    var pd = Python.import_module("pandas")
+    var s = Series(pd.Series(pd.to_datetime(Python.evaluate("['2020-01-15 08:37:00', '2021-06-30 23:01:00']"))))
+    var col = s.dt().ceil("h")
+    var pd_result = pd.Series(pd.to_datetime(Python.evaluate("['2020-01-15 08:37:00', '2021-06-30 23:01:00']"))).dt.ceil("h")
+    assert_equal(String(col._data[List[PythonObject]][0].__str__()), String(pd_result[0].__str__()))
+    assert_equal(String(col._data[List[PythonObject]][1].__str__()), String(pd_result[1].__str__()))
+
+
+def test_dt_round() raises:
+    var pd = Python.import_module("pandas")
+    var s = Series(pd.Series(pd.to_datetime(Python.evaluate("['2020-01-15 08:20:00', '2021-06-30 23:50:00']"))))
+    var col = s.dt().round("h")
+    var pd_result = pd.Series(pd.to_datetime(Python.evaluate("['2020-01-15 08:20:00', '2021-06-30 23:50:00']"))).dt.round("h")
+    assert_equal(String(col._data[List[PythonObject]][0].__str__()), String(pd_result[0].__str__()))
+    assert_equal(String(col._data[List[PythonObject]][1].__str__()), String(pd_result[1].__str__()))
+
+
+def test_dt_tz_localize() raises:
+    var pd = Python.import_module("pandas")
+    var s = Series(pd.Series(pd.to_datetime(Python.evaluate("['2020-01-15 08:00:00', '2021-06-30 12:00:00']"))))
+    var col = s.dt().tz_localize("UTC")
+    var pd_result = pd.Series(pd.to_datetime(Python.evaluate("['2020-01-15 08:00:00', '2021-06-30 12:00:00']"))).dt.tz_localize("UTC")
+    assert_equal(String(col._data[List[PythonObject]][0].__str__()), String(pd_result[0].__str__()))
+    assert_equal(String(col._data[List[PythonObject]][1].__str__()), String(pd_result[1].__str__()))
+
+
+def test_dt_tz_convert() raises:
+    var pd = Python.import_module("pandas")
+    var s = Series(pd.Series(pd.to_datetime(Python.evaluate("['2020-01-15 08:00:00', '2021-06-30 12:00:00']")).tz_localize("UTC")))
+    var col = s.dt().tz_convert("US/Eastern")
+    var pd_result = pd.Series(pd.to_datetime(Python.evaluate("['2020-01-15 08:00:00', '2021-06-30 12:00:00']")).tz_localize("UTC")).dt.tz_convert("US/Eastern")
+    assert_equal(String(col._data[List[PythonObject]][0].__str__()), String(pd_result[0].__str__()))
+    assert_equal(String(col._data[List[PythonObject]][1].__str__()), String(pd_result[1].__str__()))
 
 
 def main() raises:


### PR DESCRIPTION
All 16 .dt accessor methods are now implemented natively in Mojo by
iterating over the stored List[PythonObject] Timestamp elements and
extracting attributes/calling methods via Python interop:

- Integer properties: year, month, day, hour, minute, second,
  dayofweek, dayofyear, quarter → return int64 Column
- Object properties: date(), time() → return object Column
- Datetime operations: tz_localize, tz_convert, floor, ceil, round
  → return datetime64_ns Column

Series.dt() now validates the column dtype and populates DatetimeMethods
with the column's data, mirroring the StringMethods accessor pattern.

Tests updated: replaced 2 stub tests with 16 real tests covering all
methods, asserting values match pandas output.

https://claude.ai/code/session_019ZLNMPbZgBGFouZ6n3xehS