### PR TITLE
feat: wire DataFrame.query to native parse+eval pipeline (#497)

### DIFF
--- a/benchmarks/bench_core.mojo
+++ b/benchmarks/bench_core.mojo
@@ -188,8 +188,7 @@ fn main() raises:
         )
 
     # ------------------------------------------------------------------
-    # query_filter  (boolean-mask equivalent; uses df.query since
-    #               df[bool_series] is not yet supported natively)
+    # query_filter  (native parse+eval+mask pipeline via df.query)
     # ------------------------------------------------------------------
     skipped = False
     try:

--- a/bison/_frame.mojo
+++ b/bison/_frame.mojo
@@ -32,6 +32,7 @@ from .column import (
 )
 from .accessors.str_accessor import StringMethods
 from .accessors.dt_accessor import DatetimeMethods
+from .expr import parse as _parse_expr, eval_expr as _eval_expr
 
 
 struct Series(Copyable, ImplicitlyCopyable, Movable):
@@ -3129,16 +3130,9 @@ struct DataFrame(Copyable, Movable):
         return Series.from_pandas(result)
 
     def query(self, expr: String) raises -> DataFrame:
-        var pd_df = self.to_pandas()
-        # Filter via module-level pd.eval() with explicit local_dict to avoid
-        # sys._getframe() failures when called from Mojo's shallow call stack.
-        var query_fn = Python.evaluate(
-            "lambda df, e: df.loc["
-            "__import__('pandas').eval("
-            "e, local_dict={c: df[c] for c in df.columns}, engine='python')]"
-        )
-        var result = query_fn(pd_df, expr)
-        return DataFrame.from_pandas(result)
+        var parsed = _parse_expr(expr)
+        var mask = _eval_expr(parsed, self)
+        return self[mask]
 
     def pipe(self, func: String) raises -> DataFrame:
         _not_implemented("DataFrame.pipe")

--- a/tests/test_expr.mojo
+++ b/tests/test_expr.mojo
@@ -588,5 +588,77 @@ def test_eval_null_or() raises:
     assert_true(mask._col._data[List[Bool]][2])
 
 
+# ------------------------------------------------------------------
+# DataFrame.query integration tests
+# ------------------------------------------------------------------
+
+
+def test_query_simple_numeric() raises:
+    """df.query("a > 0.5") filters rows natively; result matches direct bool-mask filter."""
+    var pd = Python.import_module("pandas")
+    var df = DataFrame(
+        pd.DataFrame(Python.evaluate("{'a': [0.1, 0.6, 0.9, 0.3], 'b': [1, 2, 3, 4]}"))
+    )
+    var result = df.query("a > 0.5")
+    # Rows at index 1 (0.6) and 2 (0.9) pass the filter.
+    assert_equal(result.shape()[0], 2)
+    assert_equal(result.shape()[1], 2)
+    var col_a = result["a"]
+    assert_true(col_a._col._data[List[Float64]][0] > 0.5)
+    assert_true(col_a._col._data[List[Float64]][1] > 0.5)
+
+
+def test_query_logical_and() raises:
+    """df.query("a > 1 and b < 4") applies compound logical filter natively."""
+    var pd = Python.import_module("pandas")
+    var df = DataFrame(
+        pd.DataFrame(Python.evaluate("{'a': [1, 2, 3, 4], 'b': [10, 3, 5, 2]}"))
+    )
+    var result = df.query("a > 1 and b < 4")
+    # Row 1: a=2 > 1 and b=3 < 4 → pass
+    # Row 3: a=4 > 1 and b=2 < 4 → pass
+    assert_equal(result.shape()[0], 2)
+
+
+def test_query_string_eq() raises:
+    """df.query("cat == 'foo'") filters on a string column natively."""
+    var pd = Python.import_module("pandas")
+    var df = DataFrame(
+        pd.DataFrame(
+            Python.evaluate("{'cat': ['foo', 'bar', 'foo'], 'val': [1, 2, 3]}")
+        )
+    )
+    var result = df.query("cat == 'foo'")
+    assert_equal(result.shape()[0], 2)
+
+
+def test_query_unknown_column_raises() raises:
+    """df.query referencing a missing column raises with 'unknown identifier'."""
+    var pd = Python.import_module("pandas")
+    var df = DataFrame(
+        pd.DataFrame(Python.evaluate("{'a': [1, 2, 3]}"))
+    )
+    var raised = False
+    try:
+        _ = df.query("z > 1")
+    except e:
+        raised = "unknown identifier" in String(e)
+    assert_true(raised)
+
+
+def test_query_unsupported_syntax_raises() raises:
+    """df.query with unsupported syntax (e.g. '+') raises with 'unsupported syntax'."""
+    var pd = Python.import_module("pandas")
+    var df = DataFrame(
+        pd.DataFrame(Python.evaluate("{'a': [1, 2, 3]}"))
+    )
+    var raised = False
+    try:
+        _ = df.query("a + 1 > 2")
+    except e:
+        raised = "unsupported syntax" in String(e)
+    assert_true(raised)
+
+
 def main() raises:
     TestSuite.discover_tests[__functions_in_module()]().run()


### PR DESCRIPTION
Closes #497
Part of #491

## Changes

Replace the pandas round-trip in `DataFrame.query` with the native evaluator pipeline built in #492–#496:

- `parse(expr)` tokenizes and builds a flat `ParsedExpr` arena
- `eval_expr(parsed, df)` walks the arena, producing a boolean `Series` mask
- `DataFrame.__getitem__(mask)` applies the mask to filter rows (already native)

Unsupported syntax (e.g. arithmetic operators) now raises immediately with a clear error instead of silently delegating to `pd.eval()`.

## Files changed

| File | What changed |
|------|-------------|
| `bison/_frame.mojo` | Added `from .expr import ...`; replaced 9-line pandas body of `query` with 3-line native call |
| `tests/test_expr.mojo` | Added 5 `test_query_*` integration tests (numeric, logical AND, string eq, unknown column error, unsupported syntax error) |
| `benchmarks/bench_core.mojo` | Fixed stale comment — `query_filter` now uses native path |

## Verification

- All 88 tests pass (`pixi run test`)
- Zero compiler warnings (`pixi run check`)
- Compat table updated (`pixi run update-compat`) — `query` is no longer counted as a stub

## Session Notes Needing Issues

### DataFrame.eval still delegates to pandas via to_pandas() round-trip

- **File**: `bison/_frame.mojo` (line ~3121)
- **Impact**: High
- **Classification**: Couplers — Inappropriate Intimacy
- **Details**: `DataFrame.eval` round-trips through `to_pandas()` / `pd.eval()` / `from_pandas()` exactly as `query` did before #497. Now that the native parse+eval pipeline exists (`bison/expr/`), `eval` should be wired to it. The evaluator returns a `Series` directly, matching `eval`'s return type. Tracked under #491 milestone.

### query_filter benchmark uses SLOW_ITERS after query became native

- **File**: `benchmarks/bench_core.mojo` (line ~191)
- **Impact**: Medium
- **Classification**: Dispensables — Dead Code (stale configuration)
- **Details**: `SLOW_ITERS=3` was chosen because `query` paid a ~300 ms pandas round-trip per call. Now that `query` is native, `SLOW_ITERS` produces a very short total measurement window and the ratio may be noisy. Should be raised to `MED_ITERS` or `FAST_ITERS` for more statistically stable benchmark results.