### PR TITLE
fix: merge key column now carries right value for right-only rows (closes #334)

### DIFF
--- a/bison/_frame.mojo
+++ b/bison/_frame.mojo
@@ -3960,12 +3960,69 @@ struct DataFrame(Copyable, Movable):
         # Build output columns.
         var result_cols = List[Column]()
 
-        # Key columns: use left values (null where left row is unmatched).
-        # Tests for outer/right join only check shape, so null keys are fine.
+        # Key columns: left values for matched/left-only rows; right values for
+        # right-only rows (out_left[r] == -1).  Inner/left joins have no
+        # right-only rows so the fill loop is a no-op for those cases.
         for k in range(len(lkeys)):
             for i in range(len(self._cols)):
                 if self._cols[i].name == lkeys[k]:
-                    result_cols.append(self._cols[i].take_with_nulls(out_left))
+                    var key_col = self._cols[i].take_with_nulls(out_left)
+                    # For right-only rows, substitute the right frame's key value.
+                    for j in range(len(right._cols)):
+                        if right._cols[j].name == lkeys[k]:
+                            ref rk = right._cols[j]
+                            if (
+                                key_col._data.isa[List[Int64]]()
+                                and rk._data.isa[List[Int64]]()
+                            ):
+                                for r in range(len(out_left)):
+                                    if out_left[r] < 0:
+                                        key_col._int64_data()[
+                                            r
+                                        ] = rk._int64_data()[out_right[r]]
+                                        key_col._null_mask[r] = False
+                            elif (
+                                key_col._data.isa[List[Float64]]()
+                                and rk._data.isa[List[Float64]]()
+                            ):
+                                for r in range(len(out_left)):
+                                    if out_left[r] < 0:
+                                        key_col._float64_data()[
+                                            r
+                                        ] = rk._float64_data()[out_right[r]]
+                                        key_col._null_mask[r] = False
+                            elif (
+                                key_col._data.isa[List[Bool]]()
+                                and rk._data.isa[List[Bool]]()
+                            ):
+                                for r in range(len(out_left)):
+                                    if out_left[r] < 0:
+                                        key_col._bool_data()[
+                                            r
+                                        ] = rk._bool_data()[out_right[r]]
+                                        key_col._null_mask[r] = False
+                            elif (
+                                key_col._data.isa[List[String]]()
+                                and rk._data.isa[List[String]]()
+                            ):
+                                for r in range(len(out_left)):
+                                    if out_left[r] < 0:
+                                        key_col._str_data()[r] = rk._str_data()[
+                                            out_right[r]
+                                        ]
+                                        key_col._null_mask[r] = False
+                            elif (
+                                key_col._data.isa[List[PythonObject]]()
+                                and rk._data.isa[List[PythonObject]]()
+                            ):
+                                for r in range(len(out_left)):
+                                    if out_left[r] < 0:
+                                        key_col._obj_data()[r] = rk._obj_data()[
+                                            out_right[r]
+                                        ]
+                                        key_col._null_mask[r] = False
+                            break
+                    result_cols.append(key_col^)
                     break
 
         # Left non-key columns.

--- a/tests/test_combining.mojo
+++ b/tests/test_combining.mojo
@@ -213,5 +213,58 @@ def test_take_with_nulls_obj_col_null_placeholder_is_none() raises:
     assert_true(Bool(check(result_pd).__bool__()))  # fails with bug, passes after fix
 
 
+def test_merge_outer_key_col_right_only_rows() raises:
+    """outer join: right-only rows must carry the right key value, not NaN.
+
+    Regression test for issue #334: the key column was built exclusively from
+    take_with_nulls(out_left), so any row where out_left[r]==-1 (right-only)
+    emitted null instead of the right frame's key value.
+    """
+    var pd = Python.import_module("pandas")
+    var left = DataFrame(pd.DataFrame(Python.evaluate("{'key': [1, 2], 'val': [10, 20]}")))
+    var right = DataFrame(pd.DataFrame(Python.evaluate("{'key': [2, 3], 'val': [200, 300]}")))
+    var on = List[String]()
+    on.append("key")
+    var suf = List[String]()
+    suf.append("_left")
+    suf.append("_right")
+    var result = left.merge(right, how="outer", on=on^, suffixes=Optional[List[String]](suf^))
+    assert_equal(result.shape()[0], 3)
+    # Row order: row 0 = left-only (key=1), row 1 = matched (key=2),
+    # row 2 = right-only (key=3 — was null before fix).
+    var result_pd = result.to_pandas()
+    var key_col_pd = result_pd["key"]
+    assert_true(
+        not Bool(py=pd.isna(key_col_pd.iloc[2])),
+        "right-only row key must not be NaN",
+    )
+    assert_equal(Int(py=key_col_pd.iloc[2]), 3)
+
+
+def test_merge_right_key_col_right_only_rows() raises:
+    """right join: right-only rows must carry the right key value, not NaN.
+
+    Regression test for issue #334.
+    """
+    var pd = Python.import_module("pandas")
+    var left = DataFrame(pd.DataFrame(Python.evaluate("{'key': [1, 2], 'val': [10, 20]}")))
+    var right = DataFrame(pd.DataFrame(Python.evaluate("{'key': [2, 3], 'val': [200, 300]}")))
+    var on = List[String]()
+    on.append("key")
+    var suf = List[String]()
+    suf.append("_left")
+    suf.append("_right")
+    var result = left.merge(right, how="right", on=on^, suffixes=Optional[List[String]](suf^))
+    assert_equal(result.shape()[0], 2)
+    # Row 0 = matched (key=2), row 1 = right-only (key=3 — was null before fix).
+    var result_pd = result.to_pandas()
+    var key_col_pd = result_pd["key"]
+    assert_true(
+        not Bool(py=pd.isna(key_col_pd.iloc[1])),
+        "right-only row key must not be NaN",
+    )
+    assert_equal(Int(py=key_col_pd.iloc[1]), 3)
+
+
 def main() raises:
     TestSuite.discover_tests[__functions_in_module()]().run()


### PR DESCRIPTION
In outer/right joins, rows where only the right side matched previously emitted
null for the key column because take_with_nulls(out_left) was used exclusively.
The fix iterates over right-only positions (out_left[r] == -1) after the initial
take and overwrites the null placeholder with the corresponding right key value,
arm-by-arm across all five ColumnData types.

https://claude.ai/code/session_01Nh2iSZFLWVbmQ5VBjZdXXF