### PR TITLE
feat: implement boolean mask filtering (closes #416)

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,8 +82,8 @@ In CI it runs after the test suite and the result is committed back to the branc
 <!-- COMPAT_TABLE_START -->
 | Category | Stubs | Implemented |
 |----------|-------|-------------|
-| DataFrame | 37 | 103 |
-| Series | 0 | 98 |
+| DataFrame | 37 | 104 |
+| Series | 0 | 106 |
 | GroupBy (DataFrame) | 0 | 24 |
 | GroupBy (Series) | 0 | 17 |
 | String accessor | 0 | 21 |
@@ -91,7 +91,7 @@ In CI it runs after the test suite and the result is committed back to the branc
 | Index | 0 | 14 |
 | IO | 0 | 8 |
 | Reshape | 0 | 2 |
-| **Total** | **37** | **307** |
+| **Total** | **37** | **316** |
 <!-- COMPAT_TABLE_END -->
 
 ## Known limitations

--- a/bison/_frame.mojo
+++ b/bison/_frame.mojo
@@ -226,6 +226,114 @@ struct Series(Copyable, Movable):
     def ge(self, other: Series) raises -> Series:
         return Series(self._col._cmp_ge(other._col))
 
+    def __gt__(self, other: Float64) raises -> Series:
+        """Element-wise ``>`` against a scalar, returning a boolean Series."""
+        var n = len(self._col)
+        var rhs = List[Float64]()
+        for _ in range(n):
+            rhs.append(other)
+        var rhs_col = Column(self._col.name, ColumnData(rhs^), float64)
+        return Series(self._col._cmp_gt(rhs_col))
+
+    def __lt__(self, other: Float64) raises -> Series:
+        """Element-wise ``<`` against a scalar, returning a boolean Series."""
+        var n = len(self._col)
+        var rhs = List[Float64]()
+        for _ in range(n):
+            rhs.append(other)
+        var rhs_col = Column(self._col.name, ColumnData(rhs^), float64)
+        return Series(self._col._cmp_lt(rhs_col))
+
+    def __ge__(self, other: Float64) raises -> Series:
+        """Element-wise ``>=`` against a scalar, returning a boolean Series."""
+        var n = len(self._col)
+        var rhs = List[Float64]()
+        for _ in range(n):
+            rhs.append(other)
+        var rhs_col = Column(self._col.name, ColumnData(rhs^), float64)
+        return Series(self._col._cmp_ge(rhs_col))
+
+    def __le__(self, other: Float64) raises -> Series:
+        """Element-wise ``<=`` against a scalar, returning a boolean Series."""
+        var n = len(self._col)
+        var rhs = List[Float64]()
+        for _ in range(n):
+            rhs.append(other)
+        var rhs_col = Column(self._col.name, ColumnData(rhs^), float64)
+        return Series(self._col._cmp_le(rhs_col))
+
+    def __eq__(self, other: Float64) raises -> Series:
+        """Element-wise ``==`` against a numeric scalar, returning a boolean Series.
+        """
+        var n = len(self._col)
+        var rhs = List[Float64]()
+        for _ in range(n):
+            rhs.append(other)
+        var rhs_col = Column(self._col.name, ColumnData(rhs^), float64)
+        return Series(self._col._cmp_eq(rhs_col))
+
+    def __ne__(self, other: Float64) raises -> Series:
+        """Element-wise ``!=`` against a numeric scalar, returning a boolean Series.
+        """
+        var n = len(self._col)
+        var rhs = List[Float64]()
+        for _ in range(n):
+            rhs.append(other)
+        var rhs_col = Column(self._col.name, ColumnData(rhs^), float64)
+        return Series(self._col._cmp_ne(rhs_col))
+
+    def __eq__(self, other: String) raises -> Series:
+        """Element-wise ``==`` against a string scalar, returning a boolean Series.
+        """
+        var n = len(self._col)
+        var result = List[Bool]()
+        var has_mask = len(self._col._null_mask) > 0
+        if self._col._data.isa[List[String]]():
+            ref d = self._col._data[List[String]]
+            for i in range(n):
+                if has_mask and self._col._null_mask[i]:
+                    result.append(False)
+                else:
+                    result.append(d[i] == other)
+        elif self._col._data.isa[List[PythonObject]]():
+            ref d = self._col._data[List[PythonObject]]
+            for i in range(n):
+                if has_mask and self._col._null_mask[i]:
+                    result.append(False)
+                else:
+                    result.append(String(d[i]) == other)
+        else:
+            for _ in range(n):
+                result.append(False)
+        var col = Column(self._col.name, ColumnData(result^), bool_)
+        return Series(col^)
+
+    def __ne__(self, other: String) raises -> Series:
+        """Element-wise ``!=`` against a string scalar, returning a boolean Series.
+        """
+        var n = len(self._col)
+        var result = List[Bool]()
+        var has_mask = len(self._col._null_mask) > 0
+        if self._col._data.isa[List[String]]():
+            ref d = self._col._data[List[String]]
+            for i in range(n):
+                if has_mask and self._col._null_mask[i]:
+                    result.append(True)
+                else:
+                    result.append(d[i] != other)
+        elif self._col._data.isa[List[PythonObject]]():
+            ref d = self._col._data[List[PythonObject]]
+            for i in range(n):
+                if has_mask and self._col._null_mask[i]:
+                    result.append(True)
+                else:
+                    result.append(String(d[i]) != other)
+        else:
+            for _ in range(n):
+                result.append(True)
+        var col = Column(self._col.name, ColumnData(result^), bool_)
+        return Series(col^)
+
     # ------------------------------------------------------------------
     # Aggregation
     # ------------------------------------------------------------------
@@ -2043,6 +2151,42 @@ struct DataFrame(Copyable, Movable):
             if self._cols[i].name == key:
                 return Series(self._cols[i].copy())
         raise Error("DataFrame.__getitem__: column not found: " + key)
+
+    def __getitem__(self, mask: Series) raises -> DataFrame:
+        """Filter rows using a boolean mask Series.
+
+        Returns a new DataFrame containing only the rows where *mask* is True.
+        Null mask values are treated as False (row excluded).
+
+        Example::
+
+            df[df["a"] > 0.5]
+        """
+        var n = self.shape()[0]
+        var mask_len = len(mask._col)
+        if mask_len != n:
+            raise Error(
+                "DataFrame.__getitem__: boolean mask length "
+                + String(mask_len)
+                + " does not match DataFrame length "
+                + String(n)
+            )
+        var indices = List[Int]()
+        var has_mask = len(mask._col._null_mask) > 0
+        if mask._col._data.isa[List[Bool]]():
+            ref d = mask._col._data[List[Bool]]
+            for i in range(mask_len):
+                var is_null = has_mask and mask._col._null_mask[i]
+                if not is_null and d[i]:
+                    indices.append(i)
+        else:
+            raise Error(
+                "DataFrame.__getitem__: mask Series must have bool dtype"
+            )
+        var result_cols = List[Column]()
+        for i in range(len(self._cols)):
+            result_cols.append(self._cols[i].take(indices))
+        return DataFrame(result_cols^)
 
     def __setitem__(mut self, key: String, value: Series) raises:
         var new_col = value._col.copy()

--- a/tests/test_dataframe.mojo
+++ b/tests/test_dataframe.mojo
@@ -102,6 +102,70 @@ def test_getitem_column() raises:
     assert_equal(s.size(), 3)
 
 
+def test_getitem_bool_mask_basic() raises:
+    """df[boolean_series] returns only rows where mask is True."""
+    var pd = Python.import_module("pandas")
+    var df = DataFrame(pd.DataFrame(Python.evaluate("{'a': [1, 2, 3, 4, 5]}")))
+    var mask = df["a"].__gt__(3.0)
+    var result = df[mask]
+    assert_equal(result.shape()[0], 2)
+    assert_equal(result.shape()[1], 1)
+
+
+def test_getitem_bool_mask_pattern() raises:
+    """df[df['a'] > threshold] is the canonical pandas filter pattern."""
+    var pd = Python.import_module("pandas")
+    var df = DataFrame(pd.DataFrame(Python.evaluate("{'a': [1.0, 2.0, 3.0], 'b': [4.0, 5.0, 6.0]}")))
+    var result = df[df["a"].__gt__(1.5)]
+    assert_equal(result.shape()[0], 2)
+    assert_equal(result.shape()[1], 2)
+    # Rows 1 and 2 survive; first value of 'b' should be 5.0
+    assert_true(result["b"].iloc(0)[Float64] == 5.0)
+    assert_true(result["b"].iloc(1)[Float64] == 6.0)
+
+
+def test_getitem_bool_mask_none_pass() raises:
+    """All-False mask returns empty DataFrame."""
+    var pd = Python.import_module("pandas")
+    var df = DataFrame(pd.DataFrame(Python.evaluate("{'a': [1, 2, 3]}")))
+    var mask = df["a"].__gt__(100.0)
+    var result = df[mask]
+    assert_equal(result.shape()[0], 0)
+    assert_equal(result.shape()[1], 1)
+
+
+def test_getitem_bool_mask_all_pass() raises:
+    """All-True mask returns all rows."""
+    var pd = Python.import_module("pandas")
+    var df = DataFrame(pd.DataFrame(Python.evaluate("{'a': [1, 2, 3]}")))
+    var mask = df["a"].__gt__(0.0)
+    var result = df[mask]
+    assert_equal(result.shape()[0], 3)
+
+
+def test_getitem_bool_mask_length_mismatch_raises() raises:
+    var pd = Python.import_module("pandas")
+    var df = DataFrame(pd.DataFrame(Python.evaluate("{'a': [1, 2, 3]}")))
+    var mask = Series(pd.Series(Python.evaluate("[True, False]")))
+    var raised = False
+    try:
+        _ = df[mask]
+    except:
+        raised = True
+    assert_true(raised)
+
+
+def test_getitem_bool_mask_string_eq() raises:
+    """Boolean mask created via string equality filters correctly."""
+    var pd = Python.import_module("pandas")
+    var df = DataFrame(pd.DataFrame(Python.evaluate("{'cat': ['a', 'b', 'a', 'c'], 'val': [1, 2, 3, 4]}")))
+    var mask = df["cat"].__eq__(String("a"))
+    var result = df[mask]
+    assert_equal(result.shape()[0], 2)
+    assert_equal(result["val"].iloc(0)[Int64], Int64(1))
+    assert_equal(result["val"].iloc(1)[Int64], Int64(3))
+
+
 def test_getitem_missing_raises() raises:
     var pd = Python.import_module("pandas")
     var df = DataFrame(pd.DataFrame(Python.evaluate("{'a': [1]}")))

--- a/tests/test_series_math.mojo
+++ b/tests/test_series_math.mojo
@@ -663,5 +663,90 @@ def test_cov_with_nulls() raises:
     assert_true(result > expected - 1e-9 and result < expected + 1e-9)
 
 
+def test_gt_scalar() raises:
+    var pd = Python.import_module("pandas")
+    var s = Series(pd.Series(Python.evaluate("[1.0, 3.0, 5.0]")))
+    var mask = s.__gt__(2.0)
+    assert_equal(mask.dtype().name, "bool")
+    assert_true(mask.iloc(0)[Bool] == False)
+    assert_true(mask.iloc(1)[Bool] == True)
+    assert_true(mask.iloc(2)[Bool] == True)
+
+
+def test_lt_scalar() raises:
+    var pd = Python.import_module("pandas")
+    var s = Series(pd.Series(Python.evaluate("[1.0, 3.0, 5.0]")))
+    var mask = s.__lt__(3.0)
+    assert_equal(mask.dtype().name, "bool")
+    assert_true(mask.iloc(0)[Bool] == True)
+    assert_true(mask.iloc(1)[Bool] == False)
+    assert_true(mask.iloc(2)[Bool] == False)
+
+
+def test_ge_scalar() raises:
+    var pd = Python.import_module("pandas")
+    var s = Series(pd.Series(Python.evaluate("[1.0, 3.0, 5.0]")))
+    var mask = s.__ge__(3.0)
+    assert_true(mask.iloc(0)[Bool] == False)
+    assert_true(mask.iloc(1)[Bool] == True)
+    assert_true(mask.iloc(2)[Bool] == True)
+
+
+def test_le_scalar() raises:
+    var pd = Python.import_module("pandas")
+    var s = Series(pd.Series(Python.evaluate("[1.0, 3.0, 5.0]")))
+    var mask = s.__le__(3.0)
+    assert_true(mask.iloc(0)[Bool] == True)
+    assert_true(mask.iloc(1)[Bool] == True)
+    assert_true(mask.iloc(2)[Bool] == False)
+
+
+def test_eq_scalar_float() raises:
+    var pd = Python.import_module("pandas")
+    var s = Series(pd.Series(Python.evaluate("[1.0, 2.0, 3.0]")))
+    var mask = s.__eq__(Float64(2.0))
+    assert_true(mask.iloc(0)[Bool] == False)
+    assert_true(mask.iloc(1)[Bool] == True)
+    assert_true(mask.iloc(2)[Bool] == False)
+
+
+def test_ne_scalar_float() raises:
+    var pd = Python.import_module("pandas")
+    var s = Series(pd.Series(Python.evaluate("[1.0, 2.0, 3.0]")))
+    var mask = s.__ne__(Float64(2.0))
+    assert_true(mask.iloc(0)[Bool] == True)
+    assert_true(mask.iloc(1)[Bool] == False)
+    assert_true(mask.iloc(2)[Bool] == True)
+
+
+def test_eq_scalar_string() raises:
+    var pd = Python.import_module("pandas")
+    var s = Series(pd.Series(Python.evaluate("['a', 'b', 'a']")))
+    var mask = s.__eq__(String("a"))
+    assert_equal(mask.dtype().name, "bool")
+    assert_true(mask.iloc(0)[Bool] == True)
+    assert_true(mask.iloc(1)[Bool] == False)
+    assert_true(mask.iloc(2)[Bool] == True)
+
+
+def test_ne_scalar_string() raises:
+    var pd = Python.import_module("pandas")
+    var s = Series(pd.Series(Python.evaluate("['a', 'b', 'a']")))
+    var mask = s.__ne__(String("a"))
+    assert_true(mask.iloc(0)[Bool] == False)
+    assert_true(mask.iloc(1)[Bool] == True)
+    assert_true(mask.iloc(2)[Bool] == False)
+
+
+def test_gt_int_series() raises:
+    # Int64 column compared against a Float64 scalar (numeric promotion path)
+    var pd = Python.import_module("pandas")
+    var s = Series(pd.Series(Python.evaluate("[1, 2, 3, 4, 5]")))
+    var mask = s.__gt__(3.0)
+    assert_true(mask.iloc(0)[Bool] == False)
+    assert_true(mask.iloc(3)[Bool] == True)
+    assert_true(mask.iloc(4)[Bool] == True)
+
+
 def main() raises:
     TestSuite.discover_tests[__functions_in_module()]().run()


### PR DESCRIPTION
Add Series scalar comparison operators (__gt__, __lt__, __ge__, __le__,
__eq__, __ne__) for Float64 and String scalars, enabling the idiomatic
pandas pattern df[df["col"] > threshold].

Add DataFrame.__getitem__(mask: Series) overload that filters rows where
the boolean mask is True.

Covers numeric columns (Int64/Float64/Bool via _cmp_op) and string
columns (List[String] and List[PythonObject] arms for eq/ne).

https://claude.ai/code/session_018dbD4Tj8XkpK9KtB7W1BN3