### PR TITLE
perf: replace O(n²) insertion sort with _sort_list in quantile(axis=1)

### DIFF
--- a/bison/_frame.mojo
+++ b/bison/_frame.mojo
@@ -2689,14 +2689,7 @@ struct DataFrame(Copyable, Movable):
                 if n == 0:
                     results.append(nan)
                     continue
-                # Insertion sort
-                for a in range(1, n):
-                    var key = vals[a]
-                    var b = a - 1
-                    while b >= 0 and vals[b] > key:
-                        vals[b + 1] = vals[b]
-                        b -= 1
-                    vals[b + 1] = key
+                _sort_list(vals)
                 var pos = q * Float64(n - 1)
                 var lo = Int(pos)
                 var hi = lo + 1


### PR DESCRIPTION
## Summary

- Removed the 7-line hand-rolled insertion sort in the `axis=1` branch of `DataFrame.quantile`
- Replaced with a single `_sort_list(vals)` call (already imported from `std.builtin.sort`)
- Per-row sort complexity drops from O(k²) to O(k log k) where k = number of columns

## Test plan

- [ ] All 79 existing tests pass (`pixi run test`)
- [ ] `test_df_quantile_axis1` continues to pass with correct values
- [ ] `mojo package --Werror` passes (zero warnings)

Closes #464