### PR TITLE
fix: raise on dtype mismatch in _ConcatDataVisitor (closes #330)

### DIFF
--- a/bison/column.mojo
+++ b/bison/column.mojo
@@ -1843,7 +1843,7 @@ struct _SliceVisitor(ColumnDataVisitor, Copyable, Movable):
         self.result = ColumnData(result^)
 
 
-struct _ConcatDataVisitor(ColumnDataVisitor, Copyable, Movable):
+struct _ConcatDataVisitor(ColumnDataVisitorRaises, Copyable, Movable):
     """Appends *other* data onto the visited arm's list."""
 
     var other: ColumnData
@@ -1853,44 +1853,49 @@ struct _ConcatDataVisitor(ColumnDataVisitor, Copyable, Movable):
         self.other = other
         self.result = ColumnData(List[PythonObject]())
 
-    def on_int64(mut self, data: List[Int64]):
+    def on_int64(mut self, data: List[Int64]) raises:
+        if not self.other.isa[List[Int64]]():
+            raise Error("concat: dtype mismatch")
         var out = data.copy()
-        if self.other.isa[List[Int64]]():
-            ref o = self.other[List[Int64]]
-            for i in range(len(o)):
-                out.append(o[i])
+        ref o = self.other[List[Int64]]
+        for i in range(len(o)):
+            out.append(o[i])
         self.result = ColumnData(out^)
 
-    def on_float64(mut self, data: List[Float64]):
+    def on_float64(mut self, data: List[Float64]) raises:
+        if not self.other.isa[List[Float64]]():
+            raise Error("concat: dtype mismatch")
         var out = data.copy()
-        if self.other.isa[List[Float64]]():
-            ref o = self.other[List[Float64]]
-            for i in range(len(o)):
-                out.append(o[i])
+        ref o = self.other[List[Float64]]
+        for i in range(len(o)):
+            out.append(o[i])
         self.result = ColumnData(out^)
 
-    def on_bool(mut self, data: List[Bool]):
+    def on_bool(mut self, data: List[Bool]) raises:
+        if not self.other.isa[List[Bool]]():
+            raise Error("concat: dtype mismatch")
         var out = data.copy()
-        if self.other.isa[List[Bool]]():
-            ref o = self.other[List[Bool]]
-            for i in range(len(o)):
-                out.append(o[i])
+        ref o = self.other[List[Bool]]
+        for i in range(len(o)):
+            out.append(o[i])
         self.result = ColumnData(out^)
 
-    def on_str(mut self, data: List[String]):
+    def on_str(mut self, data: List[String]) raises:
+        if not self.other.isa[List[String]]():
+            raise Error("concat: dtype mismatch")
         var out = data.copy()
-        if self.other.isa[List[String]]():
-            ref o = self.other[List[String]]
-            for i in range(len(o)):
-                out.append(o[i])
+        ref o = self.other[List[String]]
+        for i in range(len(o)):
+            out.append(o[i])
         self.result = ColumnData(out^)
 
-    def on_obj(mut self, data: List[PythonObject]):
+    def on_obj(mut self, data: List[PythonObject]) raises:
+        if not self.other.isa[List[PythonObject]]():
+            raise Error("concat: dtype mismatch")
         var out = data.copy()
-        if self.other.isa[List[PythonObject]]():
-            ref o = self.other[List[PythonObject]]
-            for i in range(len(o)):
-                out.append(o[i])
+        ref o = self.other[List[PythonObject]]
+        for i in range(len(o)):
+            out.append(o[i])
         self.result = ColumnData(out^)
 
 
@@ -3384,7 +3389,7 @@ struct Column(Copyable, Movable, Sized):
     def concat(self, other: Column) raises -> Column:
         """Return a new Column with *other* appended row-wise."""
         var visitor = _ConcatDataVisitor(other._data)
-        visit_col_data(visitor, self._data)
+        visit_col_data_raises(visitor, self._data)
         var col = Column(self.name, visitor^.result, self.dtype)
         # Merge null masks only when at least one side has nulls
         if len(self._null_mask) > 0 or len(other._null_mask) > 0:

--- a/tests/test_concat.mojo
+++ b/tests/test_concat.mojo
@@ -162,5 +162,18 @@ def test_concat_keys_raises() raises:
     assert_true(raised)
 
 
+def test_append_dtype_mismatch_raises() raises:
+    """Appending a Float64 column onto an Int64 column must raise, not silently drop data."""
+    var pd = Python.import_module("pandas")
+    var df1 = DataFrame(pd.DataFrame(Python.evaluate("{'x': [1, 2]}")))
+    var df2 = DataFrame(pd.DataFrame(Python.evaluate("{'x': [1.5, 2.5]}")))
+    var raised = False
+    try:
+        _ = df1.append(df2)
+    except e:
+        raised = "dtype mismatch" in String(e)
+    assert_true(raised)
+
+
 def main() raises:
     TestSuite.discover_tests[__functions_in_module()]().run()


### PR DESCRIPTION
Silent no-ops in each on_* arm caused Column.concat (used by
DataFrame.append) to silently return truncated data when self and other
had different storage types (e.g. Int64 vs Float64 same-named column).
Each arm now raises "concat: dtype mismatch" immediately, and the struct
is upgraded from ColumnDataVisitor to ColumnDataVisitorRaises so the
error propagates through visit_col_data_raises.

TDD: test_append_dtype_mismatch_raises was written red first, then the
fix was applied to make it green.

https://claude.ai/code/session_012LgUsdXGzxxWaiXDEUsk8b