### PR TITLE
Adopt shared test helpers in interop tests

### DIFF
--- a/tests/test_interop.mojo
+++ b/tests/test_interop.mojo
@@ -2,6 +2,7 @@
 from std.python import Python, PythonObject
 from std.testing import assert_equal, assert_true, TestSuite
 from bison import DataFrame, Series, Column, ColumnData, int64, object_
+from _helpers import assert_frame_equal, assert_series_equal
 
 
 def test_df_from_pandas_preserves_shape() raises:
@@ -17,8 +18,7 @@ def test_df_to_pandas_identity() raises:
     var pd_df = pd.DataFrame(Python.evaluate("{'x': [10, 20]}"))
     var df = DataFrame.from_pandas(pd_df)
     var back = df.to_pandas()
-    var testing = Python.import_module("pandas.testing")
-    testing.assert_frame_equal(pd_df, back)
+    assert_frame_equal(pd_df, back)
 
 
 def test_series_from_pandas_preserves_name() raises:
@@ -34,8 +34,7 @@ def test_series_to_pandas_identity() raises:
     var pd_s = pd.Series(Python.evaluate("[5, 6, 7]"), name="v")
     var s = Series.from_pandas(pd_s)
     var back = s.to_pandas()
-    var testing = Python.import_module("pandas.testing")
-    testing.assert_series_equal(pd_s, back)
+    assert_series_equal(pd_s, back)
 
 
 def test_df_columns_match() raises:
@@ -61,8 +60,7 @@ def test_quickstart_example() raises:
     assert_equal(cols[1], "b")
 
     var original = df.to_pandas()
-    var testing = Python.import_module("pandas.testing")
-    testing.assert_frame_equal(pd_df, original)
+    assert_frame_equal(pd_df, original)
 
 
 def test_column_typed_storage() raises:
@@ -97,7 +95,6 @@ def test_column_typed_storage() raises:
 def test_series_index_roundtrip() raises:
     """Custom string index must survive from_pandas → to_pandas."""
     var pd = Python.import_module("pandas")
-    var testing = Python.import_module("pandas.testing")
     var pd_s = pd.Series(
         Python.evaluate("[1, 2, 3]"),
         index=Python.evaluate("['a', 'b', 'c']"),
@@ -105,20 +102,19 @@ def test_series_index_roundtrip() raises:
     )
     var s = Series.from_pandas(pd_s)
     var back = s.to_pandas()
-    testing.assert_series_equal(pd_s, back)
+    assert_series_equal(pd_s, back)
 
 
 def test_df_index_roundtrip() raises:
     """Custom string index on a DataFrame must survive from_pandas → to_pandas."""
     var pd = Python.import_module("pandas")
-    var testing = Python.import_module("pandas.testing")
     var pd_df = pd.DataFrame(
         Python.evaluate("{'v': [10, 20]}"),
         index=Python.evaluate("['r0', 'r1']"),
     )
     var df = DataFrame.from_pandas(pd_df)
     var back = df.to_pandas()
-    testing.assert_frame_equal(pd_df, back)
+    assert_frame_equal(pd_df, back)
 
 
 def test_float64_bitcast_roundtrip() raises:


### PR DESCRIPTION
## Summary
- migrate `tests/test_interop.mojo` to shared assertion helpers from `tests/_helpers.mojo`
- remove repeated inline `pandas.testing` imports in migrated tests
- keep behavior unchanged while establishing a pattern for broader suite migration

Closes #504.

## Validation
- `pixi run test`
- `pixi run check`

## Session Notes Needing Issues
### pivot_table count null parity on object values

- **File**: `bison/_frame.mojo` (pivot_table around line 4250)
- **Impact**: Medium
- **Classification**: Change Preventers
- **Details**: `DataFrame.pivot_table(..., aggfunc='count')` appears to diverge from pandas when source values are object-backed `None` values imported via pandas. Add a focused fix to align null-mask handling for object values before strict parity assertions.

### composite row-key serialization can collide on delimiter content

- **File**: `bison/_frame.mojo` (`_row_key_str` around line 5095)
- **Impact**: High
- **Classification**: Primitive Obsession
- **Details**: Multi-column keys are serialized by joining values with `|`, so string values containing that delimiter can collide with different key tuples. Replace string concatenation with a structured key representation or escaping strategy before expanding more reshape and groupby logic on top of it.

### pivot_table repeats row and column key construction

- **File**: `bison/_frame.mojo` (pivot_table around line 4200)
- **Impact**: Medium
- **Classification**: Extract Method
- **Details**: `pivot_table` builds row and column labels twice using nearly identical loops before and during aggregation. Extracting shared key-construction helpers would reduce duplication and lower the chance of key-generation drift between the two passes.

### tests should reuse shared helper assertions

- **File**: `tests/_helpers.mojo` (and across `tests/test_*.mojo`)
- **Impact**: Medium
- **Classification**: Consolidate Duplicate Conditional Fragments
- **Details**: Many test files repeatedly import `pandas.testing` and call `testing.assert_frame_equal`/`testing.assert_series_equal` inline instead of using `tests/_helpers.mojo` wrappers. Standardizing on shared helpers would reduce duplication and make assertion options easier to adjust globally.
