### PR TITLE
spec: minimal query/eval grammar and semantics

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,13 @@ This is a current limitation of Mojo's parametric function support
 (tracked in [modularml/mojo#6130](https://github.com/modularml/mojo/issues/6130)).
 Use `clip()` or `where()` for threshold-style operations in the meantime.
 
+### Query/eval native grammar specification
+
+The minimal native `DataFrame.query()` and `DataFrame.eval()` grammar and
+semantics are documented in [`docs/query-eval-spec.md`](docs/query-eval-spec.md).
+Use this as the canonical reference for supported syntax, precedence,
+null semantics, and unsupported expression behavior.
+
 ## Contributing
 
 1. Pick a stub method from the table above.

--- a/docs/query-eval-spec.md
+++ b/docs/query-eval-spec.md
@@ -1,0 +1,173 @@
+# Query/Eval Minimal Grammar Specification
+
+Status: Draft for issue #492 (parent: #491, related: #418)
+
+This document defines the minimal grammar and semantics for the first native
+`DataFrame.query()` and `DataFrame.eval()` release.
+
+For in-scope syntax, behavior should match pandas as closely as possible.
+
+## 1. Supported Syntax
+
+### 1.1 Expression forms
+
+The initial release supports the following forms:
+
+- Column references by bare identifier name.
+- Literal values: integer, float, boolean, string, null.
+- Comparisons: `<`, `<=`, `>`, `>=`, `==`, `!=`.
+- Logical operators: `not`, `and`, `or`.
+- Parentheses for grouping.
+
+### 1.2 Minimal grammar (EBNF)
+
+```text
+expr          := or_expr
+or_expr       := and_expr ("or" and_expr)*
+and_expr      := not_expr ("and" not_expr)*
+not_expr      := "not" not_expr | comparison
+comparison    := primary (comp_op primary)?
+comp_op       := "<" | "<=" | ">" | ">=" | "==" | "!="
+primary       := IDENT | literal | "(" expr ")"
+literal       := INT | FLOAT | BOOL | STRING | NULL
+IDENT         := /[A-Za-z_][A-Za-z0-9_]*/
+BOOL          := "True" | "False"
+NULL          := "None"
+```
+
+Notes:
+
+- Comparison chaining (for example `a < b < c`) is out of scope for this
+  minimal release.
+- The same grammar applies to both `query` and `eval` in this phase.
+
+## 2. Operator Precedence And Associativity
+
+Highest to lowest precedence:
+
+1. Parentheses: `( ... )`
+2. Unary logical negation: `not`
+3. Comparisons: `<`, `<=`, `>`, `>=`, `==`, `!=`
+4. Logical conjunction: `and`
+5. Logical disjunction: `or`
+
+Associativity:
+
+- `and` and `or` are left-associative.
+- `not` is right-associative as a unary operator.
+
+Examples:
+
+- `a > 1 and b < 2 or c == 3` parses as `((a > 1 and b < 2) or c == 3)`.
+- `not a > 1` parses as `not (a > 1)`.
+
+## 3. Null Semantics
+
+The engine uses three-valued boolean logic for expression composition where
+null can appear in intermediate masks.
+
+### 3.1 `and` truth table
+
+| left | right | result |
+|------|-------|--------|
+| True | True | True |
+| True | False | False |
+| True | Null | Null |
+| False | True | False |
+| False | False | False |
+| False | Null | False |
+| Null | True | Null |
+| Null | False | False |
+| Null | Null | Null |
+
+### 3.2 `or` truth table
+
+| left | right | result |
+|------|-------|--------|
+| True | True | True |
+| True | False | True |
+| True | Null | True |
+| False | True | True |
+| False | False | False |
+| False | Null | Null |
+| Null | True | True |
+| Null | False | Null |
+| Null | Null | Null |
+
+### 3.3 `not` truth table
+
+| input | result |
+|-------|--------|
+| True | False |
+| False | True |
+| Null | Null |
+
+### 3.4 Comparison with nulls
+
+- Any comparison where either side is null evaluates to Null.
+- Nulls are not equal to non-null values.
+- Null compared with null also evaluates to Null in this phase.
+
+## 4. Explicit Out-Of-Scope Syntax
+
+The following are explicitly unsupported in the minimal release:
+
+- Function calls: `f(a)`, `abs(a)`, `len(a)`.
+- Attribute access: `a.str.len`, `obj.attr`.
+- Indexing and slicing: `a[0]`, `a[1:3]`.
+- Assignment expressions: `a = b`, `a := b`.
+- Membership and identity operators: `in`, `not in`, `is`, `is not`.
+- Arithmetic operators and expressions: `a + b`, `a * 2`, `-a`.
+- Comparison chaining: `a < b < c`.
+- Engine and parser keyword options in expression text.
+
+## 5. Error Behavior
+
+### 5.1 Unsupported syntax
+
+- Parse-time unsupported grammar must raise `Error` with a message containing
+  `unsupported syntax` and the failing token or construct.
+
+### 5.2 Invalid expression structure
+
+- Parse errors (for example missing parenthesis) must raise `Error` with a
+  message containing `invalid expression`.
+
+### 5.3 Unknown identifiers
+
+- Referencing a missing column must raise `Error` with a message containing
+  `unknown column` and the identifier.
+
+### 5.4 Type errors during evaluation
+
+- Invalid logical/comparison operand types must raise `Error` with a message
+  containing `type error` and the operator.
+
+### 5.5 Null handling failures
+
+- Internal null-mask shape mismatches or impossible null states should raise
+  `Error` with a message containing `null semantics`.
+
+## 6. Examples
+
+### 6.1 Valid expressions
+
+- `a > 2`
+- `(a > 2) and (b <= 10)`
+- `not (flag == True)`
+- `(x != None) or (y == 0)`
+- `a == 1 or b == 2 and c == 3`
+
+### 6.2 Invalid expressions
+
+- `a + b` (arithmetic out of scope)
+- `len(a) > 0` (function call out of scope)
+- `a[0] == 1` (indexing out of scope)
+- `a < b < c` (comparison chaining out of scope)
+- `(a > 1` (invalid expression)
+
+## 7. Follow-up Implementation Issues
+
+This spec is the semantic baseline for parser and runtime implementation issues
+in the #491 thread. Implementation issues must reference this document and
+update it if behavior changes.


### PR DESCRIPTION
## Summary
- add canonical query/eval minimal grammar spec in `docs/query-eval-spec.md`
- document supported syntax, precedence, null truth tables, out-of-scope constructs, and error behavior
- add README discoverability link to the new spec

## Validation
- `pixi run check`

Closes #492

## Session Notes Needing Issues
### query/eval semantics lived only in sparse tests and inline comments

- **File**: `README.md` and `bison/_frame.mojo` (query/eval area around line 3077)
- **Impact**: Medium
- **Classification**: Change Preventers
- **Details**: Query/eval behavior lacked a single normative grammar/semantics document, which made follow-on parser and evaluator work prone to interpretation drift. Keep `docs/query-eval-spec.md` updated as a contract whenever syntax or null semantics evolve.

### pivot_table count null parity on object values

- **File**: `bison/_frame.mojo` (pivot_table around line 4250)
- **Impact**: Medium
- **Classification**: Change Preventers
- **Details**: `DataFrame.pivot_table(..., aggfunc='count')` appears to diverge from pandas when source values are object-backed `None` values imported via pandas. Add a focused fix to align null-mask handling for object values before strict parity assertions.

### composite row-key serialization can collide on delimiter content

- **File**: `bison/_frame.mojo` (`_row_key_str` around line 5095)
- **Impact**: High
- **Classification**: Primitive Obsession
- **Details**: Multi-column keys are serialized by joining values with `|`, so string values containing that delimiter can collide with different key tuples. Replace string concatenation with a structured key representation or escaping strategy before expanding more reshape and groupby logic on top of it.

### pivot_table repeats row and column key construction

- **File**: `bison/_frame.mojo` (pivot_table around line 4200)
- **Impact**: Medium
- **Classification**: Extract Method
- **Details**: `pivot_table` builds row and column labels twice using nearly identical loops before and during aggregation. Extracting shared key-construction helpers would reduce duplication and lower the chance of key-generation drift between the two passes.

### tests should reuse shared helper assertions

- **File**: `tests/_helpers.mojo` (and across `tests/test_*.mojo`)
- **Impact**: Medium
- **Classification**: Consolidate Duplicate Conditional Fragments
- **Details**: Many test files repeatedly import `pandas.testing` and call `testing.assert_frame_equal`/`testing.assert_series_equal` inline instead of using `tests/_helpers.mojo` wrappers. Standardizing on shared helpers would reduce duplication and make assertion options easier to adjust globally.
