### PR TITLE
feat: implement DataFrame.shift / diff / pct_change natively (closes #430)

### DIFF
--- a/bison/_frame.mojo
+++ b/bison/_frame.mojo
@@ -2930,16 +2930,48 @@ struct DataFrame(Copyable, Movable):
         return DataFrame(result_cols^)
 
     def shift(self, periods: Int = 1, axis: Int = 0) raises -> DataFrame:
-        _not_implemented("DataFrame.shift")
-        return DataFrame()
+        """Return a DataFrame with values shifted by *periods* positions.
+
+        For ``axis=0`` (default), each column is shifted independently:
+        positive *periods* lags rows (first *periods* rows become null);
+        negative *periods* leads rows (last *|periods|* rows become null).
+        String and object columns are supported in addition to numeric.
+        ``axis=1`` is not yet implemented.
+        """
+        if axis != 0:
+            _not_implemented("DataFrame.shift")
+        var result_cols = List[Column]()
+        for i in range(len(self._cols)):
+            result_cols.append(self._cols[i].shift(periods))
+        return DataFrame(result_cols^)
 
     def diff(self, periods: Int = 1, axis: Int = 0) raises -> DataFrame:
-        _not_implemented("DataFrame.diff")
-        return DataFrame()
+        """Return element-wise first discrete difference along the rows.
+
+        ``result[i] = self[i] - self[i - periods]`` for each numeric column.
+        Exposed positions are null.  Non-numeric columns raise.
+        ``axis=1`` is not yet implemented.
+        """
+        if axis != 0:
+            _not_implemented("DataFrame.diff")
+        var result_cols = List[Column]()
+        for i in range(len(self._cols)):
+            result_cols.append(self._cols[i].diff(periods))
+        return DataFrame(result_cols^)
 
     def pct_change(self, periods: Int = 1, axis: Int = 0) raises -> DataFrame:
-        _not_implemented("DataFrame.pct_change")
-        return DataFrame()
+        """Return element-wise percentage change along the rows.
+
+        ``result[i] = (self[i] - self[i - periods]) / self[i - periods]``
+        for each numeric column.  Exposed positions are null.
+        ``axis=1`` is not yet implemented.
+        """
+        if axis != 0:
+            _not_implemented("DataFrame.pct_change")
+        var result_cols = List[Column]()
+        for i in range(len(self._cols)):
+            result_cols.append(self._cols[i].pct_change(periods))
+        return DataFrame(result_cols^)
 
     def agg(self, func: String, axis: Int = 0) raises -> Series:
         if axis == 1:

--- a/tests/test_transform.mojo
+++ b/tests/test_transform.mojo
@@ -5,7 +5,7 @@ from bison import DataFrame, Series
 
 
 # ---------------------------------------------------------------------------
-# shift — implemented
+# shift
 # ---------------------------------------------------------------------------
 
 def test_series_shift() raises:
@@ -17,20 +17,63 @@ def test_series_shift() raises:
     assert_true(r.iloc(2)[Float64] == 2.0)
 
 
-def test_df_shift_raises() raises:
+def test_df_shift_default() raises:
+    """Shift(1) on a two-column DataFrame — matches pandas output."""
     var pd = Python.import_module("pandas")
-    var df = DataFrame(pd.DataFrame(Python.evaluate("{'a': [1.0, 2.0, 3.0]}")))
+    var df = DataFrame(
+        pd.DataFrame(Python.evaluate("{'a': [1.0, 2.0, 3.0], 'b': [10.0, 20.0, 30.0]}"))
+    )
+    var r = df.shift()
+    # Row 0 should be null in both columns
+    assert_true(r["a"].isna().iloc(0)[Bool])
+    assert_true(r["b"].isna().iloc(0)[Bool])
+    # Row 1 gets original row 0
+    assert_true(r["a"].iloc(1)[Float64] == 1.0)
+    assert_true(r["b"].iloc(1)[Float64] == 10.0)
+    # Row 2 gets original row 1
+    assert_true(r["a"].iloc(2)[Float64] == 2.0)
+    assert_true(r["b"].iloc(2)[Float64] == 20.0)
+
+
+def test_df_shift_periods_2() raises:
+    var pd = Python.import_module("pandas")
+    var df = DataFrame(
+        pd.DataFrame(Python.evaluate("{'a': [1.0, 2.0, 3.0, 4.0]}"))
+    )
+    var r = df.shift(2)
+    assert_true(r["a"].isna().iloc(0)[Bool])
+    assert_true(r["a"].isna().iloc(1)[Bool])
+    assert_true(r["a"].iloc(2)[Float64] == 1.0)
+    assert_true(r["a"].iloc(3)[Float64] == 2.0)
+
+
+def test_df_shift_negative() raises:
+    var pd = Python.import_module("pandas")
+    var df = DataFrame(
+        pd.DataFrame(Python.evaluate("{'a': [1.0, 2.0, 3.0]}"))
+    )
+    var r = df.shift(-1)
+    assert_true(r["a"].iloc(0)[Float64] == 2.0)
+    assert_true(r["a"].iloc(1)[Float64] == 3.0)
+    assert_true(r["a"].isna().iloc(2)[Bool])
+
+
+def test_df_shift_axis1_raises() raises:
+    var pd = Python.import_module("pandas")
+    var df = DataFrame(
+        pd.DataFrame(Python.evaluate("{'a': [1.0, 2.0], 'b': [3.0, 4.0]}"))
+    )
     var raised = False
     try:
-        _ = df.shift()
+        _ = df.shift(1, axis=1)
     except:
         raised = True
     if not raised:
-        raise Error("DataFrame.shift should have raised")
+        raise Error("DataFrame.shift(axis=1) should have raised")
 
 
 # ---------------------------------------------------------------------------
-# diff — implemented
+# diff
 # ---------------------------------------------------------------------------
 
 def test_series_diff() raises:
@@ -42,20 +85,49 @@ def test_series_diff() raises:
     assert_true(r.iloc(2)[Float64] == 1.0)
 
 
-def test_df_diff_raises() raises:
+def test_df_diff_default() raises:
+    """Diff(1) on a two-column DataFrame — matches pandas output."""
     var pd = Python.import_module("pandas")
-    var df = DataFrame(pd.DataFrame(Python.evaluate("{'a': [1.0, 2.0, 3.0]}")))
+    var df = DataFrame(
+        pd.DataFrame(Python.evaluate("{'a': [1.0, 3.0, 6.0], 'b': [10.0, 15.0, 21.0]}"))
+    )
+    var r = df.diff()
+    assert_true(r["a"].isna().iloc(0)[Bool])
+    assert_true(r["b"].isna().iloc(0)[Bool])
+    assert_true(r["a"].iloc(1)[Float64] == 2.0)
+    assert_true(r["b"].iloc(1)[Float64] == 5.0)
+    assert_true(r["a"].iloc(2)[Float64] == 3.0)
+    assert_true(r["b"].iloc(2)[Float64] == 6.0)
+
+
+def test_df_diff_periods_2() raises:
+    var pd = Python.import_module("pandas")
+    var df = DataFrame(
+        pd.DataFrame(Python.evaluate("{'a': [1.0, 2.0, 4.0, 7.0]}"))
+    )
+    var r = df.diff(2)
+    assert_true(r["a"].isna().iloc(0)[Bool])
+    assert_true(r["a"].isna().iloc(1)[Bool])
+    assert_true(r["a"].iloc(2)[Float64] == 3.0)
+    assert_true(r["a"].iloc(3)[Float64] == 5.0)
+
+
+def test_df_diff_axis1_raises() raises:
+    var pd = Python.import_module("pandas")
+    var df = DataFrame(
+        pd.DataFrame(Python.evaluate("{'a': [1.0, 2.0], 'b': [3.0, 4.0]}"))
+    )
     var raised = False
     try:
-        _ = df.diff()
+        _ = df.diff(1, axis=1)
     except:
         raised = True
     if not raised:
-        raise Error("DataFrame.diff should have raised")
+        raise Error("DataFrame.diff(axis=1) should have raised")
 
 
 # ---------------------------------------------------------------------------
-# pct_change — implemented
+# pct_change
 # ---------------------------------------------------------------------------
 
 def test_series_pct_change() raises:
@@ -67,16 +139,45 @@ def test_series_pct_change() raises:
     assert_true(r.iloc(2)[Float64] == 1.0)
 
 
-def test_df_pct_change_raises() raises:
+def test_df_pct_change_default() raises:
+    """Pct_change(1) on a two-column DataFrame — matches pandas output."""
     var pd = Python.import_module("pandas")
-    var df = DataFrame(pd.DataFrame(Python.evaluate("{'a': [1.0, 2.0, 4.0]}")))
+    var df = DataFrame(
+        pd.DataFrame(Python.evaluate("{'a': [1.0, 2.0, 4.0], 'b': [10.0, 20.0, 40.0]}"))
+    )
+    var r = df.pct_change()
+    assert_true(r["a"].isna().iloc(0)[Bool])
+    assert_true(r["b"].isna().iloc(0)[Bool])
+    assert_true(r["a"].iloc(1)[Float64] == 1.0)
+    assert_true(r["b"].iloc(1)[Float64] == 1.0)
+    assert_true(r["a"].iloc(2)[Float64] == 1.0)
+    assert_true(r["b"].iloc(2)[Float64] == 1.0)
+
+
+def test_df_pct_change_periods_2() raises:
+    var pd = Python.import_module("pandas")
+    var df = DataFrame(
+        pd.DataFrame(Python.evaluate("{'a': [1.0, 2.0, 3.0, 6.0]}"))
+    )
+    var r = df.pct_change(2)
+    assert_true(r["a"].isna().iloc(0)[Bool])
+    assert_true(r["a"].isna().iloc(1)[Bool])
+    assert_true(r["a"].iloc(2)[Float64] == 2.0)
+    assert_true(r["a"].iloc(3)[Float64] == 2.0)
+
+
+def test_df_pct_change_axis1_raises() raises:
+    var pd = Python.import_module("pandas")
+    var df = DataFrame(
+        pd.DataFrame(Python.evaluate("{'a': [1.0, 2.0], 'b': [3.0, 4.0]}"))
+    )
     var raised = False
     try:
-        _ = df.pct_change()
+        _ = df.pct_change(1, axis=1)
     except:
         raised = True
     if not raised:
-        raise Error("DataFrame.pct_change should have raised")
+        raise Error("DataFrame.pct_change(axis=1) should have raised")
 
 
 def main() raises:


### PR DESCRIPTION
## Summary

Implements `DataFrame.shift`, `DataFrame.diff`, and `DataFrame.pct_change` natively for `axis=0` (the default), closing issue #430.

Each method is implemented as a column-by-column application of the existing `Column` -level operations (`Column.shift`, `Column.diff`, `Column.pct_change`) which were already fully tested in `tests/test_series_transforms.mojo`.

### Behaviour

| Method | axis=0 | axis=1 |
|--------|--------|--------|
| `shift(periods)` | native — all dtypes (int, float, bool, string, object) | raises _not_implemented |
| `diff(periods)` | native — numeric dtypes; raises for non-numeric | raises _not_implemented |
| `pct_change(periods)` | native — numeric dtypes; raises for non-numeric | raises _not_implemented |

### Tests updated (`tests/test_transform.mojo`)

Removed three 'expect raises' stub tests and replaced with ten real assertions:

- `test_df_shift_default` — positive shift, two columns
- `test_df_shift_periods_2` — periods=2
- `test_df_shift_negative` — negative periods (lead)
- `test_df_shift_axis1_raises` — axis=1 guard
- `test_df_diff_default` — periods=1, two columns
- `test_df_diff_periods_2`
- `test_df_diff_axis1_raises`
- `test_df_pct_change_default` — periods=1, two columns
- `test_df_pct_change_periods_2`
- `test_df_pct_change_axis1_raises`

All 13 new transform tests pass. Full test suite: 19 files, 0 failures.

## Session Notes Needing Issues

### update_compat.py counts axis-guard `_not_implemented` calls as stubs

- **File**: `scripts/update_compat.py` (line 120)
- **Impact**: Medium
- **Classification**: Misleading Metrics (Dispensables — Obscured Intent)
- **Details**: The script counts every `_not_implemented(...)` call, regardless of whether it is an unconditional stub or an axis-guard inside an otherwise-implemented method. After implementing `DataFrame.shift/diff/pct_change` for axis=0, the reported stub count does not decrease because the axis != 0 guard still calls `_not_implemented("DataFrame.shift")`. The fix would be to either (a) count unique method names rather than call sites, or (b) use a different sentinel for parameter-guard branches inside implemented methods.

### DataFrame.shift / diff / pct_change do not support axis=1

- **File**: `bison/_frame.mojo` (lines ~2939–2977)
- **Impact**: Low
- **Classification**: Incomplete Implementation (Change Preventer — Divergent Change)
- **Details**: pandas supports `axis=1` for all three methods. Our implementation raises `_not_implemented` for axis != 0. Implementing axis=1 requires collecting float values across columns per row — similar to `_row_numeric_vals` — then writing results back into new columns.