### PR TITLE
feat: implement Series.dtype() natively

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ In CI it runs after the test suite and the result is committed back to the branc
 | Category | Stubs | Implemented |
 |----------|-------|-------------|
 | DataFrame | 39 | 96 |
-| Series | 11 | 86 |
+| Series | 10 | 87 |
 | GroupBy (DataFrame) | 16 | 1 |
 | GroupBy (Series) | 15 | 1 |
 | String accessor | 0 | 21 |
@@ -91,7 +91,7 @@ In CI it runs after the test suite and the result is committed back to the branc
 | Index | 0 | 14 |
 | IO | 5 | 6 |
 | Reshape | 1 | 0 |
-| **Total** | **87** | **245** |
+| **Total** | **86** | **246** |
 <!-- COMPAT_TABLE_END -->
 
 ## Known limitations

--- a/bison/_frame.mojo
+++ b/bison/_frame.mojo
@@ -65,9 +65,8 @@ struct Series(Copyable, Movable):
     def empty(self) -> Bool:
         return self._col.__len__() == 0
 
-    def dtype(self) raises -> BisonDtype:
-        _not_implemented("Series.dtype")
-        return object_
+    def dtype(self) -> BisonDtype:
+        return self._col.dtype
 
     # ------------------------------------------------------------------
     # Selection

--- a/tests/test_series_construction.mojo
+++ b/tests/test_series_construction.mojo
@@ -30,6 +30,18 @@ def test_empty_true() raises:
     assert_true(s.empty())
 
 
+def test_dtype_int64() raises:
+    var pd = Python.import_module("pandas")
+    var s = Series(pd.Series(Python.evaluate("[1, 2, 3]"), dtype="int64"))
+    assert_equal(s.dtype().name, "int64")
+
+
+def test_dtype_float64() raises:
+    var pd = Python.import_module("pandas")
+    var s = Series(pd.Series(Python.evaluate("[1.0, 2.0]"), dtype="float64"))
+    assert_equal(s.dtype().name, "float64")
+
+
 def test_shape() raises:
     var pd = Python.import_module("pandas")
     var s = Series(pd.Series(Python.evaluate("[1, 2, 3, 4]")))


### PR DESCRIPTION
Removes the _not_implemented stub and delegates directly to
self._col.dtype, which is already set correctly on construction.
Adds two tests (int64 and float64) to test_series_construction.mojo.

Closes #326

https://claude.ai/code/session_0118YLtsyiX8QTcrV7DgK815