### PR TITLE
fix: preserve int64 dtype in GroupBy sum/min/max (#383)

### DIFF
--- a/bison/_frame.mojo
+++ b/bison/_frame.mojo
@@ -4885,12 +4885,22 @@ struct DataFrameGroupBy:
                 continue
             if not (col.dtype.is_integer() or col.dtype.is_float()):
                 continue
-            var vals = List[Float64]()
-            for j in range(len(self._group_keys)):
-                vals.append(
-                    col.take(self._group_map[self._group_keys[j]]).sum()
-                )
-            result_cols.append(self._make_result_col(col.name, vals^))
+            if col.dtype.is_integer():
+                var vals = List[Int64]()
+                for j in range(len(self._group_keys)):
+                    vals.append(
+                        col.take(
+                            self._group_map[self._group_keys[j]]
+                        ).sum_int64()
+                    )
+                result_cols.append(self._make_result_col_int64(col.name, vals^))
+            else:
+                var vals = List[Float64]()
+                for j in range(len(self._group_keys)):
+                    vals.append(
+                        col.take(self._group_map[self._group_keys[j]]).sum()
+                    )
+                result_cols.append(self._make_result_col(col.name, vals^))
         return DataFrame(result_cols^)
 
     def mean(self) raises -> DataFrame:
@@ -4927,12 +4937,22 @@ struct DataFrameGroupBy:
                 continue
             if not (col.dtype.is_integer() or col.dtype.is_float()):
                 continue
-            var vals = List[Float64]()
-            for j in range(len(self._group_keys)):
-                vals.append(
-                    col.take(self._group_map[self._group_keys[j]]).min()
-                )
-            result_cols.append(self._make_result_col(col.name, vals^))
+            if col.dtype.is_integer():
+                var vals = List[Int64]()
+                for j in range(len(self._group_keys)):
+                    vals.append(
+                        col.take(
+                            self._group_map[self._group_keys[j]]
+                        ).min_int64()
+                    )
+                result_cols.append(self._make_result_col_int64(col.name, vals^))
+            else:
+                var vals = List[Float64]()
+                for j in range(len(self._group_keys)):
+                    vals.append(
+                        col.take(self._group_map[self._group_keys[j]]).min()
+                    )
+                result_cols.append(self._make_result_col(col.name, vals^))
         return DataFrame(result_cols^)
 
     def max(self) raises -> DataFrame:
@@ -4948,12 +4968,22 @@ struct DataFrameGroupBy:
                 continue
             if not (col.dtype.is_integer() or col.dtype.is_float()):
                 continue
-            var vals = List[Float64]()
-            for j in range(len(self._group_keys)):
-                vals.append(
-                    col.take(self._group_map[self._group_keys[j]]).max()
-                )
-            result_cols.append(self._make_result_col(col.name, vals^))
+            if col.dtype.is_integer():
+                var vals = List[Int64]()
+                for j in range(len(self._group_keys)):
+                    vals.append(
+                        col.take(
+                            self._group_map[self._group_keys[j]]
+                        ).max_int64()
+                    )
+                result_cols.append(self._make_result_col_int64(col.name, vals^))
+            else:
+                var vals = List[Float64]()
+                for j in range(len(self._group_keys)):
+                    vals.append(
+                        col.take(self._group_map[self._group_keys[j]]).max()
+                    )
+                result_cols.append(self._make_result_col(col.name, vals^))
         return DataFrame(result_cols^)
 
     def std(self, ddof: Int = 1) raises -> DataFrame:
@@ -5199,7 +5229,13 @@ struct DataFrameGroupBy:
                 result_col.name = col.name
                 result_cols.append(result_col^)
             return DataFrame(result_cols^)
-        # Float64-returning scalar-broadcast functions.
+        # Detect whether any row has no group key (dropna null-key row).
+        var any_null_row = False
+        for r in range(n_rows):
+            if row_key[r] == "":
+                any_null_row = True
+                break
+        # Scalar-broadcast functions (float64 or int64-preserving).
         var needs_numeric = (
             func == "sum"
             or func == "mean"
@@ -5208,6 +5244,7 @@ struct DataFrameGroupBy:
             or func == "std"
             or func == "var"
         )
+        var int_preserving = func == "sum" or func == "min" or func == "max"
         var result_cols = List[Column]()
         for i in range(len(self._df._cols)):
             ref col = self._df._cols[i]
@@ -5216,6 +5253,25 @@ struct DataFrameGroupBy:
             if needs_numeric and not (
                 col.dtype.is_integer() or col.dtype.is_float()
             ):
+                continue
+            # Integer-preserving path: only when no null rows can arise.
+            if int_preserving and col.dtype.is_integer() and not any_null_row:
+                var key_to_int = Dict[String, Int64]()
+                for j in range(len(self._group_keys)):
+                    var key = self._group_keys[j]
+                    var sub = col.take(self._group_map[key])
+                    if func == "sum":
+                        key_to_int[key] = sub.sum_int64()
+                    elif func == "min":
+                        key_to_int[key] = sub.min_int64()
+                    else:  # max
+                        key_to_int[key] = sub.max_int64()
+                var int_vals = List[Int64]()
+                for r in range(n_rows):
+                    int_vals.append(key_to_int[row_key[r]])
+                result_cols.append(
+                    Column(col.name, ColumnData(int_vals^), int64)
+                )
                 continue
             var key_to_val = Dict[String, Float64]()
             for j in range(len(self._group_keys)):
@@ -5319,13 +5375,23 @@ struct SeriesGroupBy:
         )
 
     def sum(self) raises -> Series:
+        var idx = ColumnIndex(Index(self._group_keys.copy()))
+        if self._series._col.dtype.is_integer():
+            var result_vals = List[Int64]()
+            for i in range(len(self._group_keys)):
+                var key = self._group_keys[i]
+                result_vals.append(
+                    self._series._col.take(self._group_map[key]).sum_int64()
+                )
+            return Series(
+                Column(self._series.name, ColumnData(result_vals^), int64, idx^)
+            )
         var result_vals = List[Float64]()
         for i in range(len(self._group_keys)):
             var key = self._group_keys[i]
             result_vals.append(
                 self._series._col.take(self._group_map[key]).sum()
             )
-        var idx = ColumnIndex(Index(self._group_keys.copy()))
         return Series(
             Column(self._series.name, ColumnData(result_vals^), float64, idx^)
         )
@@ -5343,25 +5409,45 @@ struct SeriesGroupBy:
         )
 
     def min(self) raises -> Series:
+        var idx = ColumnIndex(Index(self._group_keys.copy()))
+        if self._series._col.dtype.is_integer():
+            var result_vals = List[Int64]()
+            for i in range(len(self._group_keys)):
+                var key = self._group_keys[i]
+                result_vals.append(
+                    self._series._col.take(self._group_map[key]).min_int64()
+                )
+            return Series(
+                Column(self._series.name, ColumnData(result_vals^), int64, idx^)
+            )
         var result_vals = List[Float64]()
         for i in range(len(self._group_keys)):
             var key = self._group_keys[i]
             result_vals.append(
                 self._series._col.take(self._group_map[key]).min()
             )
-        var idx = ColumnIndex(Index(self._group_keys.copy()))
         return Series(
             Column(self._series.name, ColumnData(result_vals^), float64, idx^)
         )
 
     def max(self) raises -> Series:
+        var idx = ColumnIndex(Index(self._group_keys.copy()))
+        if self._series._col.dtype.is_integer():
+            var result_vals = List[Int64]()
+            for i in range(len(self._group_keys)):
+                var key = self._group_keys[i]
+                result_vals.append(
+                    self._series._col.take(self._group_map[key]).max_int64()
+                )
+            return Series(
+                Column(self._series.name, ColumnData(result_vals^), int64, idx^)
+            )
         var result_vals = List[Float64]()
         for i in range(len(self._group_keys)):
             var key = self._group_keys[i]
             result_vals.append(
                 self._series._col.take(self._group_map[key]).max()
             )
-        var idx = ColumnIndex(Index(self._group_keys.copy()))
         return Series(
             Column(self._series.name, ColumnData(result_vals^), float64, idx^)
         )
@@ -5486,6 +5572,29 @@ struct SeriesGroupBy:
         return self.agg(func)
 
     def transform(self, func: String) raises -> Series:
+        # Integer-preserving scalar-broadcast path for sum / min / max.
+        var int_preserving = func == "sum" or func == "min" or func == "max"
+        if int_preserving and self._series._col.dtype.is_integer():
+            var key_to_int = Dict[String, Int64]()
+            for i in range(len(self._group_keys)):
+                var key = self._group_keys[i]
+                var sub = self._series._col.take(self._group_map[key])
+                if func == "sum":
+                    key_to_int[key] = sub.sum_int64()
+                elif func == "min":
+                    key_to_int[key] = sub.min_int64()
+                else:  # max
+                    key_to_int[key] = sub.max_int64()
+            var n = len(self._series._col)
+            var int_vals = List[Int64]()
+            for i in range(n):
+                int_vals.append(key_to_int[self._by[i]])
+            var result_col = Column(
+                self._series.name, ColumnData(int_vals^), int64
+            )
+            result_col._index = self._series._col._index
+            result_col._index_name = self._series._col._index_name
+            return Series(result_col^)
         # Float64-returning scalar-broadcast functions
         if (
             func == "sum"

--- a/bison/column.mojo
+++ b/bison/column.mojo
@@ -3642,6 +3642,45 @@ struct Column(Copyable, Movable, Sized):
             return zero / zero
         return visitor.result
 
+    def sum_int64(self) raises -> Int64:
+        """Return the sum of an Int64 column as Int64, skipping nulls."""
+        ref data = self._int64_data()
+        var has_mask = len(self._null_mask) > 0
+        var result = Int64(0)
+        for i in range(len(data)):
+            if has_mask and self._null_mask[i]:
+                continue
+            result += data[i]
+        return result
+
+    def min_int64(self) raises -> Int64:
+        """Return the minimum of an Int64 column as Int64, skipping nulls."""
+        ref data = self._int64_data()
+        var has_mask = len(self._null_mask) > 0
+        var found = False
+        var result = Int64(0)
+        for i in range(len(data)):
+            if has_mask and self._null_mask[i]:
+                continue
+            if not found or data[i] < result:
+                result = data[i]
+                found = True
+        return result
+
+    def max_int64(self) raises -> Int64:
+        """Return the maximum of an Int64 column as Int64, skipping nulls."""
+        ref data = self._int64_data()
+        var has_mask = len(self._null_mask) > 0
+        var found = False
+        var result = Int64(0)
+        for i in range(len(data)):
+            if has_mask and self._null_mask[i]:
+                continue
+            if not found or data[i] > result:
+                result = data[i]
+                found = True
+        return result
+
     def var(self, ddof: Int = 1, skipna: Bool = True) raises -> Float64:
         """Return the variance with Bessel correction (ddof=1 by default).
 

--- a/tests/test_groupby.mojo
+++ b/tests/test_groupby.mojo
@@ -26,8 +26,7 @@ def test_dataframegroupby_sum() raises:
     var by = List[String]()
     by.append("grp")
     var result = df.groupby(by).sum().to_pandas()
-    # check_dtype=False: native returns float64; pandas returns int64 for integer columns
-    testing.assert_frame_equal(result, pd_df.groupby("grp").sum(), check_dtype=False)
+    testing.assert_frame_equal(result, pd_df.groupby("grp").sum())
 
 
 def test_dataframegroupby_mean() raises:
@@ -47,8 +46,7 @@ def test_dataframegroupby_min() raises:
     var by = List[String]()
     by.append("grp")
     var result = df.groupby(by).min().to_pandas()
-    # check_dtype=False: native returns float64; pandas returns int64 for integer columns
-    testing.assert_frame_equal(result, pd_df.groupby("grp").min(), check_dtype=False)
+    testing.assert_frame_equal(result, pd_df.groupby("grp").min())
 
 
 def test_dataframegroupby_max() raises:
@@ -58,8 +56,7 @@ def test_dataframegroupby_max() raises:
     var by = List[String]()
     by.append("grp")
     var result = df.groupby(by).max().to_pandas()
-    # check_dtype=False: native returns float64; pandas returns int64 for integer columns
-    testing.assert_frame_equal(result, pd_df.groupby("grp").max(), check_dtype=False)
+    testing.assert_frame_equal(result, pd_df.groupby("grp").max())
 
 
 def test_dataframegroupby_count() raises:
@@ -141,8 +138,7 @@ def test_dataframegroupby_agg() raises:
     var by = List[String]()
     by.append("grp")
     var result = df.groupby(by).agg("sum").to_pandas()
-    # check_dtype=False: dispatches to sum() which returns float64 for integer columns
-    testing.assert_frame_equal(result, pd_df.groupby("grp").agg("sum"), check_dtype=False)
+    testing.assert_frame_equal(result, pd_df.groupby("grp").agg("sum"))
 
 
 def test_dataframegroupby_transform() raises:
@@ -152,8 +148,7 @@ def test_dataframegroupby_transform() raises:
     var by = List[String]()
     by.append("grp")
     var result = df.groupby(by).transform("sum").to_pandas()
-    # check_dtype=False: native returns float64; pandas returns int64 for integer columns
-    testing.assert_frame_equal(result, pd_df.groupby("grp").transform("sum"), check_dtype=False)
+    testing.assert_frame_equal(result, pd_df.groupby("grp").transform("sum"))
 
 
 def test_dataframegroupby_transform_dropna() raises:
@@ -251,9 +246,8 @@ def test_seriesgroupby_sum() raises:
     var pd_df = _make_pd_df()
     var s = Series(pd_df["val"], "val")
     var result = s.groupby(_mojo_labels()).sum().to_pandas()
-    # check_dtype=False: native returns Float64; pandas returns Int64
     testing.assert_series_equal(
-        result, pd_df["val"].groupby(_pd_labels()).sum(), check_dtype=False
+        result, pd_df["val"].groupby(_pd_labels()).sum()
     )
 
 
@@ -272,9 +266,8 @@ def test_seriesgroupby_min() raises:
     var pd_df = _make_pd_df()
     var s = Series(pd_df["val"], "val")
     var result = s.groupby(_mojo_labels()).min().to_pandas()
-    # check_dtype=False: native returns Float64; pandas returns Int64
     testing.assert_series_equal(
-        result, pd_df["val"].groupby(_pd_labels()).min(), check_dtype=False
+        result, pd_df["val"].groupby(_pd_labels()).min()
     )
 
 
@@ -283,9 +276,8 @@ def test_seriesgroupby_max() raises:
     var pd_df = _make_pd_df()
     var s = Series(pd_df["val"], "val")
     var result = s.groupby(_mojo_labels()).max().to_pandas()
-    # check_dtype=False: native returns Float64; pandas returns Int64
     testing.assert_series_equal(
-        result, pd_df["val"].groupby(_pd_labels()).max(), check_dtype=False
+        result, pd_df["val"].groupby(_pd_labels()).max()
     )
 
 
@@ -314,9 +306,8 @@ def test_seriesgroupby_agg() raises:
     var pd_df = _make_pd_df()
     var s = Series(pd_df["val"], "val")
     var result = s.groupby(_mojo_labels()).agg("sum").to_pandas()
-    # check_dtype=False: dispatches to sum() which returns Float64
     testing.assert_series_equal(
-        result, pd_df["val"].groupby(_pd_labels()).agg("sum"), check_dtype=False
+        result, pd_df["val"].groupby(_pd_labels()).agg("sum")
     )
 
 
@@ -377,11 +368,9 @@ def test_seriesgroupby_transform() raises:
     var pd_df = _make_pd_df()
     var s = Series(pd_df["val"], "val")
     var result = s.groupby(_mojo_labels()).transform("sum").to_pandas()
-    # check_dtype=False: native returns Float64; pandas returns Int64
     testing.assert_series_equal(
         result,
         pd_df["val"].groupby(_pd_labels()).transform("sum"),
-        check_dtype=False,
     )
 
 
@@ -405,7 +394,6 @@ def test_seriesgroupby_transform_min() raises:
     testing.assert_series_equal(
         result,
         pd_df["val"].groupby(_pd_labels()).transform("min"),
-        check_dtype=False,
     )
 
 
@@ -417,7 +405,6 @@ def test_seriesgroupby_transform_max() raises:
     testing.assert_series_equal(
         result,
         pd_df["val"].groupby(_pd_labels()).transform("max"),
-        check_dtype=False,
     )
 
 


### PR DESCRIPTION
DataFrameGroupBy and SeriesGroupBy sum/min/max (and their agg/transform
paths) now return int64 when the source column is integer, matching
pandas behaviour. Previously all results were float64, requiring
check_dtype=False workarounds in every groupby test.

- Add Column.sum_int64/min_int64/max_int64 typed aggregation methods
- Branch on col.dtype.is_integer() in DataFrameGroupBy.sum/min/max
- Branch on col.dtype.is_integer() in SeriesGroupBy.sum/min/max
- Int64-preserving broadcast added to DataFrameGroupBy.transform and
  SeriesGroupBy.transform for sum/min/max; falls back to float64 when
  null-keyed rows require NaN emission
- Remove check_dtype=False from 12 groupby tests that no longer need it

Closes #383

https://claude.ai/code/session_01NAUR7V3zo43RgPePRQW2Wo