### PR TITLE
feat(expr): implement NK_AND/NK_OR/NK_NOT evaluation (#496)

### DIFF
--- a/bison/expr/_eval.mojo
+++ b/bison/expr/_eval.mojo
@@ -160,23 +160,16 @@ def _eval_node(idx: Int, parsed: ParsedExpr, df: DataFrame) raises -> Series:
     if node.kind == NK_COMPARE:
         return _eval_compare(node, parsed, df)
     elif node.kind == NK_AND:
-        raise Error(
-            "evaluator: unsupported expression kind "
-            + String(node.kind)
-            + " (NK_AND — not yet implemented)"
-        )
+        var left_mask = _eval_node(node.left, parsed, df)
+        var right_mask = _eval_node(node.right, parsed, df)
+        return left_mask.__and__(right_mask)
     elif node.kind == NK_OR:
-        raise Error(
-            "evaluator: unsupported expression kind "
-            + String(node.kind)
-            + " (NK_OR — not yet implemented)"
-        )
+        var left_mask = _eval_node(node.left, parsed, df)
+        var right_mask = _eval_node(node.right, parsed, df)
+        return left_mask.__or__(right_mask)
     elif node.kind == NK_NOT:
-        raise Error(
-            "evaluator: unsupported expression kind "
-            + String(node.kind)
-            + " (NK_NOT — not yet implemented)"
-        )
+        var operand = _eval_node(node.left, parsed, df)
+        return operand.__invert__()
     else:
         raise Error(
             "evaluator: unsupported expression kind " + String(node.kind)
@@ -191,8 +184,8 @@ def _eval_node(idx: Int, parsed: ParsedExpr, df: DataFrame) raises -> Series:
 def eval_expr(parsed: ParsedExpr, df: DataFrame) raises -> Series:
     """Evaluate *parsed* against *df* and return a boolean Series mask.
 
-    Only single ``NK_COMPARE`` nodes are supported at this stage.  Logical
-    connectives (and / or / not) will be added in a later release and raise
-    with a clear "unsupported expression kind" error until then.
+    Supports comparison nodes (``NK_COMPARE``) and logical connectives
+    (``NK_AND``, ``NK_OR``, ``NK_NOT``) with Kleene null semantics.
+    Parenthetical groupings and precedence are handled by the parser.
     """
     return _eval_node(parsed.root, parsed, df)

--- a/tests/test_expr.mojo
+++ b/tests/test_expr.mojo
@@ -496,5 +496,97 @@ def test_eval_all_numeric_ops() raises:
     assert_true(ne._col._data[List[Bool]][2])
 
 
+def test_eval_and() raises:
+    # a > 1 and a < 4 → [F, T, T, F]
+    var pd = Python.import_module("pandas")
+    var df = DataFrame(pd.DataFrame(Python.evaluate("{'a': [1, 2, 3, 4]}")))
+    var mask = eval_expr(parse("a > 1 and a < 4"), df)
+    ref d = mask._col._data[List[Bool]]
+    assert_true(not d[0])
+    assert_true(d[1])
+    assert_true(d[2])
+    assert_true(not d[3])
+
+
+def test_eval_or() raises:
+    # a < 2 or a > 3 → [T, F, F, T]
+    var pd = Python.import_module("pandas")
+    var df = DataFrame(pd.DataFrame(Python.evaluate("{'a': [1, 2, 3, 4]}")))
+    var mask = eval_expr(parse("a < 2 or a > 3"), df)
+    ref d = mask._col._data[List[Bool]]
+    assert_true(d[0])
+    assert_true(not d[1])
+    assert_true(not d[2])
+    assert_true(d[3])
+
+
+def test_eval_not() raises:
+    # not a > 2 → [T, T, F]
+    var pd = Python.import_module("pandas")
+    var df = DataFrame(pd.DataFrame(Python.evaluate("{'a': [1, 2, 3]}")))
+    var mask = eval_expr(parse("not a > 2"), df)
+    ref d = mask._col._data[List[Bool]]
+    assert_true(d[0])
+    assert_true(d[1])
+    assert_true(not d[2])
+
+
+def test_eval_chained_and() raises:
+    # a > 0 and b > 0 with b = [4, 0, 5] → [T, F, T]
+    var pd = Python.import_module("pandas")
+    var df = DataFrame(pd.DataFrame(Python.evaluate("{'a': [1, 2, 3], 'b': [4, 0, 5]}")))
+    var mask = eval_expr(parse("a > 0 and b > 0"), df)
+    ref d = mask._col._data[List[Bool]]
+    assert_true(d[0])
+    assert_true(not d[1])
+    assert_true(d[2])
+
+
+def test_eval_mixed_parens() raises:
+    # a > 1 and (b > 5 or a > 2) with a=[1,2,3], b=[10,1,10]
+    # row 0: F and (T or F) = F and T = F
+    # row 1: T and (F or F) = T and F = F
+    # row 2: T and (T or T) = T and T = T
+    var pd = Python.import_module("pandas")
+    var df = DataFrame(pd.DataFrame(Python.evaluate("{'a': [1, 2, 3], 'b': [10, 1, 10]}")))
+    var mask = eval_expr(parse("a > 1 and (b > 5 or a > 2)"), df)
+    ref d = mask._col._data[List[Bool]]
+    assert_true(not d[0])
+    assert_true(not d[1])
+    assert_true(d[2])
+
+
+def test_eval_null_and() raises:
+    # a = [1.0, None, 3.0]; expr "a > 1 and a < 5"
+    # row 0: F and T = F (non-null)
+    # row 1: null and null = null
+    # row 2: T and T = T (non-null)
+    var pd = Python.import_module("pandas")
+    var df = DataFrame(pd.DataFrame(Python.evaluate("{'a': [1.0, None, 3.0]}")))
+    var mask = eval_expr(parse("a > 1 and a < 5"), df)
+    assert_true(len(mask._col._null_mask) > 0)
+    assert_true(not mask._col._null_mask[0])
+    assert_true(not mask._col._data[List[Bool]][0])
+    assert_true(mask._col._null_mask[1])
+    assert_true(not mask._col._null_mask[2])
+    assert_true(mask._col._data[List[Bool]][2])
+
+
+def test_eval_null_or() raises:
+    # a = [1.0, None, 6.0]; expr "a < 2 or a > 5"
+    # row 0: T or F = T (non-null)
+    # row 1: null or null = null
+    # row 2: F or T = T (non-null)
+    var pd = Python.import_module("pandas")
+    var df = DataFrame(pd.DataFrame(Python.evaluate("{'a': [1.0, None, 6.0]}")))
+    var mask = eval_expr(parse("a < 2 or a > 5"), df)
+    assert_true(len(mask._col._null_mask) > 0)
+    assert_true(not mask._col._null_mask[0])
+    assert_true(mask._col._data[List[Bool]][0])
+    assert_true(mask._col._null_mask[1])
+    assert_true(not mask._col._null_mask[2])
+    assert_true(mask._col._data[List[Bool]][2])
+
+
 def main() raises:
     TestSuite.discover_tests[__functions_in_module()]().run()


### PR DESCRIPTION
Closes #496
Parent tracker: #491

## Summary

Wire logical connective nodes (`NK_AND`, `NK_OR`, `NK_NOT`) in `_eval_node` by recursively evaluating child nodes and composing the resulting boolean `Series` masks via the already-implemented `Series.__and__`, `.__or__`, `.__invert__`. Kleene null semantics are fully delegated to the existing column kernel layer (`_bool_and`, `_bool_or`, `_bool_invert`) — no new null-handling logic was needed in the evaluator.

The parser, tokenizer, and `_ast.mojo` are unchanged; they already produce correct trees for all logical expressions including nested parenthetical groupings.

## Changes

- `bison/expr/_eval.mojo`: Replace three stub `elif` branches with recursive `_eval_node` calls and mask composition; update `eval_expr` docstring to remove the "connectives will raise" caveat.
- `tests/test_expr.mojo`: Add 7 new evaluator tests (AND, OR, NOT, chained AND, mixed parentheses, and two Kleene null cases). All 14 evaluator tests pass; full suite (20 test files, 65 unit tests) is green.

## Session Notes Needing Issues

### `_eval_node` uses sequential elif chain instead of structural dispatch

- **File**: `bison/expr/_eval.mojo` (lines 152–177)
- **Impact**: Low
- **Classification**: Replace Conditional with Polymorphism
- **Details**: The top-level `_eval_node` is a flat `if/elif` chain over `node.kind`. As more node kinds are added (arithmetic, in, between, etc.) this will grow. A visitor table or `match`-like dispatch would be more extensible.

### `_eval_compare` is a Bloater with duplicated column-resolve pattern

- **File**: `bison/expr/_eval.mojo` (lines ~103–150)
- **Impact**: Low
- **Classification**: Extract Method / Long Method (Bloaters)
- **Details**: The `lhs_is_ident/rhs_is_ident/lhs_is_numeric/...` bool variables plus the large `if/elif` cascade in `_eval_compare` could be simplified once literal-left cases are unified via `_flip_op`. Consider a small internal dispatcher that normalises to (column, op, literal) form first.

### `_eval_compare` null-handling gap: NK_NULL on either side silently errors

- **File**: `bison/expr/_eval.mojo`
- **Impact**: Medium
- **Classification**: Introduce Null Object / Consolidate Duplicate Conditional Fragments
- **Details**: `_eval_compare` checks for `NK_IDENT`, `NK_INT`, `NK_FLOAT`, and `NK_STRING` but has no branch for `NK_NULL` or `NK_BOOL`. An expression like `x == None` parses successfully but falls through to the "comparison must involve at least one column identifier" error at runtime. The fix is to add an `NK_NULL` arm that uses the column's null mask, and an `NK_BOOL` arm for boolean-typed columns.