### PR TITLE
Fix pivot_table count null parity

### DIFF
--- a/bison/_frame.mojo
+++ b/bison/_frame.mojo
@@ -4314,6 +4314,13 @@ struct DataFrame(Copyable, Movable):
 
                 ref vcol = self._cols[name_to_ci[val_names[vi]]]
                 var is_null = len(vcol._null_mask) > 0 and vcol._null_mask[r]
+                if not is_null and vcol._data.isa[List[PythonObject]]():
+                    is_null = (
+                        String(
+                            vcol._data[List[PythonObject]][r].__class__.__name__
+                        )
+                        == "NoneType"
+                    )
                 if is_null:
                     continue
 
@@ -4345,15 +4352,17 @@ struct DataFrame(Copyable, Movable):
             var null_mask = List[Bool]()
             var any_null = False
             for rk in range(n_rk):
+                if aggfunc == "count":
+                    data.append(PythonObject(Int(counts[rk][out_i])))
+                    null_mask.append(False)
+                    continue
                 if counts[rk][out_i] == 0:
                     data.append(py_none)
                     null_mask.append(True)
                     any_null = True
                     continue
                 null_mask.append(False)
-                if aggfunc == "count":
-                    data.append(PythonObject(Int(counts[rk][out_i])))
-                elif aggfunc == "sum":
+                if aggfunc == "sum":
                     data.append(PythonObject(sums[rk][out_i]))
                 else:
                     data.append(

--- a/tests/test_reshaping.mojo
+++ b/tests/test_reshaping.mojo
@@ -208,11 +208,14 @@ def test_pivot_table_mean_matches_pandas() raises:
 
 def test_pivot_table_count_matches_pandas_with_nulls() raises:
     var pd = Python.import_module("pandas")
-    var pd_df = pd.DataFrame(Python.evaluate(
-        "{'grp': ['a', 'a', 'b', 'b'],"
-        " 'cat': ['x', 'y', 'x', 'y'],"
-        " 'val': [1.0, None, 2.0, 8.0]}"
-    ))
+    var make_df = Python.evaluate(
+        "lambda pd: pd.DataFrame({"
+        "'grp': ['a', 'a', 'b', 'b'], "
+        "'cat': ['x', 'y', 'x', 'y'], "
+        "'val': pd.Series([1, None, 2, 8], dtype=object)"
+        "})"
+    )
+    var pd_df = make_df(pd)
     var df = DataFrame(pd_df)
 
     var values = List[String]()
@@ -236,9 +239,8 @@ def test_pivot_table_count_matches_pandas_with_nulls() raises:
     )
     assert_true(String(got.shape[0]) == String(expected.shape[0]))
     assert_true(String(got.shape[1]) == String(expected.shape[1]))
-    # Validate stable count buckets and keep the null-containing bucket out of
-    # strict parity checks until null-masking for object values is unified.
     assert_true(String(got.iloc[0, 0]) == String(expected.iloc[0, 0]))
+    assert_true(String(got.iloc[0, 1]) == String(expected.iloc[0, 1]))
     assert_true(String(got.iloc[1, 0]) == String(expected.iloc[1, 0]))
     assert_true(String(got.iloc[1, 1]) == String(expected.iloc[1, 1]))
 


### PR DESCRIPTION
## Summary
- align `DataFrame.pivot_table(..., aggfunc="count")` with pandas for object-backed `None` values
- emit zero-valued count buckets instead of nulls when no non-null values are present
- tighten the reshaping regression to assert the previously skipped bucket against pandas

Closes #484.

## Validation
- `pixi run test`
- `pixi run check`

## Session Notes Needing Issues
### pivot_table count null parity on object values

- **File**: `bison/_frame.mojo` (pivot_table around line 4250)
- **Impact**: Medium
- **Classification**: Change Preventers
- **Details**: `DataFrame.pivot_table(..., aggfunc='count')` appears to diverge from pandas when source values are object-backed `None` values imported via pandas. Add a focused fix to align null-mask handling for object values before strict parity assertions.

### pivot_table repeats row and column key construction

- **File**: `bison/_frame.mojo` (pivot_table around line 4200)
- **Impact**: Medium
- **Classification**: Extract Method
- **Details**: `pivot_table` builds row and column labels twice using nearly identical loops before and during aggregation. Extracting shared key-construction helpers would reduce duplication and lower the chance of key-generation drift between the two passes.
