### PR TITLE
fix: use PythonObject(None) as null placeholder in _TakeWithNullsVisitor.on_obj (closes #331)

### DIFF
--- a/bison/column.mojo
+++ b/bison/column.mojo
@@ -2015,7 +2015,7 @@ struct _TakeWithNullsVisitor(ColumnDataVisitor, Copyable, Movable):
         for k in range(len(self.indices)):
             var i = self.indices[k]
             if i < 0:
-                out.append(data[0] if len(data) > 0 else PythonObject(None))
+                out.append(PythonObject(None))
                 self.out_mask.append(True)
             else:
                 out.append(data[i])

--- a/tests/test_combining.mojo
+++ b/tests/test_combining.mojo
@@ -1,5 +1,5 @@
 """Tests for DataFrame combining methods: merge, join, append."""
-from std.python import Python
+from std.python import Python, PythonObject
 from std.testing import assert_true, assert_equal, TestSuite
 from bison import DataFrame
 
@@ -183,6 +183,34 @@ def test_join_sort_raises() raises:
         assert_true("not implemented" in String(e))
     if not raised:
         raise Error("join with sort=True should have raised")
+
+
+def test_take_with_nulls_obj_col_null_placeholder_is_none() raises:
+    """take_with_nulls on a PythonObject column must emit None (not data[0])
+    as the null placeholder for unmatched rows.  Regression test for #331."""
+    var pd = Python.import_module("pandas")
+    # Build a right frame whose 'tag' column is object-dtype so bison stores
+    # it as List[PythonObject].  Only key=1 is present on the right side.
+    var make_right = Python.evaluate(
+        "lambda pd: pd.DataFrame({'key': [1], 'tag': pd.Series([99], dtype=object)})"
+    )
+    var right_pd = make_right(pd)
+    var left = DataFrame(pd.DataFrame(Python.evaluate("{'key': [1, 2], 'a': [10, 20]}")))
+    var right = DataFrame(right_pd)
+    var on = List[String]()
+    on.append("key")
+    var result = left.merge(right, how="left", on=on^)
+    # Row 0 (key=1): matched — tag should be 99, not null.
+    # Row 1 (key=2): unmatched — tag should be null, NOT 99 (which is data[0]).
+    assert_equal(result.shape()[0], 2)
+    # to_pandas() for List[PythonObject] columns passes raw data unconditionally
+    # (no null-mask override).  With the bug, data[0]=99 is the placeholder so
+    # the round-trip exposes it as 99 instead of NaN.
+    var result_pd = result.to_pandas()
+    var check = Python.evaluate(
+        "lambda df: __import__('pandas').isna(df['tag'].iloc[1])"
+    )
+    assert_true(Bool(check(result_pd).__bool__()))  # fails with bug, passes after fix
 
 
 def main() raises:


### PR DESCRIPTION
Previously, on_obj copied data[0] as the placeholder value for index -1 rows,
making the stored null indistinguishable from a real value. _ToPandasVisitor
appends List[PythonObject] data unconditionally, so the round-trip returned
data[0] instead of NaN for unmatched merge rows.

Replace with PythonObject(None), consistent with _null_column's PythonObject arm.
Added a regression test that left-merges on a pandas object-dtype column and
verifies the unmatched row round-trips as NaN via to_pandas().

https://claude.ai/code/session_01766vwD5qqhsqGKU4wSUx3M