### PR TITLE
feat: implement concat keys parameter natively (#435)

### DIFF
--- a/bison/reshape/_concat.mojo
+++ b/bison/reshape/_concat.mojo
@@ -48,6 +48,16 @@ def _null_col(
         return col^
 
 
+def _build_key_col(keys: List[String], counts: List[Int]) raises -> Column:
+    """Build a string Column named '__key__' repeating keys[i] counts[i] times.
+    """
+    var data = List[String]()
+    for i in range(len(keys)):
+        for _ in range(counts[i]):
+            data.append(keys[i])
+    return Column(Optional[String]("__key__"), ColumnData(data^), object_)
+
+
 def _promote_dtype(a: BisonDtype, b: BisonDtype) raises -> BisonDtype:
     """Return the common promoted dtype for *a* and *b*.
 
@@ -509,8 +519,11 @@ def concat(
         When ``True``, reset the output index (axis=0) or column labels
         (axis=1) to a default integer range.
     keys : Optional[List[String]]
-        Hierarchical index keys — not yet implemented natively; raises if
-        provided.
+        When provided, a ``"__key__"`` string column is prepended to the
+        result (position 0).  For axis=0 each row is labelled with the key
+        of its source DataFrame; for axis=1 each original column is labelled
+        with the key of its source DataFrame.  ``len(keys)`` must equal
+        ``len(objs)``.
     sort : Bool
         When ``True``, sort the non-concatenation axis labels alphabetically.
     """
@@ -518,8 +531,37 @@ def concat(
         return DataFrame()
 
     if keys:
-        _not_implemented("concat")
+        if len(keys.value()) != len(objs):
+            raise Error(
+                "concat: len(keys) = "
+                + String(len(keys.value()))
+                + " but len(objs) = "
+                + String(len(objs))
+            )
 
     if axis == 1:
-        return _concat_axis1(objs, join, ignore_index, sort)
-    return _concat_axis0(objs, join, ignore_index, sort)
+        var result = _concat_axis1(objs, join, ignore_index, sort)
+        if keys:
+            var counts = List[Int]()
+            for i in range(len(objs)):
+                counts.append(len(objs[i]._cols))
+            var key_col = _build_key_col(keys.value(), counts)
+            var new_cols = List[Column]()
+            new_cols.append(key_col^)
+            for i in range(len(result._cols)):
+                new_cols.append(result._cols[i].copy())
+            result._cols = new_cols^
+        return result^
+
+    var result = _concat_axis0(objs, join, ignore_index, sort)
+    if keys:
+        var counts = List[Int]()
+        for i in range(len(objs)):
+            counts.append(objs[i].shape()[0])
+        var key_col = _build_key_col(keys.value(), counts)
+        var new_cols = List[Column]()
+        new_cols.append(key_col^)
+        for i in range(len(result._cols)):
+            new_cols.append(result._cols[i].copy())
+        result._cols = new_cols^
+    return result^

--- a/tests/test_concat.mojo
+++ b/tests/test_concat.mojo
@@ -144,7 +144,46 @@ def test_concat_three_dfs() raises:
     assert_equal(s.iloc(2)[Int64], Int64(3))
 
 
-def test_concat_keys_raises() raises:
+def test_concat_keys_axis0() raises:
+    """keys parameter prepends a __key__ column with one label per source row."""
+    var pd = Python.import_module("pandas")
+    var df1 = DataFrame(pd.DataFrame(Python.evaluate("{'a': [1, 2]}")))
+    var df2 = DataFrame(pd.DataFrame(Python.evaluate("{'a': [3]}")))
+    var dfs = List[DataFrame]()
+    dfs.append(df1^)
+    dfs.append(df2^)
+    var keys = List[String]()
+    keys.append("x")
+    keys.append("y")
+    var result = concat(dfs, keys=Optional[List[String]](keys^))
+    assert_equal(result.shape()[0], 3)
+    assert_equal(result.shape()[1], 2)
+    var k = result["__key__"]
+    assert_equal(k.iloc(0)[String], "x")
+    assert_equal(k.iloc(1)[String], "x")
+    assert_equal(k.iloc(2)[String], "y")
+
+
+def test_concat_keys_axis1() raises:
+    """keys parameter prepends a __key__ column with one label per source column."""
+    var pd = Python.import_module("pandas")
+    var df1 = DataFrame(pd.DataFrame(Python.evaluate("{'a': [1, 2]}")))
+    var df2 = DataFrame(pd.DataFrame(Python.evaluate("{'b': [3, 4]}")))
+    var dfs = List[DataFrame]()
+    dfs.append(df1^)
+    dfs.append(df2^)
+    var keys = List[String]()
+    keys.append("left")
+    keys.append("right")
+    var result = concat(dfs, axis=1, keys=Optional[List[String]](keys^))
+    assert_equal(result.shape()[1], 3)
+    var k = result["__key__"]
+    assert_equal(k.iloc(0)[String], "left")
+    assert_equal(k.iloc(1)[String], "right")
+
+
+def test_concat_keys_length_mismatch_raises() raises:
+    """concat raises when len(keys) != len(objs)."""
     var pd = Python.import_module("pandas")
     var df1 = DataFrame(pd.DataFrame(Python.evaluate("{'a': [1]}")))
     var df2 = DataFrame(pd.DataFrame(Python.evaluate("{'a': [2]}")))
@@ -154,8 +193,7 @@ def test_concat_keys_raises() raises:
     var raised = False
     try:
         var keys = List[String]()
-        keys.append("k1")
-        keys.append("k2")
+        keys.append("only_one")
         _ = concat(dfs, keys=Optional[List[String]](keys^))
     except:
         raised = True


### PR DESCRIPTION
Add a native `keys` implementation to `concat` that prepends a
`"__key__"` string column (position 0) labelling each row (axis=0)
or each source column (axis=1) with its originating key.  Raises
a descriptive error when `len(keys) != len(objs)`.  No pandas
delegation.

https://claude.ai/code/session_01FcdbipAc3EfpvkEWRgwebc