### PR TITLE
Fix multikey groupby sort order

### DIFF
--- a/bison/_frame.mojo
+++ b/bison/_frame.mojo
@@ -6200,6 +6200,89 @@ fn _insertion_sort_keys_by[
         group_keys[j + 1] = key_i
 
 
+fn _groupby_row_less(
+    df: DataFrame,
+    by: List[String],
+    left_row: Int,
+    right_row: Int,
+    col_idx: Dict[String, Int],
+) raises -> Bool:
+    """Return True when *left_row* should sort before *right_row* for groupby keys.
+    """
+    for key_i in range(len(by)):
+        var ci = col_idx[by[key_i]]
+        ref col = df._cols[ci]
+        var left_is_null = len(col._null_mask) > 0 and col._null_mask[left_row]
+        var right_is_null = (
+            len(col._null_mask) > 0 and col._null_mask[right_row]
+        )
+        if left_is_null or right_is_null:
+            if left_is_null and right_is_null:
+                continue
+            return not left_is_null and right_is_null
+
+        ref col_data = col._data
+        if col_data.isa[List[Int64]]():
+            var left_val = col_data[List[Int64]][left_row]
+            var right_val = col_data[List[Int64]][right_row]
+            if left_val < right_val:
+                return True
+            if left_val > right_val:
+                return False
+        elif col_data.isa[List[Float64]]():
+            var left_val = col_data[List[Float64]][left_row]
+            var right_val = col_data[List[Float64]][right_row]
+            if left_val < right_val:
+                return True
+            if left_val > right_val:
+                return False
+        elif col_data.isa[List[Bool]]():
+            var left_val = col_data[List[Bool]][left_row]
+            var right_val = col_data[List[Bool]][right_row]
+            if left_val != right_val:
+                return not left_val and right_val
+        elif col_data.isa[List[String]]():
+            var left_val = col_data[List[String]][left_row]
+            var right_val = col_data[List[String]][right_row]
+            if left_val < right_val:
+                return True
+            if left_val > right_val:
+                return False
+        else:
+            var left_val = String(col_data[List[PythonObject]][left_row])
+            var right_val = String(col_data[List[PythonObject]][right_row])
+            if left_val < right_val:
+                return True
+            if left_val > right_val:
+                return False
+
+    return False
+
+
+fn _insertion_sort_multikey_group_keys(
+    df: DataFrame,
+    by: List[String],
+    mut group_keys: List[String],
+    group_map: Dict[String, List[Int]],
+    col_idx: Dict[String, Int],
+) raises -> None:
+    """Insertion-sort *group_keys* using typed comparisons across multiple key columns.
+    """
+    var n = len(group_keys)
+    for i in range(1, n):
+        var key_i = group_keys[i]
+        var row_i = group_map[key_i][0]
+        var j = i - 1
+        while j >= 0:
+            var key_j = group_keys[j]
+            var row_j = group_map[key_j][0]
+            if not _groupby_row_less(df, by, row_i, row_j, col_idx):
+                break
+            group_keys[j + 1] = key_j
+            j -= 1
+        group_keys[j + 1] = key_i
+
+
 def _groupby_indices(
     df: DataFrame,
     by: List[String],
@@ -6260,8 +6343,9 @@ def _groupby_indices(
                 else:
                     _sort_list(group_keys)
             else:
-                # Multi-column groupby: fall back to lexicographic sort for now.
-                _sort_list(group_keys)
+                _insertion_sort_multikey_group_keys(
+                    df, by, group_keys, group_map, col_idx
+                )
 
 
 def _label_groupby_indices(

--- a/tests/test_groupby.mojo
+++ b/tests/test_groupby.mojo
@@ -525,6 +525,28 @@ def test_dataframegroupby_float_key_natural_sort() raises:
     )
 
 
+def test_dataframegroupby_multikey_numeric_secondary_sort() raises:
+    """Multi-key groupby must sort later numeric keys numerically within each prefix."""
+    var testing = Python.import_module("pandas.testing")
+    var pd = Python.import_module("pandas")
+    var pd_df = pd.DataFrame(
+        Python.evaluate(
+            "{'grp1': ['a', 'a', 'a', 'b', 'b', 'b'],"
+            " 'grp2': [10, 1, 2, 10, 1, 2],"
+            " 'val': [100, 10, 20, 200, 30, 40]}"
+        )
+    )
+    var df = DataFrame(pd_df)
+    var by = List[String]()
+    by.append("grp1")
+    by.append("grp2")
+    var result = df.groupby(by).sum().to_pandas()
+    testing.assert_frame_equal(
+        result,
+        pd_df.groupby(Python.evaluate("['grp1', 'grp2']")).sum(),
+    )
+
+
 def test_seriesgroupby_dropna_sum() raises:
     """Dropna=True must exclude null-labelled rows from all groups."""
     var testing = Python.import_module("pandas.testing")


### PR DESCRIPTION
## Summary
- replace lexicographic multikey groupby sorting with typed per-column comparisons
- preserve natural numeric ordering even when the numeric key is not the first groupby column
- add a regression that compares native multikey ordering directly against pandas

Closes #409.

## Validation
- `pixi run test`
- `pixi run check`

## Session Notes Needing Issues
### pivot_table count null parity on object values

- **File**: `bison/_frame.mojo` (pivot_table around line 4250)
- **Impact**: Medium
- **Classification**: Change Preventers
- **Details**: `DataFrame.pivot_table(..., aggfunc='count')` appears to diverge from pandas when source values are object-backed `None` values imported via pandas. Add a focused fix to align null-mask handling for object values before strict parity assertions.

### composite row-key serialization can collide on delimiter content

- **File**: `bison/_frame.mojo` (`_row_key_str` around line 5095)
- **Impact**: High
- **Classification**: Primitive Obsession
- **Details**: Multi-column keys are serialized by joining values with `|`, so string values containing that delimiter can collide with different key tuples. Replace string concatenation with a structured key representation or escaping strategy before expanding more reshape and groupby logic on top of it.

### pivot_table repeats row and column key construction

- **File**: `bison/_frame.mojo` (pivot_table around line 4200)
- **Impact**: Medium
- **Classification**: Extract Method
- **Details**: `pivot_table` builds row and column labels twice using nearly identical loops before and during aggregation. Extracting shared key-construction helpers would reduce duplication and lower the chance of key-generation drift between the two passes.
