### PR TITLE
chore: apply shadow-safe stdlib import convention

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -248,3 +248,4 @@ Use names from the refactoring.guru catalogs:
 - Do not add `pixi.lock` to `.gitignore` — commit it for reproducibility.
 - `docs/data.json` and `results/` are gitignored — generated at runtime.
 - The zero-warnings policy is enforced by CI; `pixi run check` must pass before opening a PR.
+- When importing stdlib helpers that may collide with parameter names (`sort`, `min`, `max`, `sum`, `len`, `print`), alias the import to a leading-underscore name (for example `sort as _sort_list`) and call the alias.

--- a/bison/index.mojo
+++ b/bison/index.mojo
@@ -1,6 +1,6 @@
 from std.collections import Set
 from std.python import PythonObject
-from std.builtin.sort import sort
+from std.builtin.sort import sort as _sort_list
 from std.utils import Variant
 
 
@@ -58,7 +58,7 @@ struct Index(Copyable, Movable):
 
     def sort_values(self, ascending: Bool = True) raises -> Index:
         var result = self._data.copy()
-        sort(result)
+        _sort_list(result)
         if not ascending:
             var n = len(result)
             for i in range(n // 2):


### PR DESCRIPTION
## Summary
- alias std.builtin.sort in bison/index.mojo as _sort_list and update call sites
- document the project-wide rule for aliasing shadow-prone stdlib helpers

Closes #367

## Validation
- pixi run mojo run -I .bison-cache -I . tests/test_index.mojo
- pre-commit hooks from commit: mojo format and mojo build --Werror passed

## Session Notes Needing Issues
### pivot_table count null parity on object values

- File: bison/_frame.mojo (pivot_table around line 4250)
- Impact: Medium
- Classification: Change Preventers
- Details: DataFrame.pivot_table(..., aggfunc='count') appears to diverge from pandas when source values are object-backed None values imported via pandas. Add a focused fix to align null-mask handling for object values before strict parity assertions.