### PR TITLE
feat: Series boolean logical operators with Kleene null semantics (#493)

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ In CI it runs after the test suite and the result is committed back to the branc
 | Category | Stubs | Implemented |
 |----------|-------|-------------|
 | DataFrame | 5 | 138 |
-| Series | 0 | 106 |
+| Series | 0 | 117 |
 | GroupBy (DataFrame) | 0 | 24 |
 | GroupBy (Series) | 0 | 17 |
 | String accessor | 0 | 21 |
@@ -91,7 +91,7 @@ In CI it runs after the test suite and the result is committed back to the branc
 | Index | 0 | 14 |
 | IO | 0 | 8 |
 | Reshape | 0 | 2 |
-| **Total** | **5** | **350** |
+| **Total** | **5** | **361** |
 <!-- COMPAT_TABLE_END -->
 
 ## Known limitations

--- a/bison/_frame.mojo
+++ b/bison/_frame.mojo
@@ -226,6 +226,48 @@ struct Series(Copyable, Movable):
     def ge(self, other: Series) raises -> Series:
         return Series(self._col._cmp_ge(other._col))
 
+    # ------------------------------------------------------------------
+    # Boolean logical
+    # ------------------------------------------------------------------
+
+    def and_(self, other: Series) raises -> Series:
+        """Element-wise logical AND with Kleene null semantics."""
+        return Series(self._col._bool_and(other._col))
+
+    def or_(self, other: Series) raises -> Series:
+        """Element-wise logical OR with Kleene null semantics."""
+        return Series(self._col._bool_or(other._col))
+
+    def xor(self, other: Series) raises -> Series:
+        """Element-wise logical XOR (null propagates if either operand is null).
+        """
+        return Series(self._col._bool_xor(other._col))
+
+    def invert(self) raises -> Series:
+        """Element-wise logical NOT.  Null elements remain null."""
+        return Series(self._col._bool_invert())
+
+    def __and__(self, other: Series) raises -> Series:
+        return self.and_(other)
+
+    def __or__(self, other: Series) raises -> Series:
+        return self.or_(other)
+
+    def __xor__(self, other: Series) raises -> Series:
+        return self.xor(other)
+
+    def __invert__(self) raises -> Series:
+        return self.invert()
+
+    def __rand__(self, other: Series) raises -> Series:
+        return other.and_(self)
+
+    def __ror__(self, other: Series) raises -> Series:
+        return other.or_(self)
+
+    def __rxor__(self, other: Series) raises -> Series:
+        return other.xor(self)
+
     def __gt__(self, other: Float64) raises -> Series:
         """Element-wise ``>`` against a scalar, returning a boolean Series."""
         return Series(self._col._cmp_scalar_gt(other))

--- a/bison/column.mojo
+++ b/bison/column.mojo
@@ -2434,6 +2434,14 @@ comptime _CMP_GE = 5
 
 
 # ------------------------------------------------------------------
+# Compile-time operation selectors for Column._bool_op
+# ------------------------------------------------------------------
+comptime _BOOL_AND = 0
+comptime _BOOL_OR = 1
+comptime _BOOL_XOR = 2
+
+
+# ------------------------------------------------------------------
 # Comparison visitor — dispatches on self's ColumnData arm and stores
 # the RHS column's data to handle the Bool-Bool fast path internally.
 # ------------------------------------------------------------------
@@ -2694,6 +2702,130 @@ struct _CmpScalarVisitor[op: Int](ColumnDataVisitorRaises, Copyable, Movable):
         raise Error(
             "cmp: comparison not supported for object/datetime column type"
         )
+
+
+# ------------------------------------------------------------------
+# Boolean logical visitor — element-wise and/or/xor with Kleene three-valued
+# null semantics (per docs/query-eval-spec.md § 3).
+#
+# Both self and other must be bool_ columns; all other arms raise.
+# Kleene short-circuit rules for AND and OR differ from the simple
+# "null if either null" propagation used in arithmetic / comparison:
+#
+#   AND: False AND Null → False   (False absorbs)
+#        True  AND Null → Null
+#   OR:  True  OR  Null → True    (True absorbs)
+#        False OR  Null → Null
+#   XOR: standard propagation — null if either operand is null.
+# ------------------------------------------------------------------
+
+
+struct _BoolOpVisitor[op: Int](ColumnDataVisitorRaises, Copyable, Movable):
+    """Element-wise boolean logical visitor for ``Column._bool_op``.
+
+    ``op`` is one of the ``_BOOL_*`` compile-time constants.  Both the
+    self column and the RHS column must be bool_ dtype; any other arm raises
+    immediately.  Null propagation follows Kleene three-valued logic for AND
+    and OR, and standard (either-null → null) propagation for XOR.
+    """
+
+    var self_null_mask: List[Bool]
+    var other_null_mask: List[Bool]
+    var other_bool: List[Bool]
+    var result: List[Bool]
+    var result_mask: List[Bool]
+    var has_any_null: Bool
+
+    def __init__(out self, self_null_mask: List[Bool], other: Column) raises:
+        if not other._data.isa[List[Bool]]():
+            raise Error("bool_op: non-bool column type on right-hand side")
+        self.self_null_mask = self_null_mask.copy()
+        self.other_null_mask = other._null_mask.copy()
+        self.other_bool = other._data[List[Bool]].copy()
+        self.result = List[Bool]()
+        self.result_mask = List[Bool]()
+        self.has_any_null = False
+
+    def on_bool(mut self, data: List[Bool]) raises:
+        var has_a_mask = len(self.self_null_mask) > 0
+        var has_b_mask = len(self.other_null_mask) > 0
+        ref ob = self.other_bool
+        for i in range(len(data)):
+            var a_null = has_a_mask and self.self_null_mask[i]
+            var b_null = has_b_mask and self.other_null_mask[i]
+            comptime if Self.op == _BOOL_AND:
+                # Kleene AND: False absorbs null
+                if a_null:
+                    if (not b_null) and (not ob[i]):
+                        # Null AND False → False
+                        self.result.append(False)
+                        self.result_mask.append(False)
+                    else:
+                        # Null AND True → Null; Null AND Null → Null
+                        self.result.append(False)
+                        self.result_mask.append(True)
+                        self.has_any_null = True
+                elif b_null:
+                    if not data[i]:
+                        # False AND Null → False
+                        self.result.append(False)
+                        self.result_mask.append(False)
+                    else:
+                        # True AND Null → Null
+                        self.result.append(False)
+                        self.result_mask.append(True)
+                        self.has_any_null = True
+                else:
+                    self.result.append(data[i] and ob[i])
+                    self.result_mask.append(False)
+            elif Self.op == _BOOL_OR:
+                # Kleene OR: True absorbs null
+                if a_null:
+                    if (not b_null) and ob[i]:
+                        # Null OR True → True
+                        self.result.append(True)
+                        self.result_mask.append(False)
+                    else:
+                        # Null OR False → Null; Null OR Null → Null
+                        self.result.append(False)
+                        self.result_mask.append(True)
+                        self.has_any_null = True
+                elif b_null:
+                    if data[i]:
+                        # True OR Null → True
+                        self.result.append(True)
+                        self.result_mask.append(False)
+                    else:
+                        # False OR Null → Null
+                        self.result.append(False)
+                        self.result_mask.append(True)
+                        self.has_any_null = True
+                else:
+                    self.result.append(data[i] or ob[i])
+                    self.result_mask.append(False)
+            else:
+                # XOR: standard null propagation
+                if a_null or b_null:
+                    self.result.append(False)
+                    self.result_mask.append(True)
+                    self.has_any_null = True
+                else:
+                    self.result.append(
+                        (data[i] and not ob[i]) or (not data[i] and ob[i])
+                    )
+                    self.result_mask.append(False)
+
+    def on_int64(mut self, data: List[Int64]) raises:
+        raise Error("bool_op: non-bool column type (got int64)")
+
+    def on_float64(mut self, data: List[Float64]) raises:
+        raise Error("bool_op: non-bool column type (got float64)")
+
+    def on_str(mut self, data: List[String]) raises:
+        raise Error("bool_op: non-bool column type (got string)")
+
+    def on_obj(mut self, data: List[PythonObject]) raises:
+        raise Error("bool_op: non-bool column type (got object)")
 
 
 # Compile-time function type for element-wise Float64 transforms (_apply kernel)
@@ -4737,6 +4869,75 @@ struct Column(Copyable, Movable, Sized):
         return self._cmp_scalar_op[_CMP_GE](scalar)
 
     # ------------------------------------------------------------------
+    # Boolean logical kernels
+    # ------------------------------------------------------------------
+
+    def _bool_op[
+        op: Int
+    ](self, op_name: String, other: Column) raises -> Column:
+        """Core element-wise boolean logical kernel with Kleene null semantics.
+
+        Dispatches through ``_BoolOpVisitor[op]``.  Both self and other must
+        be bool_ columns; any other dtype raises.  ``op`` is one of the
+        ``_BOOL_*`` compile-time constants.
+
+        AND and OR use Kleene three-valued logic (False absorbs null for AND;
+        True absorbs null for OR).  XOR uses standard null propagation.
+        """
+        if len(self) != len(other):
+            raise Error(
+                op_name
+                + ": length mismatch ("
+                + String(len(self))
+                + " vs "
+                + String(len(other))
+                + ")"
+            )
+        if not self._data.isa[List[Bool]]():
+            raise Error("bool_op: non-bool column type on left-hand side")
+        var visitor = _BoolOpVisitor[op](self._null_mask, other)
+        visit_col_data_raises(visitor, self._data)
+        return self._build_result_col(
+            ColumnData(visitor.result.copy()),
+            visitor.result_mask.copy(),
+            visitor.has_any_null,
+        )
+
+    def _bool_and(self, other: Column) raises -> Column:
+        return self._bool_op[_BOOL_AND]("and", other)
+
+    def _bool_or(self, other: Column) raises -> Column:
+        return self._bool_op[_BOOL_OR]("or", other)
+
+    def _bool_xor(self, other: Column) raises -> Column:
+        return self._bool_op[_BOOL_XOR]("xor", other)
+
+    def _bool_invert(self) raises -> Column:
+        """Element-wise boolean NOT.  Returns a bool_ Column with the same
+        null mask; null elements remain null.  Raises if self is not bool_.
+        """
+        if not self._data.isa[List[Bool]]():
+            raise Error("bool_op: non-bool column type (invert)")
+        ref src = self._data[List[Bool]]
+        var result = List[Bool]()
+        var result_mask = List[Bool]()
+        var has_any_null = False
+        var has_input_mask = len(self._null_mask) > 0
+        for i in range(len(src)):
+            if has_input_mask and self._null_mask[i]:
+                result.append(False)
+                result_mask.append(True)
+                has_any_null = True
+            else:
+                result.append(not src[i])
+                result_mask.append(False)
+        return self._build_result_col(
+            ColumnData(result^),
+            result_mask^,
+            has_any_null,
+        )
+
+    # ------------------------------------------------------------------
     # Transformation kernels
     # ------------------------------------------------------------------
 
@@ -5324,7 +5525,7 @@ struct Column(Copyable, Movable, Sized):
             bison_dtype = int64
         elif dtype_str == "float32" or dtype_str == "float64":
             bison_dtype = float64
-        elif dtype_str == "bool":
+        elif dtype_str == "bool" or dtype_str == "boolean":
             bison_dtype = bool_
         elif dtype_str.startswith("datetime64"):
             bison_dtype = datetime64_ns

--- a/tests/test_series_math.mojo
+++ b/tests/test_series_math.mojo
@@ -547,6 +547,152 @@ def test_bool_ge() raises:
     assert_true(Bool(rp.iloc[3]) == True)
 
 
+# ------------------------------------------------------------------
+# Bool column logical operator tests (and/or/xor/invert) — issue #493
+# ------------------------------------------------------------------
+
+
+def test_bool_and() raises:
+    # [T,T,F,F] AND [T,F,T,F] == [T,F,F,F]
+    var pd = Python.import_module("pandas")
+    var s1 = Series(pd.Series(Python.evaluate("[True, True, False, False]"), dtype="bool"))
+    var s2 = Series(pd.Series(Python.evaluate("[True, False, True, False]"), dtype="bool"))
+    var result = s1.and_(s2)
+    ref d = result._col._data[List[Bool]]
+    assert_true(d[0] == True)
+    assert_true(d[1] == False)
+    assert_true(d[2] == False)
+    assert_true(d[3] == False)
+    assert_true(len(result._col._null_mask) == 0)
+
+
+def test_bool_and_dunder() raises:
+    # __and__ delegates to and_
+    var pd = Python.import_module("pandas")
+    var s1 = Series(pd.Series(Python.evaluate("[True, False]"), dtype="bool"))
+    var s2 = Series(pd.Series(Python.evaluate("[False, False]"), dtype="bool"))
+    var result = s1.__and__(s2)
+    ref d = result._col._data[List[Bool]]
+    assert_true(d[0] == False)
+    assert_true(d[1] == False)
+
+
+def test_bool_or() raises:
+    # [T,T,F,F] OR [T,F,T,F] == [T,T,T,F]
+    var pd = Python.import_module("pandas")
+    var s1 = Series(pd.Series(Python.evaluate("[True, True, False, False]"), dtype="bool"))
+    var s2 = Series(pd.Series(Python.evaluate("[True, False, True, False]"), dtype="bool"))
+    var result = s1.or_(s2)
+    ref d = result._col._data[List[Bool]]
+    assert_true(d[0] == True)
+    assert_true(d[1] == True)
+    assert_true(d[2] == True)
+    assert_true(d[3] == False)
+    assert_true(len(result._col._null_mask) == 0)
+
+
+def test_bool_xor() raises:
+    # [T,T,F,F] XOR [T,F,T,F] == [F,T,T,F]
+    var pd = Python.import_module("pandas")
+    var s1 = Series(pd.Series(Python.evaluate("[True, True, False, False]"), dtype="bool"))
+    var s2 = Series(pd.Series(Python.evaluate("[True, False, True, False]"), dtype="bool"))
+    var result = s1.xor(s2)
+    ref d = result._col._data[List[Bool]]
+    assert_true(d[0] == False)
+    assert_true(d[1] == True)
+    assert_true(d[2] == True)
+    assert_true(d[3] == False)
+    assert_true(len(result._col._null_mask) == 0)
+
+
+def test_bool_invert() raises:
+    # ~[T,F,T,F] == [F,T,F,T]
+    var pd = Python.import_module("pandas")
+    var s = Series(pd.Series(Python.evaluate("[True, False, True, False]"), dtype="bool"))
+    var result = s.invert()
+    ref d = result._col._data[List[Bool]]
+    assert_true(d[0] == False)
+    assert_true(d[1] == True)
+    assert_true(d[2] == False)
+    assert_true(d[3] == True)
+    assert_true(len(result._col._null_mask) == 0)
+
+
+def test_bool_and_kleene_nulls() raises:
+    # Kleene AND: False AND Null = False; True AND Null = Null; Null AND Null = Null
+    var pd = Python.import_module("pandas")
+    # s1 = [False, True,  Null]
+    # s2 = [Null,  Null,  Null]
+    var s1 = Series(pd.Series(Python.evaluate("[False, True, None]"), dtype="object").astype("boolean"))
+    var s2 = Series(pd.Series(Python.evaluate("[None, None, None]"), dtype="object").astype("boolean"))
+    var result = s1.and_(s2)
+    # False AND Null → False (non-null)
+    assert_true(len(result._col._null_mask) > 0)
+    assert_true(result._col._null_mask[0] == False)
+    assert_true(result._col._data[List[Bool]][0] == False)
+    # True AND Null → Null
+    assert_true(result._col._null_mask[1] == True)
+    # Null AND Null → Null
+    assert_true(result._col._null_mask[2] == True)
+
+
+def test_bool_or_kleene_nulls() raises:
+    # Kleene OR: True OR Null = True; False OR Null = Null; Null OR Null = Null
+    var pd = Python.import_module("pandas")
+    # s1 = [True, False, Null]
+    # s2 = [Null, Null,  Null]
+    var s1 = Series(pd.Series(Python.evaluate("[True, False, None]"), dtype="object").astype("boolean"))
+    var s2 = Series(pd.Series(Python.evaluate("[None, None, None]"), dtype="object").astype("boolean"))
+    var result = s1.or_(s2)
+    # True OR Null → True (non-null)
+    assert_true(len(result._col._null_mask) > 0)
+    assert_true(result._col._null_mask[0] == False)
+    assert_true(result._col._data[List[Bool]][0] == True)
+    # False OR Null → Null
+    assert_true(result._col._null_mask[1] == True)
+    # Null OR Null → Null
+    assert_true(result._col._null_mask[2] == True)
+
+
+def test_bool_invert_null() raises:
+    # ~Null == Null
+    var pd = Python.import_module("pandas")
+    var s = Series(pd.Series(Python.evaluate("[True, None, False]"), dtype="object").astype("boolean"))
+    var result = s.invert()
+    assert_true(len(result._col._null_mask) > 0)
+    assert_true(result._col._null_mask[0] == False)
+    assert_true(result._col._data[List[Bool]][0] == False)
+    assert_true(result._col._null_mask[1] == True)
+    assert_true(result._col._null_mask[2] == False)
+    assert_true(result._col._data[List[Bool]][2] == True)
+
+
+def test_bool_and_mismatch() raises:
+    var pd = Python.import_module("pandas")
+    var s1 = Series(pd.Series(Python.evaluate("[True, False]"), dtype="bool"))
+    var s2 = Series(pd.Series(Python.evaluate("[True, False, True]"), dtype="bool"))
+    var raised = False
+    try:
+        _ = s1.and_(s2)
+    except e:
+        raised = True
+        assert_true("length mismatch" in String(e))
+    assert_true(raised)
+
+
+def test_bool_non_bool_dtype() raises:
+    var pd = Python.import_module("pandas")
+    var s1 = Series(pd.Series(Python.evaluate("[1, 0, 1]")))
+    var s2 = Series(pd.Series(Python.evaluate("[1, 1, 0]")))
+    var raised = False
+    try:
+        _ = s1.and_(s2)
+    except e:
+        raised = True
+        assert_true("non-bool" in String(e))
+    assert_true(raised)
+
+
 def test_sem() raises:
     var pd = Python.import_module("pandas")
     var s = Series(pd.Series(Python.evaluate("[2.0, 4.0, 4.0, 4.0, 5.0, 5.0, 7.0, 9.0]")))


### PR DESCRIPTION
## Summary

Implements element-wise boolean logical operators on `Series` as required by issue #493 (parent: #491, depends on: #492).

### Operators added

| Method | Dunder | Reflected |
|---|---|---|
| `and_(other)` | `__and__` | `__rand__` |
| `or_(other)` | `__or__` | `__ror__` |
| `xor(other)` | `__xor__` | `__rxor__` |
| `invert()` | `__invert__` | — |

### Null semantics

AND and OR use **Kleene three-valued logic** as specified in `docs/query-eval-spec.md` § 3:

- `False AND Null → False` (False absorbs null)
- `True AND Null → Null`
- `True OR Null → True` (True absorbs null)
- `False OR Null → Null`
- `not Null → Null`
- XOR uses standard propagation (null if either operand is null)

Both operands must be `bool_` dtype; any other dtype raises `"bool_op: non-bool column type"`.

### Changes

**`bison/column.mojo`**
- `_BOOL_{AND,OR,XOR}` comptime selectors
- `_BoolOpVisitor[op]` struct with Kleene logic in `on_bool`; all other arms raise
- `Column._bool_op[op]` kernel + `_bool_and`, `_bool_or`, `_bool_xor`, `_bool_invert` methods
- `from_pandas` now maps pandas nullable `"boolean"` dtype to `bool_`

**`bison/_frame.mojo`**
- `Series.and_`, `or_`, `xor`, `invert` named methods
- `__and__`, `__or__`, `__xor__`, `__invert__` dunders
- `__rand__`, `__ror__`, `__rxor__` reflected dunders

**`tests/test_series_math.mojo`** — 9 new test functions:
`test_bool_and`, `test_bool_and_dunder`, `test_bool_or`, `test_bool_xor`, `test_bool_invert`, `test_bool_and_kleene_nulls`, `test_bool_or_kleene_nulls`, `test_bool_invert_null`, `test_bool_and_mismatch`, `test_bool_non_bool_dtype`

All 88 tests pass. `pixi run check` and `pixi run update-compat` clean.

Closes #493

## Session Notes Needing Issues

### CSV reader lacks bool dtype inference

- **File**: `bison/io/csv.mojo`
- **Impact**: Medium
- **Classification**: Incomplete Code (missing feature parity with JSON reader)
- **Details**: CSV inference order is `Int64 > Float64 > String` — no bool. JSON reader handles `bool`. Add `bool > Int64 > Float64 > String` inference, recognising `"True"/"False"` (case-insensitive) as boolean values, to match pandas CSV behaviour.