### PR TITLE
Fix compat counting for axis-guarded methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ pixi run test
 ## pandas compatibility
 
 This table is generated automatically from the source by `scripts/update_compat.py`,
-which counts `_not_implemented()` calls in the bison package. Run it locally with:
+which counts fully stubbed APIs in the bison package. Run it locally with:
 
 ```bash
 python scripts/update_compat.py
@@ -82,7 +82,7 @@ In CI it runs after the test suite and the result is committed back to the branc
 <!-- COMPAT_TABLE_START -->
 | Category | Stubs | Implemented |
 |----------|-------|-------------|
-| DataFrame | 34 | 109 |
+| DataFrame | 5 | 138 |
 | Series | 0 | 106 |
 | GroupBy (DataFrame) | 0 | 24 |
 | GroupBy (Series) | 0 | 17 |
@@ -91,7 +91,7 @@ In CI it runs after the test suite and the result is committed back to the branc
 | Index | 0 | 14 |
 | IO | 0 | 8 |
 | Reshape | 0 | 2 |
-| **Total** | **34** | **321** |
+| **Total** | **5** | **350** |
 <!-- COMPAT_TABLE_END -->
 
 ## Known limitations

--- a/scripts/test_update_compat.py
+++ b/scripts/test_update_compat.py
@@ -1,0 +1,48 @@
+import importlib.util
+import pathlib
+import tempfile
+import unittest
+
+
+MODULE_PATH = pathlib.Path(__file__).with_name("update_compat.py")
+SPEC = importlib.util.spec_from_file_location("update_compat", MODULE_PATH)
+update_compat = importlib.util.module_from_spec(SPEC)
+assert SPEC.loader is not None
+SPEC.loader.exec_module(update_compat)
+
+
+class UpdateCompatTests(unittest.TestCase):
+    def test_collect_stubs_counts_only_full_method_stubs(self) -> None:
+        mojo_source = """
+struct DataFrame:
+    def shift(self, axis: Int = 0) raises -> Self:
+        if axis != 0:
+            _not_implemented("DataFrame.shift")
+        return self
+
+    def apply(self, func: String) raises -> Self:
+        _not_implemented("DataFrame.apply")
+        return self
+
+def concat(objs: Int) raises -> Int:
+    _not_implemented("concat")
+    return objs
+""".strip()
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            bison_dir = pathlib.Path(tmpdir) / "bison"
+            bison_dir.mkdir()
+            (bison_dir / "_frame.mojo").write_text(mojo_source)
+
+            original_dir = update_compat.BISON_DIR
+            try:
+                update_compat.BISON_DIR = bison_dir
+                counts = update_compat.collect_stubs()
+            finally:
+                update_compat.BISON_DIR = original_dir
+
+        self.assertEqual(counts, {"DataFrame": 1, "Reshape": 1})
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/update_compat.py
+++ b/scripts/update_compat.py
@@ -1,10 +1,9 @@
 #!/usr/bin/env python3
 """
-Count stub methods per category and update the compatibility table in README.md.
+Count fully stubbed methods per category and update the compatibility table in README.md.
 
-Stubs are detected by _not_implemented() calls in bison/**/*.mojo.
-Each call is expected on a line of the form:
-    _not_implemented("Category.method_name")
+Stubs are detected by scanning bison/**/*.mojo for API bodies whose first
+executable statement is _not_implemented("Category.method_name").
 
 The table in README.md is rewritten between the sentinel comments:
     <!-- COMPAT_TABLE_START -->
@@ -93,6 +92,21 @@ STRUCT_PATTERN = re.compile(r"^\s*struct\s+([A-Za-z_][A-Za-z0-9_]*)\b")
 FN_PATTERN = re.compile(r"^\s*(?:fn|def)\s+([A-Za-z_][A-Za-z0-9_]*)\s*\(")
 
 
+def _indent(line: str) -> int:
+    return len(line) - len(line.lstrip())
+
+
+def _is_meaningful_statement(line: str) -> bool:
+    stripped = line.strip()
+    if not stripped:
+        return False
+    if stripped.startswith("#"):
+        return False
+    if stripped in {'"""', "'''"}:
+        return False
+    return True
+
+
 def _category_for_key(key: str) -> str:
     # Longest prefix match wins (e.g. "Series.str" before "Series").
     for prefix in sorted(CATEGORY_MAP, key=len, reverse=True):
@@ -107,18 +121,65 @@ def _function_key(struct_name: str | None, fn_name: str) -> str | None:
     return TOP_LEVEL_KEY_MAP.get(fn_name)
 
 
-def collect_stubs() -> dict[str, int]:
-    """Return {category: stub_count} by scanning _not_implemented() calls."""
-    counts: dict[str, int] = {}
+def _iter_functions() -> list[tuple[str | None, str, list[str]]]:
+    functions: list[tuple[str | None, str, list[str]]] = []
 
     for mojo_file in BISON_DIR.rglob("*.mojo"):
+        current_struct: str | None = None
+        current_fn: tuple[str | None, str, int, list[str]] | None = None
+
         for line in mojo_file.read_text().splitlines():
-            m = NOT_IMPLEMENTED_PATTERN.search(line)
-            if not m:
+            stripped = line.lstrip()
+            line_indent = _indent(line)
+
+            if current_fn is not None:
+                _, _, fn_indent, fn_body = current_fn
+                if stripped and line_indent <= fn_indent:
+                    functions.append((current_fn[0], current_fn[1], fn_body))
+                    current_fn = None
+
+            if current_struct is not None and stripped and line == stripped:
+                current_struct = None
+
+            m_struct = STRUCT_PATTERN.match(line)
+            if m_struct:
+                current_struct = m_struct.group(1)
                 continue
-            key = m.group(1)
-            category = _category_for_key(key)
-            counts[category] = counts.get(category, 0) + 1
+
+            m_fn = FN_PATTERN.match(line)
+            if m_fn:
+                current_fn = (current_struct, m_fn.group(1), line_indent, [])
+                continue
+
+            if current_fn is not None:
+                current_fn[3].append(line)
+
+        if current_fn is not None:
+            functions.append((current_fn[0], current_fn[1], current_fn[3]))
+
+    return functions
+
+
+def _is_full_stub(function_key: str, body_lines: list[str]) -> bool:
+    for line in body_lines:
+        if not _is_meaningful_statement(line):
+            continue
+        match = NOT_IMPLEMENTED_PATTERN.search(line)
+        # Only count methods whose first executable statement is the stub marker.
+        return match is not None and match.group(1) == function_key
+    return False
+
+
+def collect_stubs() -> dict[str, int]:
+    """Return {category: stub_count} by counting fully stubbed API methods."""
+    counts: dict[str, int] = {}
+
+    for struct_name, fn_name, body_lines in _iter_functions():
+        key = _function_key(struct_name, fn_name)
+        if key is None or not _is_full_stub(key, body_lines):
+            continue
+        category = _category_for_key(key)
+        counts[category] = counts.get(category, 0) + 1
 
     return counts
 


### PR DESCRIPTION
## Summary
- count only fully stubbed APIs in scripts/update_compat.py instead of raw _not_implemented call sites
- add a regression test covering axis-guard guards versus full-method stubs
- refresh the README compatibility explanation and generated table

Closes #472

## Validation
- pixi run python -m unittest scripts/test_update_compat.py
- pixi run update-compat
- pixi run lint

## Session Notes Needing Issues
None.