### PR TITLE
fix: use length-prefixed encoding in composite row-key serialization (#506)

### DIFF
--- a/bison/_frame.mojo
+++ b/bison/_frame.mojo
@@ -5311,23 +5311,35 @@ struct DataFrame(Copyable, Movable):
 
         *col_idx* must be a pre-built name→column-index map for *df* so that
         each key lookup is O(1) rather than O(n_cols).
+
+        For multi-column keys, uses length-prefixed encoding (``len:value``)
+        for each component so that values containing arbitrary characters
+        never cause collisions.  For example, (``"a|b"``, ``"c"``) encodes
+        as ``"3:a|b1:c"`` while (``"a"``, ``"b|c"``) encodes as
+        ``"1:a3:b|c"`` — always distinct.
+
+        Single-column keys return the raw stringified value (no encoding
+        needed since there is no inter-column delimiter to collide with).
         """
+        var n_keys = len(key_cols)
         var key = String()
-        for k in range(len(key_cols)):
-            if k > 0:
-                key += "|"
+        for k in range(n_keys):
             var i = col_idx[key_cols[k]]
             ref col_data = df._cols[i]._data
+            var part: String
             if col_data.isa[List[Int64]]():
-                key += String(Int(col_data[List[Int64]][row]))
+                part = String(Int(col_data[List[Int64]][row]))
             elif col_data.isa[List[Float64]]():
-                key += String(col_data[List[Float64]][row])
+                part = String(col_data[List[Float64]][row])
             elif col_data.isa[List[Bool]]():
-                key += "1" if col_data[List[Bool]][row] else "0"
+                part = "1" if col_data[List[Bool]][row] else "0"
             elif col_data.isa[List[String]]():
-                key += col_data[List[String]][row]
+                part = col_data[List[String]][row]
             else:
-                key += String(col_data[List[PythonObject]][row])
+                part = String(col_data[List[PythonObject]][row])
+            if n_keys == 1:
+                return part
+            key += String(len(part)) + ":" + part
         return key
 
     def merge(

--- a/tests/test_combining.mojo
+++ b/tests/test_combining.mojo
@@ -264,5 +264,67 @@ def test_merge_right_key_col_right_only_rows() raises:
     assert_equal(Int(py=key_col_pd.iloc[1]), 3)
 
 
+# ------------------------------------------------------------------
+# Composite key delimiter collision tests (issue #506)
+# ------------------------------------------------------------------
+
+
+def test_merge_multikey_delimiter_collision() raises:
+    """Multi-key merge where string values contain the pipe delimiter.
+
+    Without collision-safe serialisation, ("a|b", "c") and ("a", "b|c")
+    both serialise to "a|b|c", producing incorrect join matches.
+    """
+    var pd = Python.import_module("pandas")
+    var left = DataFrame(
+        pd.DataFrame(
+            Python.evaluate(
+                "{'k1': ['a|b', 'a'], 'k2': ['c', 'b|c'], 'val': [1, 2]}"
+            )
+        )
+    )
+    var right = DataFrame(
+        pd.DataFrame(
+            Python.evaluate(
+                "{'k1': ['a|b', 'a'], 'k2': ['c', 'b|c'], 'score': [100, 200]}"
+            )
+        )
+    )
+    var on = List[String]()
+    on.append("k1")
+    on.append("k2")
+    var result = right.merge(left, on=on^)
+    # Each row should match exactly once: 2 result rows, not 4.
+    assert_equal(result.shape()[0], 2)
+    var result_pd = result.to_pandas()
+    # Verify row 0 matched ("a|b", "c") → score=100, val=1
+    assert_equal(Int(py=result_pd["score"].iloc[0]), 100)
+    assert_equal(Int(py=result_pd["val"].iloc[0]), 1)
+    # Verify row 1 matched ("a", "b|c") → score=200, val=2
+    assert_equal(Int(py=result_pd["score"].iloc[1]), 200)
+    assert_equal(Int(py=result_pd["val"].iloc[1]), 2)
+
+
+def test_merge_multikey_delimiter_no_false_match() raises:
+    """Keys that would collide under naive pipe-joining must NOT match."""
+    var pd = Python.import_module("pandas")
+    var left = DataFrame(
+        pd.DataFrame(
+            Python.evaluate("{'k1': ['a|b'], 'k2': ['c'], 'val': [1]}")
+        )
+    )
+    var right = DataFrame(
+        pd.DataFrame(
+            Python.evaluate("{'k1': ['a'], 'k2': ['b|c'], 'score': [99]}")
+        )
+    )
+    var on = List[String]()
+    on.append("k1")
+    on.append("k2")
+    var result = left.merge(right, on=on^)
+    # Inner join: no keys actually match, so result must be empty.
+    assert_equal(result.shape()[0], 0)
+
+
 def main() raises:
     TestSuite.discover_tests[__functions_in_module()]().run()

--- a/tests/test_groupby.mojo
+++ b/tests/test_groupby.mojo
@@ -1,6 +1,6 @@
 """Tests for DataFrame.groupby(), DataFrameGroupBy, and SeriesGroupBy."""
 from std.python import Python, PythonObject
-from std.testing import TestSuite
+from std.testing import assert_equal, TestSuite
 from bison import DataFrame, Series
 from _helpers import assert_frame_equal, assert_series_equal
 
@@ -720,6 +720,55 @@ def test_dataframegroupby_multikey_as_index_false_sum() raises:
         ).sum(),
         check_dtype=False,
     )
+
+
+# ------------------------------------------------------------------
+# Composite key delimiter collision tests (issue #506)
+# ------------------------------------------------------------------
+
+
+def test_groupby_multikey_delimiter_in_value() raises:
+    """Groupby with two string key columns where values contain the pipe
+    delimiter must produce the same number of groups as pandas.
+
+    Without collision-safe serialisation, ("a|b", "c") and ("a", "b|c")
+    both serialise to "a|b|c" and get merged into one group.
+    """
+    var pd = Python.import_module("pandas")
+    var pd_df = pd.DataFrame(
+        Python.evaluate(
+            "{'k1': ['a|b', 'a'], 'k2': ['c', 'b|c'], 'val': [10, 20]}"
+        )
+    )
+    var df = DataFrame(pd_df)
+    var by = List[String]()
+    by.append("k1")
+    by.append("k2")
+    var result = df.groupby(by).sum()
+    # pandas sees two distinct groups: ("a|b", "c") and ("a", "b|c")
+    assert_equal(result.shape()[0], 2)
+    var result_pd = result.to_pandas()
+    var expected = pd_df.groupby(Python.evaluate("['k1', 'k2']")).sum()
+    assert_frame_equal(result_pd, expected)
+
+
+def test_groupby_multikey_delimiter_only_values() raises:
+    """Edge case: key values that are exactly the delimiter character."""
+    var pd = Python.import_module("pandas")
+    var pd_df = pd.DataFrame(
+        Python.evaluate(
+            "{'k1': ['|', 'a'], 'k2': ['a', '|'], 'val': [1, 2]}"
+        )
+    )
+    var df = DataFrame(pd_df)
+    var by = List[String]()
+    by.append("k1")
+    by.append("k2")
+    var result = df.groupby(by).sum()
+    assert_equal(result.shape()[0], 2)
+    var result_pd = result.to_pandas()
+    var expected = pd_df.groupby(Python.evaluate("['k1', 'k2']")).sum()
+    assert_frame_equal(result_pd, expected)
 
 
 def main() raises:


### PR DESCRIPTION
`_row_key_str` previously joined multi-column key values with a bare `|`
delimiter, so distinct tuples like ("a|b", "c") and ("a", "b|c") would
both serialize to "a|b|c" and collide. This caused incorrect groupby,
merge, and pivot results when string key values contained the delimiter.

For multi-column keys, each component is now length-prefixed
(`len:value`), guaranteeing collision-free serialization regardless of
value content. Single-column keys return the raw value (no encoding
needed, preserves existing behavior for index labels).

Closes #506

https://claude.ai/code/session_01Lc5AdWD8CZyWrDCbXy69WL