### PR TITLE
feat(#630): migrate List[Bool] NullMask bridge callers to native API

### DIFF
--- a/bison/_frame.mojo
+++ b/bison/_frame.mojo
@@ -658,7 +658,7 @@ struct Series(Copyable, ImplicitlyCopyable, Movable):
                 keep.append(i)
         var result_col = self._col.take(keep)
         # All kept elements are non-null; clear the mask.
-        result_col._null_mask = List[Bool]()
+        result_col._null_mask = NullMask()
         result_col._try_activate_storage()
         return Series(result_col^)
 
@@ -792,17 +792,18 @@ struct Series(Copyable, ImplicitlyCopyable, Movable):
         # Build Float64 result: NaN wherever the sort permutation points to a
         # null element in the original (those positions are at the tail of perm).
         var result_data = List[Float64]()
-        var result_mask = List[Bool]()
+        var result_mask = NullMask()
         for i in range(n):
             var orig_pos = perm[i]
             if self._col._null_mask.is_null(orig_pos):
                 result_data.append(Float64(0))
-                result_mask.append(True)
+                result_mask.append_null()
             else:
                 result_data.append(Float64(perm[i]))
-                result_mask.append(False)
+                result_mask.append_valid()
         var col = Column(self._col.name, result_data^, float64, idx^)
-        col._null_mask = result_mask^
+        if result_mask.has_nulls():
+            col._null_mask = result_mask^
         col._try_activate_storage()
         return Series(col^)
 
@@ -823,13 +824,12 @@ struct Series(Copyable, ImplicitlyCopyable, Movable):
                     n_non_null += 1
         # Prepare Float64 result; null slots are marked in rank_mask.
         var ranks = List[Float64]()
-        var rank_mask = List[Bool]()
+        var rank_mask = NullMask.all_valid(n)
         for _ in range(n):
             ranks.append(Float64(0))
-            rank_mask.append(False)
         if has_mask:
             for i in range(n_non_null, n):
-                rank_mask[perm[i]] = True
+                rank_mask.set_null(perm[i])
         # Assign average ranks for each tied group (type-dispatch via visitor).
         # avg = ((i+1) + (j+1)) / 2 where i..j is the 0-based sorted range.
         var rank_visitor = _RankVisitor(perm, n_non_null, ranks)
@@ -1308,7 +1308,7 @@ struct DataFrame(Copyable, Movable):
 
         for ci in range(len(col_names)):
             var col_name = col_names[ci]
-            var null_mask = List[Bool]()
+            var null_mask = NullMask()
 
             # Scan ALL rows to determine dominant column dtype.
             # Promotion order matches pandas/NumPy type coercion rules:
@@ -1341,7 +1341,7 @@ struct DataFrame(Copyable, Movable):
                 var py_none = Python.evaluate("None")
                 for _ in range(len(records)):
                     data.append(py_none)
-                    null_mask.append(True)
+                    null_mask.append_null()
                 var col = Column(col_name, data^, object_)
                 col._null_mask = null_mask^
                 col._try_activate_storage()
@@ -1352,26 +1352,31 @@ struct DataFrame(Copyable, Movable):
                 # String dominates: convert all non-null values to String
                 var data = List[String]()
                 for ri in range(len(records)):
+                    var row_null = True
                     try:
                         var v = records[ri][col_name]
                         if v.is_null():
                             data.append(String(""))
-                            null_mask.append(True)
-                            continue
-                        var val: String
-                        if v.isa[String]():
-                            val = v[String]
-                        elif v.isa[Int64]():
-                            val = String(Int(v[Int64]))
-                        elif v.isa[Float64]():
-                            val = String(v[Float64])
-                        else:  # Bool
-                            val = String("True") if v[Bool] else String("False")
-                        data.append(val)
-                        null_mask.append(False)
+                        else:
+                            var val: String
+                            if v.isa[String]():
+                                val = v[String]
+                            elif v.isa[Int64]():
+                                val = String(Int(v[Int64]))
+                            elif v.isa[Float64]():
+                                val = String(v[Float64])
+                            else:  # Bool
+                                val = String("True") if v[Bool] else String(
+                                    "False"
+                                )
+                            data.append(val)
+                            row_null = False
                     except:
                         data.append(String(""))
-                        null_mask.append(True)
+                    if row_null:
+                        null_mask.append_null()
+                    else:
+                        null_mask.append_valid()
                 var col = Column(col_name, data^, object_)
                 col._null_mask = null_mask^
                 col._try_activate_storage()
@@ -1380,24 +1385,27 @@ struct DataFrame(Copyable, Movable):
                 # Float64 dominates Int64 and Bool
                 var data = List[Float64]()
                 for ri in range(len(records)):
+                    var row_null = True
                     try:
                         var v = records[ri][col_name]
                         if v.is_null():
                             data.append(Float64(0.0))
-                            null_mask.append(True)
-                            continue
-                        var val: Float64
-                        if v.isa[Float64]():
-                            val = v[Float64]
-                        elif v.isa[Int64]():
-                            val = Float64(v[Int64])
-                        else:  # Bool
-                            val = Float64(1) if v[Bool] else Float64(0)
-                        data.append(val)
-                        null_mask.append(False)
+                        else:
+                            var val: Float64
+                            if v.isa[Float64]():
+                                val = v[Float64]
+                            elif v.isa[Int64]():
+                                val = Float64(v[Int64])
+                            else:  # Bool
+                                val = Float64(1) if v[Bool] else Float64(0)
+                            data.append(val)
+                            row_null = False
                     except:
                         data.append(Float64(0.0))
-                        null_mask.append(True)
+                    if row_null:
+                        null_mask.append_null()
+                    else:
+                        null_mask.append_valid()
                 var col = Column(col_name, data^, float64)
                 col._null_mask = null_mask^
                 col._try_activate_storage()
@@ -1405,27 +1413,27 @@ struct DataFrame(Copyable, Movable):
             elif has_int:
                 # Int64 (Bool values are promoted to Int64)
                 var data = List[Int64]()
-                var has_nulls = False
                 for ri in range(len(records)):
+                    var row_null = True
                     try:
                         var v = records[ri][col_name]
                         if v.is_null():
                             data.append(Int64(0))
-                            null_mask.append(True)
-                            has_nulls = True
-                            continue
-                        var val: Int64
-                        if v.isa[Int64]():
-                            val = v[Int64]
-                        else:  # Bool
-                            val = Int64(1) if v[Bool] else Int64(0)
-                        data.append(val)
-                        null_mask.append(False)
+                        else:
+                            var val: Int64
+                            if v.isa[Int64]():
+                                val = v[Int64]
+                            else:  # Bool
+                                val = Int64(1) if v[Bool] else Int64(0)
+                            data.append(val)
+                            row_null = False
                     except:
                         data.append(Int64(0))
-                        null_mask.append(True)
-                        has_nulls = True
-                if has_nulls:
+                    if row_null:
+                        null_mask.append_null()
+                    else:
+                        null_mask.append_valid()
+                if null_mask.has_nulls():
                     # Promote to float64 so NaN can be represented (mirrors pandas behavior)
                     var fdata = List[Float64]()
                     for i in range(len(data)):
@@ -1441,27 +1449,27 @@ struct DataFrame(Copyable, Movable):
                 cols.append(col^)
             else:  # Bool only
                 var data = List[Bool]()
-                var has_nulls = False
                 for ri in range(len(records)):
+                    var row_null = True
                     try:
                         var v = records[ri][col_name]
                         if v.is_null():
                             data.append(False)
-                            null_mask.append(True)
-                            has_nulls = True
-                            continue
-                        data.append(v[Bool])
-                        null_mask.append(False)
+                        else:
+                            data.append(v[Bool])
+                            row_null = False
                     except:
                         data.append(False)
-                        null_mask.append(True)
-                        has_nulls = True
-                if has_nulls:
+                    if row_null:
+                        null_mask.append_null()
+                    else:
+                        null_mask.append_valid()
+                if null_mask.has_nulls():
                     # Promote to object so None can be represented (mirrors pandas behavior)
                     var py_none = Python.evaluate("None")
                     var odata = List[PythonObject]()
                     for i in range(len(data)):
-                        if null_mask[i]:
+                        if null_mask.is_null(i):
                             odata.append(py_none)
                         else:
                             odata.append(PythonObject(data[i]))
@@ -1670,7 +1678,7 @@ struct DataFrame(Copyable, Movable):
             return default
         return None
 
-    def head(self, n: Int = 5) -> DataFrame:
+    def head(self, n: Int = 5) raises -> DataFrame:
         var nrows = self.shape()[0]
         var take = n
         if take > nrows:
@@ -1680,7 +1688,7 @@ struct DataFrame(Copyable, Movable):
             result_cols.append(self._cols[i].slice(0, take))
         return DataFrame(result_cols^)
 
-    def tail(self, n: Int = 5) -> DataFrame:
+    def tail(self, n: Int = 5) raises -> DataFrame:
         var nrows = self.shape()[0]
         var take = n
         if take > nrows:
@@ -2552,13 +2560,11 @@ struct DataFrame(Copyable, Movable):
             for j in range(ncols):
                 var src_j = j - periods
                 var values = List[Float64]()
-                var null_mask = List[Bool]()
-                var has_null = False
+                var null_mask = NullMask()
                 if src_j < 0 or src_j >= ncols:
                     for _ in range(nrows):
                         values.append(nan)
-                        null_mask.append(True)
-                    has_null = True
+                        null_mask.append_null()
                 else:
                     ref src_col = self._cols[src_j]
                     if not (
@@ -2571,16 +2577,15 @@ struct DataFrame(Copyable, Movable):
                         var is_null = src_col._null_mask.is_null(i)
                         if is_null:
                             values.append(nan)
-                            null_mask.append(True)
-                            has_null = True
+                            null_mask.append_null()
                         elif src_col.dtype.is_integer():
                             values.append(Float64(src_col._int64_data()[i]))
-                            null_mask.append(False)
+                            null_mask.append_valid()
                         else:
                             values.append(src_col._float64_data()[i])
-                            null_mask.append(False)
+                            null_mask.append_valid()
                 var col = Column(self._cols[j].name, values^, float64)
-                if has_null:
+                if null_mask.has_nulls():
                     col._null_mask = null_mask^
                     col._try_activate_storage()
                 result_cols.append(col^)
@@ -2611,13 +2616,11 @@ struct DataFrame(Copyable, Movable):
             for j in range(ncols):
                 var src_j = j - periods
                 var values = List[Float64]()
-                var null_mask = List[Bool]()
-                var has_null = False
+                var null_mask = NullMask()
                 if src_j < 0 or src_j >= ncols:
                     for _ in range(nrows):
                         values.append(nan)
-                        null_mask.append(True)
-                    has_null = True
+                        null_mask.append_null()
                 else:
                     ref cur_col = self._cols[j]
                     ref src_col = self._cols[src_j]
@@ -2638,8 +2641,7 @@ struct DataFrame(Copyable, Movable):
                         var src_null = src_col._null_mask.is_null(i)
                         if cur_null or src_null:
                             values.append(nan)
-                            null_mask.append(True)
-                            has_null = True
+                            null_mask.append_null()
                         else:
                             var cur_val: Float64
                             if cur_col.dtype.is_integer():
@@ -2652,9 +2654,9 @@ struct DataFrame(Copyable, Movable):
                             else:
                                 src_val = src_col._float64_data()[i]
                             values.append(cur_val - src_val)
-                            null_mask.append(False)
+                            null_mask.append_valid()
                 var col = Column(self._cols[j].name, values^, float64)
-                if has_null:
+                if null_mask.has_nulls():
                     col._null_mask = null_mask^
                     col._try_activate_storage()
                 result_cols.append(col^)
@@ -2686,13 +2688,11 @@ struct DataFrame(Copyable, Movable):
             for j in range(ncols):
                 var src_j = j - periods
                 var values = List[Float64]()
-                var null_mask = List[Bool]()
-                var has_null = False
+                var null_mask = NullMask()
                 if src_j < 0 or src_j >= ncols:
                     for _ in range(nrows):
                         values.append(nan)
-                        null_mask.append(True)
-                    has_null = True
+                        null_mask.append_null()
                 else:
                     ref cur_col = self._cols[j]
                     ref src_col = self._cols[src_j]
@@ -2715,8 +2715,7 @@ struct DataFrame(Copyable, Movable):
                         var src_null = src_col._null_mask.is_null(i)
                         if cur_null or src_null:
                             values.append(nan)
-                            null_mask.append(True)
-                            has_null = True
+                            null_mask.append_null()
                         else:
                             var cur_val: Float64
                             if cur_col.dtype.is_integer():
@@ -2729,9 +2728,9 @@ struct DataFrame(Copyable, Movable):
                             else:
                                 src_val = src_col._float64_data()[i]
                             values.append((cur_val - src_val) / src_val)
-                            null_mask.append(False)
+                            null_mask.append_valid()
                 var col = Column(self._cols[j].name, values^, float64)
-                if has_null:
+                if null_mask.has_nulls():
                     col._null_mask = null_mask^
                     col._try_activate_storage()
                 result_cols.append(col^)
@@ -3966,20 +3965,18 @@ struct DataFrame(Copyable, Movable):
         var result_cols = List[Column]()
         for ck in range(n_ck):
             var data = List[PythonObject]()
-            var null_mask = List[Bool]()
-            var any_null = False
+            var null_mask = NullMask()
             for rk in range(n_rk):
                 var cell = rk * n_ck + ck
                 if not filled[cell]:
                     data.append(py_none)
-                    null_mask.append(True)
-                    any_null = True
+                    null_mask.append_null()
                 else:
                     data.append(table[cell])
-                    null_mask.append(False)
+                    null_mask.append_valid()
             var col = Column(col_keys[ck], data^, object_)
             col._index = result_idx.copy()
-            if any_null:
+            if null_mask.has_nulls():
                 col._null_mask = null_mask^
                 col._try_activate_storage()
             result_cols.append(col^)
@@ -4211,19 +4208,17 @@ struct DataFrame(Copyable, Movable):
 
         for out_i in range(n_out):
             var data = List[PythonObject]()
-            var null_mask = List[Bool]()
-            var any_null = False
+            var null_mask = NullMask()
             for rk in range(n_rk):
                 if aggfunc == "count":
                     data.append(PythonObject(Int(counts[rk][out_i])))
-                    null_mask.append(False)
+                    null_mask.append_valid()
                     continue
                 if counts[rk][out_i] == 0:
                     data.append(py_none)
-                    null_mask.append(True)
-                    any_null = True
+                    null_mask.append_null()
                     continue
-                null_mask.append(False)
+                null_mask.append_valid()
                 if aggfunc == "sum":
                     data.append(PythonObject(sums[rk][out_i]))
                 else:
@@ -4234,7 +4229,7 @@ struct DataFrame(Copyable, Movable):
                     )
             var col = Column(out_names[out_i], data^, object_)
             col._index = result_idx.copy()
-            if any_null:
+            if null_mask.has_nulls():
                 col._null_mask = null_mask^
                 col._try_activate_storage()
             result_cols.append(col^)
@@ -4309,8 +4304,7 @@ struct DataFrame(Copyable, Movable):
 
         # Value column: concat all value columns row-by-row.
         var val_data = List[PythonObject]()
-        var val_null_mask = List[Bool]()
-        var any_null = False
+        var val_null_mask = NullMask()
         for v in range(n_val):
             var val_ci = -1
             for j in range(len(self._cols)):
@@ -4326,13 +4320,12 @@ struct DataFrame(Copyable, Movable):
                 var is_null = vcol._null_mask.is_null(r)
                 if is_null:
                     val_data.append(py_none)
-                    val_null_mask.append(True)
-                    any_null = True
+                    val_null_mask.append_null()
                 else:
-                    val_null_mask.append(False)
+                    val_null_mask.append_valid()
                     val_data.append(_frame_cell_as_python(vcol, r))
         var val_col = Column(value_name, val_data^, object_)
-        if any_null:
+        if val_null_mask.has_nulls():
             val_col._null_mask = val_null_mask^
             val_col._try_activate_storage()
         result_cols.append(val_col^)
@@ -4355,9 +4348,8 @@ struct DataFrame(Copyable, Movable):
         var py_none = Python.evaluate("None")
 
         var val_data = List[PythonObject]()
-        var null_mask = List[Bool]()
+        var null_mask = NullMask()
         var idx_objs = List[PythonObject]()
-        var any_null = False
 
         for r in range(nrows):
             # Determine row label.
@@ -4376,14 +4368,13 @@ struct DataFrame(Copyable, Movable):
                 idx_objs.append(tup)
                 if is_null:
                     val_data.append(py_none)
-                    null_mask.append(True)
-                    any_null = True
+                    null_mask.append_null()
                 else:
-                    null_mask.append(False)
+                    null_mask.append_valid()
                     val_data.append(_frame_cell_as_python(col, r))
 
         var result_col = Column("", val_data^, object_, ColumnIndex(idx_objs^))
-        if any_null:
+        if null_mask.has_nulls():
             result_col._null_mask = null_mask^
             result_col._try_activate_storage()
         return Series(result_col^)
@@ -4509,16 +4500,14 @@ struct DataFrame(Copyable, Movable):
                     out_name = String(py.tuple(pair_items))
 
                 var data = List[PythonObject]()
-                var null_mask = List[Bool]()
-                var any_null = False
+                var null_mask = NullMask()
                 for rk in range(n_rk):
                     if not filled[rk][out]:
                         data.append(py_none)
-                        null_mask.append(True)
-                        any_null = True
+                        null_mask.append_null()
                     else:
                         data.append(table[rk][out])
-                        null_mask.append(False)
+                        null_mask.append_valid()
 
                 var col = Column(out_name, data^, object_)
                 col._index = result_idx.copy()
@@ -4528,7 +4517,7 @@ struct DataFrame(Copyable, Movable):
                 elif len(rem_idx_names) == 1:
                     col._index_names = List[String]()
                     col._index_name = rem_idx_names[0]
-                if any_null:
+                if null_mask.has_nulls():
                     col._null_mask = null_mask^
                     col._try_activate_storage()
                 result_cols.append(col^)
@@ -4556,9 +4545,8 @@ struct DataFrame(Copyable, Movable):
         var py_none = Python.evaluate("None")
 
         var val_data = List[PythonObject]()
-        var null_mask = List[Bool]()
+        var null_mask = NullMask()
         var idx_objs = List[PythonObject]()
-        var any_null = False
 
         for j in range(ncols):
             ref col = self._cols[j]
@@ -4576,14 +4564,13 @@ struct DataFrame(Copyable, Movable):
                 idx_objs.append(py.tuple(tup_items))
                 if is_null:
                     val_data.append(py_none)
-                    null_mask.append(True)
-                    any_null = True
+                    null_mask.append_null()
                 else:
-                    null_mask.append(False)
+                    null_mask.append_valid()
                     val_data.append(_frame_cell_as_python(col, r))
 
         var result_col = Column("", val_data^, object_, ColumnIndex(idx_objs^))
-        if any_null:
+        if null_mask.has_nulls():
             result_col._null_mask = null_mask^
             result_col._try_activate_storage()
         return Series(result_col^)
@@ -4619,22 +4606,20 @@ struct DataFrame(Copyable, Movable):
                 col_name = String(r)
 
             var data = List[PythonObject]()
-            var null_mask = List[Bool]()
-            var any_null = False
+            var null_mask = NullMask()
             for j in range(ncols):
                 ref col = self._cols[j]
                 var is_null = col._null_mask.is_null(r)
                 if is_null:
                     data.append(py_none)
-                    null_mask.append(True)
-                    any_null = True
+                    null_mask.append_null()
                 else:
-                    null_mask.append(False)
+                    null_mask.append_valid()
                     data.append(_frame_cell_as_python(col, r))
 
             var new_col = Column(col_name, data^, object_)
             new_col._index = shared_idx.copy()
-            if any_null:
+            if null_mask.has_nulls():
                 new_col._null_mask = null_mask^
                 new_col._try_activate_storage()
             result_cols.append(new_col^)
@@ -4770,27 +4755,25 @@ struct DataFrame(Copyable, Movable):
             if j == col_ci:
                 # The explode column: pull individual elements for list rows.
                 var data = List[PythonObject]()
-                var null_mask = List[Bool]()
-                var any_null = False
+                var null_mask = NullMask()
                 for k in range(n_out):
                     var r = src_indices[k]
                     var sub = sub_indices[k]
                     var is_null = exp_col._null_mask.is_null(r)
                     if is_null:
                         data.append(py_none)
-                        null_mask.append(True)
-                        any_null = True
+                        null_mask.append_null()
                     elif sub == -1:
                         # Scalar: keep value as-is.
                         data.append(_frame_cell_as_python(exp_col, r))
-                        null_mask.append(False)
+                        null_mask.append_valid()
                     else:
                         # List element.
                         var cell = exp_col._data[List[PythonObject]][r]
                         data.append(cell[sub])
-                        null_mask.append(False)
+                        null_mask.append_valid()
                 var new_col = Column(column, data^, object_)
-                if any_null:
+                if null_mask.has_nulls():
                     new_col._null_mask = null_mask^
                     new_col._try_activate_storage()
                 result_cols.append(new_col^)
@@ -6641,21 +6624,19 @@ struct DataFrameGroupBy:
             if is_count or (orig_is_int and agg != "mean"):
                 # int64 result: count always int64; sum/min/max of int -> int64.
                 var vals = List[Int64]()
-                var null_mask = List[Bool]()
-                var has_null = False
+                var null_mask = NullMask()
                 for i in range(n_keep):
                     var ri = keep[i]
                     if not rb_col.is_valid(ri):
                         vals.append(Int64(0))
-                        null_mask.append(True)
-                        has_null = True
+                        null_mask.append_null()
                     elif is_count:
                         vals.append(
                             rebind[Int64](
                                 rb_col.as_primitive[_m_int64]().unsafe_get(ri)
                             )
                         )
-                        null_mask.append(False)
+                        null_mask.append_valid()
                     else:
                         # sum/min/max of integer col: marrow stores as float64.
                         vals.append(
@@ -6667,34 +6648,32 @@ struct DataFrameGroupBy:
                                 )
                             )
                         )
-                        null_mask.append(False)
+                        null_mask.append_valid()
                 var col = Column(value_names[v], vals^, int64, idx.copy())
                 col._index_name = key_col_name
-                if has_null:
+                if null_mask.has_nulls():
                     col._null_mask = null_mask^
                     col._try_activate_storage()
                 result_cols.append(col^)
             else:
                 # float64 result: mean, or float col sum/min/max.
                 var vals = List[Float64]()
-                var null_mask = List[Bool]()
-                var has_null = False
+                var null_mask = NullMask()
                 for i in range(n_keep):
                     var ri = keep[i]
                     if not rb_col.is_valid(ri):
                         vals.append(Float64(0))
-                        null_mask.append(True)
-                        has_null = True
+                        null_mask.append_null()
                     else:
                         vals.append(
                             rebind[Float64](
                                 rb_col.as_primitive[_m_float64]().unsafe_get(ri)
                             )
                         )
-                        null_mask.append(False)
+                        null_mask.append_valid()
                 var col = Column(value_names[v], vals^, float64, idx.copy())
                 col._index_name = key_col_name
-                if has_null:
+                if null_mask.has_nulls():
                     col._null_mask = null_mask^
                     col._try_activate_storage()
                 result_cols.append(col^)
@@ -7115,19 +7094,17 @@ struct DataFrameGroupBy:
                 # No else needed: first/last are handled in the separate branch above.
             var nan = Float64(0) / Float64(0)
             var vals = List[Float64]()
-            var null_mask = List[Bool]()
-            var any_null = False
+            var null_mask = NullMask()
             for r in range(n_rows):
                 if row_key[r] != "":
                     vals.append(key_to_val[row_key[r]])
-                    null_mask.append(False)
+                    null_mask.append_valid()
                 else:
                     # Row was excluded by dropna — emit NaN.
                     vals.append(nan)
-                    null_mask.append(True)
-                    any_null = True
+                    null_mask.append_null()
             var result_col = Column(col.name, vals^, float64)
-            if any_null:
+            if null_mask.has_nulls():
                 result_col._null_mask = null_mask^
                 result_col._try_activate_storage()
             result_cols.append(result_col^)
@@ -7302,21 +7279,19 @@ struct SeriesGroupBy:
 
         if is_count or (orig_is_int and agg != "mean"):
             var vals = List[Int64]()
-            var null_mask = List[Bool]()
-            var has_null = False
+            var null_mask = NullMask()
             for i in range(n_keep):
                 var ri = keep[i]
                 if not rb_col.is_valid(ri):
                     vals.append(Int64(0))
-                    null_mask.append(True)
-                    has_null = True
+                    null_mask.append_null()
                 elif is_count:
                     vals.append(
                         rebind[Int64](
                             rb_col.as_primitive[_m_int64]().unsafe_get(ri)
                         )
                     )
-                    null_mask.append(False)
+                    null_mask.append_valid()
                 else:
                     vals.append(
                         Int64(
@@ -7325,31 +7300,29 @@ struct SeriesGroupBy:
                             )
                         )
                     )
-                    null_mask.append(False)
+                    null_mask.append_valid()
             var col = Column(self._series.name, vals^, int64, idx^)
-            if has_null:
+            if null_mask.has_nulls():
                 col._null_mask = null_mask^
                 col._try_activate_storage()
             return Series(col^)
         else:
             var vals = List[Float64]()
-            var null_mask = List[Bool]()
-            var has_null = False
+            var null_mask = NullMask()
             for i in range(n_keep):
                 var ri = keep[i]
                 if not rb_col.is_valid(ri):
                     vals.append(Float64(0))
-                    null_mask.append(True)
-                    has_null = True
+                    null_mask.append_null()
                 else:
                     vals.append(
                         rebind[Float64](
                             rb_col.as_primitive[_m_float64]().unsafe_get(ri)
                         )
                     )
-                    null_mask.append(False)
+                    null_mask.append_valid()
             var col = Column(self._series.name, vals^, float64, idx^)
-            if has_null:
+            if null_mask.has_nulls():
                 col._null_mask = null_mask^
                 col._try_activate_storage()
             return Series(col^)
@@ -7604,18 +7577,16 @@ struct SeriesGroupBy:
                 elif func == "var":
                     key_to_agg[key] = sub.var()
             var result_vals = List[Float64]()
-            var null_mask = List[Bool]()
-            var any_null = False
+            var null_mask = NullMask()
             for i in range(n):
                 if self._by_null_mask.is_null(i) and self._dropna:
                     result_vals.append(nan)
-                    null_mask.append(True)
-                    any_null = True
+                    null_mask.append_null()
                 else:
                     result_vals.append(key_to_agg[row_key[i]])
-                    null_mask.append(False)
+                    null_mask.append_valid()
             var result_col = Column(self._series.name, result_vals^, float64)
-            if any_null:
+            if null_mask.has_nulls():
                 result_col._null_mask = null_mask^
                 result_col._try_activate_storage()
             result_col._index = self._series._col._index.copy()
@@ -7633,14 +7604,14 @@ struct SeriesGroupBy:
                     key_to_agg[key] = Int64(len(self._group_map[key]))
             if any_excluded_row:
                 var result_vals = List[Float64]()
-                var null_mask = List[Bool]()
+                var null_mask = NullMask()
                 for i in range(n):
                     if self._by_null_mask.is_null(i) and self._dropna:
                         result_vals.append(nan)
-                        null_mask.append(True)
+                        null_mask.append_null()
                     else:
                         result_vals.append(Float64(key_to_agg[row_key[i]]))
-                        null_mask.append(False)
+                        null_mask.append_valid()
                 var result_col = Column(
                     self._series.name, result_vals^, float64
                 )
@@ -7812,7 +7783,7 @@ def _row_as_series(df: DataFrame, row: Int) raises -> Series:
     return Series(result_col^)
 
 
-def _df_slice_rows(df: DataFrame, start: Int, end: Int) -> DataFrame:
+def _df_slice_rows(df: DataFrame, start: Int, end: Int) raises -> DataFrame:
     """Return a new DataFrame with rows [start, end)."""
     var result_cols = List[Column]()
     for i in range(len(df._cols)):

--- a/bison/accessors/dt_accessor.mojo
+++ b/bison/accessors/dt_accessor.mojo
@@ -13,7 +13,7 @@ struct DatetimeMethods:
 
     def __init__(out self):
         self._data = List[PythonObject]()
-        self._null_mask = List[Bool]()
+        self._null_mask = NullMask()
         self._name = None
 
     def __init__(
@@ -45,14 +45,14 @@ struct DatetimeMethods:
         level without requiring a runtime call to Python's `getattr()`.
         """
         var result = List[Int64]()
-        var new_mask = List[Bool]()
+        var new_mask = NullMask()
         for i in range(len(self._data)):
             if self._is_null(i):
                 result.append(Int64(0))
-                new_mask.append(True)
+                new_mask.append_null()
             else:
                 result.append(Int64(Int(py=self._data[i].__getattr__(attr))))
-                new_mask.append(False)
+                new_mask.append_valid()
         var col = Column(self._name, result^, int64)
         col._null_mask = new_mask^
         return col^
@@ -90,28 +90,28 @@ struct DatetimeMethods:
 
     def date(self) raises -> Column:
         var result = List[PythonObject]()
-        var new_mask = List[Bool]()
+        var new_mask = NullMask()
         for i in range(len(self._data)):
             if self._is_null(i):
                 result.append(PythonObject(None))
-                new_mask.append(True)
+                new_mask.append_null()
             else:
                 result.append(self._data[i].date())
-                new_mask.append(False)
+                new_mask.append_valid()
         var col = Column(self._name, result^, object_)
         col._null_mask = new_mask^
         return col^
 
     def time(self) raises -> Column:
         var result = List[PythonObject]()
-        var new_mask = List[Bool]()
+        var new_mask = NullMask()
         for i in range(len(self._data)):
             if self._is_null(i):
                 result.append(PythonObject(None))
-                new_mask.append(True)
+                new_mask.append_null()
             else:
                 result.append(self._data[i].time())
-                new_mask.append(False)
+                new_mask.append_valid()
         var col = Column(self._name, result^, object_)
         col._null_mask = new_mask^
         return col^
@@ -130,14 +130,14 @@ struct DatetimeMethods:
         name at the Python level without a runtime ``getattr()`` call.
         """
         var result = List[PythonObject]()
-        var new_mask = List[Bool]()
+        var new_mask = NullMask()
         for i in range(len(self._data)):
             if self._is_null(i):
                 result.append(PythonObject(None))
-                new_mask.append(True)
+                new_mask.append_null()
             else:
                 result.append(self._data[i].__getattr__(method)(arg))
-                new_mask.append(False)
+                new_mask.append_valid()
         var col = Column(self._name, result^, datetime64_ns)
         col._null_mask = new_mask^
         return col^

--- a/bison/accessors/str_accessor.mojo
+++ b/bison/accessors/str_accessor.mojo
@@ -14,7 +14,7 @@ struct StringMethods:
 
     def __init__(out self):
         self._data = List[String]()
-        self._null_mask = List[Bool]()
+        self._null_mask = NullMask()
         self._name = None
 
     def __init__(
@@ -111,45 +111,45 @@ struct StringMethods:
         self, pat: String, `case`: Bool = True, na: Bool = False
     ) raises -> Column:
         var result = List[Bool]()
-        var new_mask = List[Bool]()
+        var new_mask = NullMask()
         for i in range(len(self._data)):
             if self._is_null(i):
                 result.append(na)
-                new_mask.append(False)
+                new_mask.append_valid()
             else:
                 if `case`:
                     result.append(self._data[i].find(pat) != -1)
                 else:
                     result.append(self._data[i].lower().find(pat.lower()) != -1)
-                new_mask.append(False)
+                new_mask.append_valid()
         var col = Column(self._name, result^, bool_)
         col._null_mask = new_mask^
         return col^
 
     def startswith(self, pat: String) raises -> Column:
         var result = List[Bool]()
-        var new_mask = List[Bool]()
+        var new_mask = NullMask()
         for i in range(len(self._data)):
             if self._is_null(i):
                 result.append(False)
-                new_mask.append(True)
+                new_mask.append_null()
             else:
                 result.append(self._data[i].startswith(pat))
-                new_mask.append(False)
+                new_mask.append_valid()
         var col = Column(self._name, result^, bool_)
         col._null_mask = new_mask^
         return col^
 
     def endswith(self, pat: String) raises -> Column:
         var result = List[Bool]()
-        var new_mask = List[Bool]()
+        var new_mask = NullMask()
         for i in range(len(self._data)):
             if self._is_null(i):
                 result.append(False)
-                new_mask.append(True)
+                new_mask.append_null()
             else:
                 result.append(self._data[i].endswith(pat))
-                new_mask.append(False)
+                new_mask.append_valid()
         var col = Column(self._name, result^, bool_)
         col._null_mask = new_mask^
         return col^
@@ -205,49 +205,49 @@ struct StringMethods:
 
     def len(self) raises -> Column:
         var result = List[Int64]()
-        var new_mask = List[Bool]()
+        var new_mask = NullMask()
         for i in range(len(self._data)):
             if self._is_null(i):
                 result.append(Int64(0))
-                new_mask.append(True)
+                new_mask.append_null()
             else:
                 result.append(Int64(len(self._data[i])))
-                new_mask.append(False)
+                new_mask.append_valid()
         var col = Column(self._name, result^, int64)
         col._null_mask = new_mask^
         return col^
 
     def find(self, sub: String, start: Int = 0, end: Int = -1) raises -> Column:
         var result = List[Int64]()
-        var new_mask = List[Bool]()
+        var new_mask = NullMask()
         for i in range(len(self._data)):
             if self._is_null(i):
                 result.append(Int64(-1))
-                new_mask.append(True)
+                new_mask.append_null()
             else:
                 var s = self._data[i]
                 var pos = s.find(sub, start)
                 if end != -1 and pos >= end:
                     pos = -1
                 result.append(Int64(pos))
-                new_mask.append(False)
+                new_mask.append_valid()
         var col = Column(self._name, result^, int64)
         col._null_mask = new_mask^
         return col^
 
     def count(self, pat: String) raises -> Column:
         var result = List[Int64]()
-        var new_mask = List[Bool]()
+        var new_mask = NullMask()
         var re_mod = Python.import_module("re")
         for i in range(len(self._data)):
             if self._is_null(i):
                 result.append(Int64(0))
-                new_mask.append(True)
+                new_mask.append_null()
             else:
                 var py_s = PythonObject(self._data[i])
                 var matches = re_mod.findall(pat, py_s)
                 result.append(Int64(Int(py=matches.__len__())))
-                new_mask.append(False)
+                new_mask.append_valid()
         var col = Column(self._name, result^, int64)
         col._null_mask = new_mask^
         return col^
@@ -258,16 +258,16 @@ struct StringMethods:
 
     def get(self, i: Int) raises -> Column:
         var result = List[String]()
-        var new_mask = List[Bool]()
+        var new_mask = NullMask()
         for idx in range(len(self._data)):
             if self._is_null(idx):
                 result.append(String(""))
-                new_mask.append(True)
+                new_mask.append_null()
             else:
                 var s = self._data[idx]
                 if i < 0 or i >= len(s):
                     result.append(String(""))
-                    new_mask.append(True)
+                    new_mask.append_null()
                 else:
                     var j = 0
                     var char_val = String("")
@@ -277,7 +277,7 @@ struct StringMethods:
                             break
                         j += 1
                     result.append(char_val)
-                    new_mask.append(False)
+                    new_mask.append_valid()
         var col = Column(self._name, result^, object_)
         col._null_mask = new_mask^
         return col^
@@ -286,11 +286,11 @@ struct StringMethods:
         self, start: Int = 0, stop: Int = -1, step: Int = 1
     ) raises -> Column:
         var result = List[String]()
-        var new_mask = List[Bool]()
+        var new_mask = NullMask()
         for i in range(len(self._data)):
             if self._is_null(i):
                 result.append(String(""))
-                new_mask.append(True)
+                new_mask.append_null()
             else:
                 var s = self._data[i]
                 var slen = len(s)
@@ -304,7 +304,7 @@ struct StringMethods:
                         sub += String(ch)
                     j += 1
                 result.append(sub)
-                new_mask.append(False)
+                new_mask.append_valid()
         var col = Column(self._name, result^, object_)
         col._null_mask = new_mask^
         return col^
@@ -331,17 +331,17 @@ struct StringMethods:
 
     def match(self, pat: String) raises -> Column:
         var result = List[Bool]()
-        var new_mask = List[Bool]()
+        var new_mask = NullMask()
         var re_mod = Python.import_module("re")
         for i in range(len(self._data)):
             if self._is_null(i):
                 result.append(False)
-                new_mask.append(True)
+                new_mask.append_null()
             else:
                 var py_s = PythonObject(self._data[i])
                 var m = re_mod.match(pat, py_s)
                 result.append(Bool(m.__bool__()))
-                new_mask.append(False)
+                new_mask.append_valid()
         var col = Column(self._name, result^, bool_)
         col._null_mask = new_mask^
         return col^

--- a/bison/arrow.mojo
+++ b/bison/arrow.mojo
@@ -25,7 +25,7 @@ from marrow.dtypes import (
 )
 from marrow.schema import Schema as _MarrowSchema
 from marrow.tabular import RecordBatch, Table
-from .column import Column, ColumnData, ColumnStorage
+from .column import Column, ColumnData, ColumnStorage, NullMask
 from .dataframe import DataFrame
 from .dtypes import int64, float64, bool_, object_
 
@@ -121,18 +121,16 @@ def marrow_array_to_column(arr: AnyArray, name: String) raises -> Column:
     if dt == _m_int64:
         ref src = arr.as_int64()
         var data = List[Int64]()
-        var null_mask = List[Bool]()
-        var has_null = False
+        var null_mask = NullMask()
         for i in range(n):
             if not arr.is_valid(i):
                 data.append(Int64(0))
-                null_mask.append(True)
-                has_null = True
+                null_mask.append_null()
             else:
                 data.append(rebind[Int64](src.unsafe_get(i)))
-                null_mask.append(False)
+                null_mask.append_valid()
         var col = Column(name, ColumnData(data^), int64)
-        if has_null:
+        if null_mask.has_nulls():
             col._null_mask = null_mask^
         col._storage = ColumnStorage(arr.copy())
         col._storage_active = True
@@ -141,18 +139,16 @@ def marrow_array_to_column(arr: AnyArray, name: String) raises -> Column:
     elif dt == _m_float64:
         ref src = arr.as_float64()
         var data = List[Float64]()
-        var null_mask = List[Bool]()
-        var has_null = False
+        var null_mask = NullMask()
         for i in range(n):
             if not arr.is_valid(i):
                 data.append(Float64(0))
-                null_mask.append(True)
-                has_null = True
+                null_mask.append_null()
             else:
                 data.append(rebind[Float64](src.unsafe_get(i)))
-                null_mask.append(False)
+                null_mask.append_valid()
         var col = Column(name, ColumnData(data^), float64)
-        if has_null:
+        if null_mask.has_nulls():
             col._null_mask = null_mask^
         col._storage = ColumnStorage(arr.copy())
         col._storage_active = True
@@ -161,18 +157,16 @@ def marrow_array_to_column(arr: AnyArray, name: String) raises -> Column:
     elif dt == _m_bool_:
         ref src = arr.as_bool()
         var data = List[Bool]()
-        var null_mask = List[Bool]()
-        var has_null = False
+        var null_mask = NullMask()
         for i in range(n):
             if not arr.is_valid(i):
                 data.append(False)
-                null_mask.append(True)
-                has_null = True
+                null_mask.append_null()
             else:
                 data.append(Bool(src.unsafe_get(i)))
-                null_mask.append(False)
+                null_mask.append_valid()
         var col = Column(name, ColumnData(data^), bool_)
-        if has_null:
+        if null_mask.has_nulls():
             col._null_mask = null_mask^
         col._storage = ColumnStorage(arr.copy())
         col._storage_active = True
@@ -181,18 +175,16 @@ def marrow_array_to_column(arr: AnyArray, name: String) raises -> Column:
     elif dt == _m_string:
         ref src = arr.as_string()
         var data = List[String]()
-        var null_mask = List[Bool]()
-        var has_null = False
+        var null_mask = NullMask()
         for i in range(n):
             if not arr.is_valid(i):
                 data.append("")
-                null_mask.append(True)
-                has_null = True
+                null_mask.append_null()
             else:
                 data.append(String(src.unsafe_get(UInt(i))))
-                null_mask.append(False)
+                null_mask.append_valid()
         var col = Column(name, ColumnData(data^), object_)
-        if has_null:
+        if null_mask.has_nulls():
             col._null_mask = null_mask^
         col._storage = ColumnStorage(arr.copy())
         col._storage_active = True

--- a/bison/column.mojo
+++ b/bison/column.mojo
@@ -773,13 +773,13 @@ struct _FfillVisitor(ColumnDataVisitorRaises, Copyable, Movable):
     """
 
     var col_data: ColumnData
-    var result_mask: List[Bool]
+    var result_mask: NullMask
     var has_any_null: Bool
     var null_mask: NullMask
 
     def __init__(out self, null_mask: NullMask):
         self.col_data = ColumnData(List[PythonObject]())
-        self.result_mask = List[Bool]()
+        self.result_mask = NullMask()
         self.has_any_null = False
         self.null_mask = null_mask.copy()
 
@@ -791,16 +791,16 @@ struct _FfillVisitor(ColumnDataVisitorRaises, Copyable, Movable):
             if self.null_mask[i]:
                 if found:
                     result.append(last_val)
-                    self.result_mask.append(False)
+                    self.result_mask.append_valid()
                 else:
                     result.append(Int64(0))
-                    self.result_mask.append(True)
+                    self.result_mask.append_null()
                     self.has_any_null = True
             else:
                 last_val = data[i]
                 found = True
                 result.append(data[i])
-                self.result_mask.append(False)
+                self.result_mask.append_valid()
         self.col_data = ColumnData(result^)
 
     def on_float64(mut self, data: List[Float64]) raises:
@@ -811,16 +811,16 @@ struct _FfillVisitor(ColumnDataVisitorRaises, Copyable, Movable):
             if self.null_mask[i]:
                 if found:
                     result.append(last_val)
-                    self.result_mask.append(False)
+                    self.result_mask.append_valid()
                 else:
                     result.append(Float64(0))
-                    self.result_mask.append(True)
+                    self.result_mask.append_null()
                     self.has_any_null = True
             else:
                 last_val = data[i]
                 found = True
                 result.append(data[i])
-                self.result_mask.append(False)
+                self.result_mask.append_valid()
         self.col_data = ColumnData(result^)
 
     def on_bool(mut self, data: List[Bool]) raises:
@@ -831,16 +831,16 @@ struct _FfillVisitor(ColumnDataVisitorRaises, Copyable, Movable):
             if self.null_mask[i]:
                 if found:
                     result.append(last_val)
-                    self.result_mask.append(False)
+                    self.result_mask.append_valid()
                 else:
                     result.append(False)
-                    self.result_mask.append(True)
+                    self.result_mask.append_null()
                     self.has_any_null = True
             else:
                 last_val = data[i]
                 found = True
                 result.append(data[i])
-                self.result_mask.append(False)
+                self.result_mask.append_valid()
         self.col_data = ColumnData(result^)
 
     def on_str(mut self, data: List[String]) raises:
@@ -851,16 +851,16 @@ struct _FfillVisitor(ColumnDataVisitorRaises, Copyable, Movable):
             if self.null_mask[i]:
                 if found:
                     result.append(last_val)
-                    self.result_mask.append(False)
+                    self.result_mask.append_valid()
                 else:
                     result.append(String(""))
-                    self.result_mask.append(True)
+                    self.result_mask.append_null()
                     self.has_any_null = True
             else:
                 last_val = data[i]
                 found = True
                 result.append(data[i])
-                self.result_mask.append(False)
+                self.result_mask.append_valid()
         self.col_data = ColumnData(result^)
 
     def on_obj(mut self, data: List[PythonObject]) raises:
@@ -872,16 +872,16 @@ struct _FfillVisitor(ColumnDataVisitorRaises, Copyable, Movable):
             if self.null_mask[i]:
                 if found:
                     result.append(last_val)
-                    self.result_mask.append(False)
+                    self.result_mask.append_valid()
                 else:
                     result.append(none_val)
-                    self.result_mask.append(True)
+                    self.result_mask.append_null()
                     self.has_any_null = True
             else:
                 last_val = data[i]
                 found = True
                 result.append(data[i])
-                self.result_mask.append(False)
+                self.result_mask.append_valid()
         self.col_data = ColumnData(result^)
 
 
@@ -893,13 +893,13 @@ struct _BfillVisitor(ColumnDataVisitorRaises, Copyable, Movable):
     """
 
     var col_data: ColumnData
-    var result_mask: List[Bool]
+    var result_mask: NullMask
     var has_any_null: Bool
     var null_mask: NullMask
 
     def __init__(out self, null_mask: NullMask):
         self.col_data = ColumnData(List[PythonObject]())
-        self.result_mask = List[Bool]()
+        self.result_mask = NullMask()
         self.has_any_null = False
         self.null_mask = null_mask.copy()
 
@@ -2616,27 +2616,27 @@ struct _TakeVisitor(ColumnDataVisitor, Copyable, Movable):
         self.result = ColumnData(result^)
 
 
-struct _TakeWithNullsVisitor(ColumnDataVisitor, Copyable, Movable):
+struct _TakeWithNullsVisitor(ColumnDataVisitorRaises, Copyable, Movable):
     """Like _TakeVisitor but index -1 emits a null placeholder row."""
 
     var indices: List[Int]
     var src_mask: NullMask
-    var out_mask: List[Bool]
+    var out_mask: NullMask
     var result: ColumnData
 
     def __init__(out self, indices: List[Int], src_mask: NullMask):
         self.indices = indices.copy()
         self.src_mask = src_mask.copy()
-        self.out_mask = List[Bool]()
+        self.out_mask = NullMask()
         self.result = ColumnData(List[PythonObject]())
 
-    def on_int64(mut self, data: List[Int64]):
+    def on_int64(mut self, data: List[Int64]) raises:
         var out = List[Int64]()
         for k in range(len(self.indices)):
             var i = self.indices[k]
             if i < 0:
                 out.append(Int64(0))
-                self.out_mask.append(True)
+                self.out_mask.append_null()
             else:
                 out.append(data[i])
                 self.out_mask.append(
@@ -2644,13 +2644,13 @@ struct _TakeWithNullsVisitor(ColumnDataVisitor, Copyable, Movable):
                 )
         self.result = ColumnData(out^)
 
-    def on_float64(mut self, data: List[Float64]):
+    def on_float64(mut self, data: List[Float64]) raises:
         var out = List[Float64]()
         for k in range(len(self.indices)):
             var i = self.indices[k]
             if i < 0:
                 out.append(Float64(0) / Float64(0))
-                self.out_mask.append(True)
+                self.out_mask.append_null()
             else:
                 out.append(data[i])
                 self.out_mask.append(
@@ -2658,13 +2658,13 @@ struct _TakeWithNullsVisitor(ColumnDataVisitor, Copyable, Movable):
                 )
         self.result = ColumnData(out^)
 
-    def on_bool(mut self, data: List[Bool]):
+    def on_bool(mut self, data: List[Bool]) raises:
         var out = List[Bool]()
         for k in range(len(self.indices)):
             var i = self.indices[k]
             if i < 0:
                 out.append(False)
-                self.out_mask.append(True)
+                self.out_mask.append_null()
             else:
                 out.append(data[i])
                 self.out_mask.append(
@@ -2672,13 +2672,13 @@ struct _TakeWithNullsVisitor(ColumnDataVisitor, Copyable, Movable):
                 )
         self.result = ColumnData(out^)
 
-    def on_str(mut self, data: List[String]):
+    def on_str(mut self, data: List[String]) raises:
         var out = List[String]()
         for k in range(len(self.indices)):
             var i = self.indices[k]
             if i < 0:
                 out.append("")
-                self.out_mask.append(True)
+                self.out_mask.append_null()
             else:
                 out.append(data[i])
                 self.out_mask.append(
@@ -2686,13 +2686,13 @@ struct _TakeWithNullsVisitor(ColumnDataVisitor, Copyable, Movable):
                 )
         self.result = ColumnData(out^)
 
-    def on_obj(mut self, data: List[PythonObject]):
+    def on_obj(mut self, data: List[PythonObject]) raises:
         var out = List[PythonObject]()
         for k in range(len(self.indices)):
             var i = self.indices[k]
             if i < 0:
                 out.append(PythonObject(None))
-                self.out_mask.append(True)
+                self.out_mask.append_null()
             else:
                 out.append(data[i])
                 self.out_mask.append(
@@ -4545,17 +4545,14 @@ struct NullMask(Copyable, Movable, Sized):
         self._capacity = 0
         self._has_nulls = False
 
-    @implicit
-    def __init__(out self, read mask: List[Bool]):
-        """Construct from a ``List[Bool]`` (implicit conversion).
+    @staticmethod
+    def from_list(read mask: List[Bool]) -> Self:
+        """Explicit conversion from ``List[Bool]``.
 
-        Backwards-compatibility bridge for call sites that still build a
-        ``List[Bool]`` and assign it directly to ``col._null_mask``
-        (notably ``arrow.mojo``, ``reshape/_concat.mojo``, and several
-        ``Column`` helpers like ``take`` / ``take_with_nulls``).  Must be
-        non-raising because most of those callers run in non-raising
-        contexts; we therefore use ``BitmapBuilder.alloc`` directly at the
-        final size and avoid the raising ``resize`` path.
+        Used by ``_build_result_col`` and other internal call sites that still
+        produce ``List[Bool]`` masks (e.g. binary-op visitors).  Unlike the
+        deleted ``@implicit`` bridge constructor, this is an explicit call so
+        it won't silently convert stray ``List[Bool]`` assignments.
         """
         var n = len(mask)
         var any_null = False
@@ -4563,17 +4560,19 @@ struct NullMask(Copyable, Movable, Sized):
             if mask[i]:
                 any_null = True
                 break
-        self._length = n
-        self._has_nulls = any_null
+        var result = NullMask()
+        result._length = n
+        result._has_nulls = any_null
         if any_null:
-            self._capacity = n
-            self._builder = BitmapBuilder.alloc(n)
+            result._capacity = n
+            result._builder = BitmapBuilder.alloc(n)
             for i in range(n):
                 if mask[i]:
-                    self._builder.set_bit(i, True)
+                    result._builder.set_bit(i, True)
         else:
-            self._capacity = 0
-            self._builder = BitmapBuilder.alloc(Self._EMPTY_ALLOC_BITS)
+            result._capacity = 0
+            result._builder = BitmapBuilder.alloc(Self._EMPTY_ALLOC_BITS)
+        return result^
 
     def __init__(out self, *, copy: Self):
         self._length = copy._length
@@ -5461,7 +5460,7 @@ struct Column(Copyable, ImplicitlyCopyable, Movable, Sized):
     # Row selection helpers
     # ------------------------------------------------------------------
 
-    def slice(self, start: Int, end: Int) -> Column:
+    def slice(self, start: Int, end: Int) raises -> Column:
         """Return a new Column containing rows [start, end).
 
         Negative indices are not supported; out-of-range bounds are clamped.
@@ -5477,7 +5476,7 @@ struct Column(Copyable, ImplicitlyCopyable, Movable, Sized):
             e = 0
         if e > n:
             e = n
-        var new_mask = List[Bool]()
+        var new_mask = NullMask()
         if self._null_mask.has_nulls():
             for i in range(s, e):
                 new_mask.append(self._null_mask[i])
@@ -5512,15 +5511,15 @@ struct Column(Copyable, ImplicitlyCopyable, Movable, Sized):
             var visitor = _SliceVisitor(s, e)
             self._visit(visitor)
             col = Column(self.name, visitor^.result.copy(), self.dtype)
-        if len(new_mask) > 0:
+        if new_mask.has_nulls():
             col._null_mask = new_mask^
         return col^
 
-    def take(self, indices: List[Int]) -> Column:
+    def take(self, indices: List[Int]) raises -> Column:
         """Return a new Column with rows selected by *indices* (arbitrary order).
         """
         var has_mask = self._null_mask.has_nulls()
-        var new_mask = List[Bool]()
+        var new_mask = NullMask()
         if has_mask:
             for k in range(len(indices)):
                 new_mask.append(self._null_mask[indices[k]])
@@ -5555,25 +5554,20 @@ struct Column(Copyable, ImplicitlyCopyable, Movable, Sized):
             var visitor = _TakeVisitor(indices)
             self._visit(visitor)
             col = Column(self.name, visitor^.result.copy(), self.dtype)
-        if len(new_mask) > 0:
+        if new_mask.has_nulls():
             col._null_mask = new_mask^
         # Activate storage on the new column (#619 Phase 4).
         col._try_activate_storage()
         return col^
 
-    def take_with_nulls(self, indices: List[Int]) -> Column:
+    def take_with_nulls(self, indices: List[Int]) raises -> Column:
         """Like take() but index -1 inserts a null placeholder row."""
         var visitor = _TakeWithNullsVisitor(indices, self._null_mask)
-        self._visit(visitor)
+        self._visit_raises(visitor)
         # Save out_mask before consuming visitor to avoid partial-move issues.
         var out_mask = visitor.out_mask.copy()
         var col = Column(self.name, visitor^.result.copy(), self.dtype)
-        var has_null = False
-        for k in range(len(out_mask)):
-            if out_mask[k]:
-                has_null = True
-                break
-        if has_null:
+        if out_mask.has_nulls():
             col._null_mask = out_mask^
         # Activate storage on the new column (#619 Phase 4).
         col._try_activate_storage()
@@ -5588,7 +5582,7 @@ struct Column(Copyable, ImplicitlyCopyable, Movable, Sized):
         if self._null_mask.has_nulls() or other._null_mask.has_nulls():
             var n_self = len(self)
             var n_other = len(other)
-            var merged = List[Bool]()
+            var merged = NullMask()
             for i in range(n_self):
                 merged.append(
                     self._null_mask.has_nulls() and self._null_mask[i]
@@ -5597,7 +5591,8 @@ struct Column(Copyable, ImplicitlyCopyable, Movable, Sized):
                 merged.append(
                     other._null_mask.has_nulls() and other._null_mask[i]
                 )
-            col._null_mask = merged^
+            if merged.has_nulls():
+                col._null_mask = merged^
         return col^
 
     # ------------------------------------------------------------------
@@ -6189,7 +6184,7 @@ struct Column(Copyable, ImplicitlyCopyable, Movable, Sized):
         var dtype = Column._sniff_dtype(col_data)
         var col = Column(self.name, col_data^, dtype)
         if has_any_null:
-            col._null_mask = result_mask^
+            col._null_mask = NullMask.from_list(result_mask)
         # Activate storage on the result (#619 Phase 4).
         col._try_activate_storage()
         return col^
@@ -7513,9 +7508,12 @@ struct Column(Copyable, ImplicitlyCopyable, Movable, Sized):
 
         # Build the null mask once, used by every branch below.
         var null_list = pd_series.isna().tolist()
-        var null_mask = List[Bool]()
+        var null_mask = NullMask()
         for i in range(n):
-            null_mask.append(Bool(null_list[i].__bool__()))
+            if Bool(null_list[i].__bool__()):
+                null_mask.append_null()
+            else:
+                null_mask.append_valid()
 
         # Capture the pandas index name (may be None).
         var idx_name = String("")
@@ -7668,9 +7666,6 @@ struct Column(Copyable, ImplicitlyCopyable, Movable, Sized):
         bool, PythonObject for everything else).  Every element is marked
         null via ``_null_mask``.
         """
-        var null_mask = List[Bool]()
-        for _ in range(n):
-            null_mask.append(True)
         var c: Column
         if dtype.is_integer():
             var data = List[Int64]()
@@ -7693,7 +7688,7 @@ struct Column(Copyable, ImplicitlyCopyable, Movable, Sized):
             for _ in range(n):
                 data.append(py_none)
             c = Column(name, ColumnData(data^), dtype, index^)
-        c._null_mask = null_mask^
+        c._null_mask = NullMask.all_null(n)
         return c^
 
     @staticmethod

--- a/bison/io/csv.mojo
+++ b/bison/io/csv.mojo
@@ -1,7 +1,7 @@
 from std.python import Python, PythonObject
 from std.collections import Optional
 from ..dataframe import DataFrame
-from ..column import Column
+from ..column import Column, NullMask
 from ..dtypes import int64, float64, object_, bool_
 
 
@@ -59,18 +59,16 @@ def _infer_and_build_column(
 
     if all_bool:
         var data = List[Bool]()
-        var null_mask = List[Bool]()
-        var has_null = False
+        var null_mask = NullMask()
         for i in range(n):
             if _in_na_set(raw[i], na_set):
                 data.append(False)
-                null_mask.append(True)
-                has_null = True
+                null_mask.append_null()
             else:
                 data.append(_parse_bool_value(raw[i]))
-                null_mask.append(False)
+                null_mask.append_valid()
         var col = Column(name, data^, bool_)
-        if has_null:
+        if null_mask.has_nulls():
             col._null_mask = null_mask^
         col._try_activate_storage()
         return col^
@@ -90,18 +88,16 @@ def _infer_and_build_column(
 
     if all_int:
         var data = List[Int64]()
-        var null_mask = List[Bool]()
-        var has_null = False
+        var null_mask = NullMask()
         for i in range(n):
             if _in_na_set(raw[i], na_set):
                 data.append(Int64(0))
-                null_mask.append(True)
-                has_null = True
+                null_mask.append_null()
             else:
                 data.append(Int64(atol(raw[i])))
-                null_mask.append(False)
+                null_mask.append_valid()
         var col = Column(name, data^, int64)
-        if has_null:
+        if null_mask.has_nulls():
             col._null_mask = null_mask^
         col._try_activate_storage()
         return col^
@@ -121,18 +117,16 @@ def _infer_and_build_column(
 
     if all_float:
         var data = List[Float64]()
-        var null_mask = List[Bool]()
-        var has_null = False
+        var null_mask = NullMask()
         for i in range(n):
             if _in_na_set(raw[i], na_set):
                 data.append(Float64(0))
-                null_mask.append(True)
-                has_null = True
+                null_mask.append_null()
             else:
                 data.append(atof(raw[i]))
-                null_mask.append(False)
+                null_mask.append_valid()
         var col = Column(name, data^, float64)
-        if has_null:
+        if null_mask.has_nulls():
             col._null_mask = null_mask^
         col._try_activate_storage()
         return col^
@@ -141,18 +135,16 @@ def _infer_and_build_column(
     # Default: String (stored as List[String] with object_ dtype)
     # ------------------------------------------------------------------
     var data = List[String]()
-    var null_mask = List[Bool]()
-    var has_null = False
+    var null_mask = NullMask()
     for i in range(n):
         if _in_na_set(raw[i], na_set):
             data.append(String(""))
-            null_mask.append(True)
-            has_null = True
+            null_mask.append_null()
         else:
             data.append(raw[i])
-            null_mask.append(False)
+            null_mask.append_valid()
     var col = Column(name, data^, object_)
-    if has_null:
+    if null_mask.has_nulls():
         col._null_mask = null_mask^
     col._try_activate_storage()
     return col^

--- a/bison/io/json.mojo
+++ b/bison/io/json.mojo
@@ -1,7 +1,7 @@
 from std.python import Python, PythonObject
 from std.collections import Optional
 from ..dataframe import DataFrame
-from ..column import Column
+from ..column import Column, NullMask
 from ..dtypes import int64, float64, object_, bool_
 
 
@@ -63,76 +63,68 @@ def _json_build_column(
 
     if dtype_str == "bool":
         var data = List[Bool]()
-        var null_mask = List[Bool]()
-        var has_null = False
+        var null_mask = NullMask()
         for ri in range(n):
             var val = py_values[ri]
             if _json_py_type(val) == "NoneType":
                 data.append(False)
-                null_mask.append(True)
-                has_null = True
+                null_mask.append_null()
             else:
                 data.append(Bool(val.__bool__()))
-                null_mask.append(False)
+                null_mask.append_valid()
         var col = Column(name, data^, bool_)
-        if has_null:
+        if null_mask.has_nulls():
             col._null_mask = null_mask^
         col._try_activate_storage()
         return col^
 
     elif dtype_str == "int64":
         var data = List[Int64]()
-        var null_mask = List[Bool]()
-        var has_null = False
+        var null_mask = NullMask()
         for ri in range(n):
             var val = py_values[ri]
             if _json_py_type(val) == "NoneType":
                 data.append(Int64(0))
-                null_mask.append(True)
-                has_null = True
+                null_mask.append_null()
             else:
                 data.append(Int64(Int(py=val)))
-                null_mask.append(False)
+                null_mask.append_valid()
         var col = Column(name, data^, int64)
-        if has_null:
+        if null_mask.has_nulls():
             col._null_mask = null_mask^
         col._try_activate_storage()
         return col^
 
     elif dtype_str == "float64":
         var data = List[Float64]()
-        var null_mask = List[Bool]()
-        var has_null = False
+        var null_mask = NullMask()
         for ri in range(n):
             var val = py_values[ri]
             if _json_py_type(val) == "NoneType":
                 data.append(Float64(0))
-                null_mask.append(True)
-                has_null = True
+                null_mask.append_null()
             else:
                 data.append(atof(String(val)))
-                null_mask.append(False)
+                null_mask.append_valid()
         var col = Column(name, data^, float64)
-        if has_null:
+        if null_mask.has_nulls():
             col._null_mask = null_mask^
         col._try_activate_storage()
         return col^
 
     else:  # "string"
         var data = List[String]()
-        var null_mask = List[Bool]()
-        var has_null = False
+        var null_mask = NullMask()
         for ri in range(n):
             var val = py_values[ri]
             if _json_py_type(val) == "NoneType":
                 data.append(String(""))
-                null_mask.append(True)
-                has_null = True
+                null_mask.append_null()
             else:
                 data.append(String(val))
-                null_mask.append(False)
+                null_mask.append_valid()
         var col = Column(name, data^, object_)
-        if has_null:
+        if null_mask.has_nulls():
             col._null_mask = null_mask^
         col._try_activate_storage()
         return col^

--- a/bison/reshape/_concat.mojo
+++ b/bison/reshape/_concat.mojo
@@ -77,7 +77,7 @@ def _promote_piece_to_object(
 
 
 def _append_piece_mask(
-    mut mask: List[Bool], piece: Column, need_mask: Bool
+    mut mask: NullMask, piece: Column, need_mask: Bool
 ) raises:
     if not need_mask:
         return
@@ -87,7 +87,7 @@ def _append_piece_mask(
         if has_m:
             mask.append(piece._null_mask[k])
         else:
-            mask.append(False)
+            mask.append_valid()
 
 
 # ------------------------------------------------------------------
@@ -99,15 +99,12 @@ def _null_col(
     name: Optional[String], n: Int, dtype: BisonDtype
 ) raises -> Column:
     """Return a Column of *n* null rows using *dtype* as the stored arm."""
-    var mask = List[Bool]()
-    for _ in range(n):
-        mask.append(True)
     if dtype == int64:
         var data = List[Int64]()
         for _ in range(n):
             data.append(Int64(0))
         var col = Column(name, data^, dtype)
-        col._null_mask = mask^
+        col._null_mask = NullMask.all_null(n)
         col._try_activate_storage()
         return col^
     elif dtype == float64:
@@ -115,7 +112,7 @@ def _null_col(
         for _ in range(n):
             data.append(Float64(0))
         var col = Column(name, data^, dtype)
-        col._null_mask = mask^
+        col._null_mask = NullMask.all_null(n)
         col._try_activate_storage()
         return col^
     elif dtype == bool_:
@@ -123,7 +120,7 @@ def _null_col(
         for _ in range(n):
             data.append(False)
         var col = Column(name, data^, dtype)
-        col._null_mask = mask^
+        col._null_mask = NullMask.all_null(n)
         col._try_activate_storage()
         return col^
     else:
@@ -131,7 +128,7 @@ def _null_col(
         for _ in range(n):
             data.append(Python.evaluate("None"))
         var col = Column(name, data^, object_)
-        col._null_mask = mask^
+        col._null_mask = NullMask.all_null(n)
         col._try_activate_storage()
         return col^
 
@@ -271,7 +268,7 @@ def _vstack(pieces: List[Column]) raises -> Column:
 
     if common and common.value() == int64:
         var data = List[Int64]()
-        var mask = List[Bool]()
+        var mask = NullMask()
         for i in range(len(pieces)):
             ref src = pieces[i]._int64_data()
             for k in range(len(src)):
@@ -284,7 +281,7 @@ def _vstack(pieces: List[Column]) raises -> Column:
         return col^
     elif common and common.value() == float64:
         var data = List[Float64]()
-        var mask = List[Bool]()
+        var mask = NullMask()
         for i in range(len(pieces)):
             ref src = pieces[i]._float64_data()
             for k in range(len(src)):
@@ -297,7 +294,7 @@ def _vstack(pieces: List[Column]) raises -> Column:
         return col^
     elif common and common.value() == bool_:
         var data = List[Bool]()
-        var mask = List[Bool]()
+        var mask = NullMask()
         for i in range(len(pieces)):
             ref src = pieces[i]._bool_data()
             for k in range(len(src)):
@@ -311,7 +308,7 @@ def _vstack(pieces: List[Column]) raises -> Column:
     elif common and common.value() == object_:
         # All pieces hold List[String]; keep the string arm intact.
         var data = List[String]()
-        var mask = List[Bool]()
+        var mask = NullMask()
         for i in range(len(pieces)):
             ref src = pieces[i]._str_data()
             for k in range(len(src)):
@@ -325,7 +322,7 @@ def _vstack(pieces: List[Column]) raises -> Column:
     elif target_dtype == float64:
         # Numeric promotion: pieces are a mix of float64, int64, and/or bool_.
         var data = List[Float64]()
-        var mask = List[Bool]()
+        var mask = NullMask()
         for i in range(len(pieces)):
             _promote_piece_to_float64(pieces[i], data)
             _append_piece_mask(mask, pieces[i], need_mask)
@@ -337,7 +334,7 @@ def _vstack(pieces: List[Column]) raises -> Column:
     elif target_dtype == int64:
         # Numeric promotion: pieces are a mix of int64 and bool_.
         var data = List[Int64]()
-        var mask = List[Bool]()
+        var mask = NullMask()
         for i in range(len(pieces)):
             _promote_piece_to_int64(pieces[i], data)
             _append_piece_mask(mask, pieces[i], need_mask)
@@ -353,7 +350,7 @@ def _vstack(pieces: List[Column]) raises -> Column:
         var py_builtins = Python.import_module("builtins")
         var py_str = py_builtins.str
         var data = List[PythonObject]()
-        var mask = List[Bool]()
+        var mask = NullMask()
         for i in range(len(pieces)):
             _promote_piece_to_object(pieces[i], data, py_str)
             _append_piece_mask(mask, pieces[i], need_mask)

--- a/tests/test_arrow.mojo
+++ b/tests/test_arrow.mojo
@@ -4,6 +4,7 @@ from bison import (
     Column,
     ColumnData,
     DataFrame,
+    NullMask,
     int64,
     float64,
     bool_,
@@ -85,7 +86,7 @@ def test_null_mask_preserved_int64() raises:
     data.append(42)
     data.append(0)
     var col = Column("x", ColumnData(data^), int64)
-    col._null_mask = List[Bool]()
+    col._null_mask = NullMask()
     col._null_mask.append(True)
     col._null_mask.append(False)
     col._null_mask.append(True)
@@ -105,7 +106,7 @@ def test_null_mask_preserved_string() raises:
     data.append("")
     data.append("world")
     var col = Column("s", ColumnData(data^), object_)
-    col._null_mask = List[Bool]()
+    col._null_mask = NullMask()
     col._null_mask.append(False)
     col._null_mask.append(True)
     col._null_mask.append(False)
@@ -164,7 +165,7 @@ def test_dataframe_round_trip_with_nulls() raises:
     d_a.append(0)
     d_a.append(30)
     var col_a = Column("a", ColumnData(d_a^), int64)
-    col_a._null_mask = List[Bool]()
+    col_a._null_mask = NullMask()
     col_a._null_mask.append(False)
     col_a._null_mask.append(True)
     col_a._null_mask.append(False)
@@ -174,7 +175,7 @@ def test_dataframe_round_trip_with_nulls() raises:
     d_b.append("bye")
     d_b.append("")
     var col_b = Column("b", ColumnData(d_b^), object_)
-    col_b._null_mask = List[Bool]()
+    col_b._null_mask = NullMask()
     col_b._null_mask.append(False)
     col_b._null_mask.append(False)
     col_b._null_mask.append(True)
@@ -256,10 +257,10 @@ def test_storage_active_with_null_mask_finalized() raises:
     data.append(0)
     data.append(30)
     var col = Column("d", data^, int64)
-    var mask = List[Bool]()
-    mask.append(False)
-    mask.append(True)
-    mask.append(False)
+    var mask = NullMask()
+    mask.append_valid()
+    mask.append_null()
+    mask.append_valid()
     col._null_mask = mask^
     col._try_activate_storage()
     assert_true(col._storage_active)

--- a/tests/test_groupby.mojo
+++ b/tests/test_groupby.mojo
@@ -2,7 +2,7 @@
 from std.python import Python, PythonObject
 from std.collections import Dict
 from std.testing import assert_equal, TestSuite
-from bison import DataFrame, Series, ColumnData, Column
+from bison import DataFrame, Series, ColumnData, Column, NullMask
 from bison.dtypes import int64 as _bison_int64, float64 as _bison_float64
 from _helpers import assert_frame_equal, assert_series_equal
 
@@ -517,11 +517,11 @@ def test_seriesgroupby_dropna_sum() raises:
     by.append("a")  # string value is ignored because null_mask marks this row as null
     by.append("b")
     by.append("b")
-    var null_mask = List[Bool]()
-    null_mask.append(False)
-    null_mask.append(True)  # row 1 is null-labelled
-    null_mask.append(False)
-    null_mask.append(False)
+    var null_mask = NullMask()
+    null_mask.append_valid()
+    null_mask.append_null()  # row 1 is null-labelled
+    null_mask.append_valid()
+    null_mask.append_valid()
     # dropna=True (the default): null-labelled row should be excluded.
     var result = s.groupby(by, dropna=True, by_null_mask=null_mask).sum()
     var result_pd = result.to_pandas()
@@ -540,11 +540,11 @@ def test_seriesgroupby_dropna_transform_sum() raises:
     by.append("a")
     by.append("b")
     by.append("b")
-    var null_mask = List[Bool]()
-    null_mask.append(False)
-    null_mask.append(True)
-    null_mask.append(False)
-    null_mask.append(False)
+    var null_mask = NullMask()
+    null_mask.append_valid()
+    null_mask.append_null()
+    null_mask.append_valid()
+    null_mask.append_valid()
     var result = s.groupby(by, dropna=True, by_null_mask=null_mask).transform(
         "sum"
     )

--- a/tests/test_interop.mojo
+++ b/tests/test_interop.mojo
@@ -1,7 +1,7 @@
 """Tests for from_pandas / to_pandas interop (these work at stub stage)."""
 from std.python import Python, PythonObject
 from std.testing import assert_equal, assert_true, TestSuite
-from bison import DataFrame, Series, Column, ColumnData, int64, float64, object_
+from bison import DataFrame, Series, Column, ColumnData, NullMask, int64, float64, object_
 from _helpers import assert_frame_equal, assert_series_equal
 
 
@@ -185,10 +185,10 @@ def test_int_column_direct_null_mask_to_pandas() raises:
     data.append(0)
     data.append(30)
     var col = Column("x", ColumnData(data^), int64)
-    var mask = List[Bool]()
-    mask.append(False)
-    mask.append(True)
-    mask.append(False)
+    var mask = NullMask()
+    mask.append_valid()
+    mask.append_null()
+    mask.append_valid()
     col._null_mask = mask^
     # Must not raise even though dtype is int64 and mask has True entries.
     var back = col.to_pandas()
@@ -212,10 +212,10 @@ def test_obj_column_with_null_mask_to_pandas() raises:
     raw.append(Python.evaluate("'should-be-null'"))  # stored value, must be masked
     raw.append(Python.evaluate("'cherry'"))
     var col = Column("fruit", ColumnData(raw^), object_)
-    var mask = List[Bool]()
-    mask.append(False)
-    mask.append(True)   # null — must appear as NaN in pandas output
-    mask.append(False)
+    var mask = NullMask()
+    mask.append_valid()
+    mask.append_null()
+    mask.append_valid()
     col._null_mask = mask^
     var back = col.to_pandas()
     assert_equal(String(py=back[0]), "apple")

--- a/tests/test_io.mojo
+++ b/tests/test_io.mojo
@@ -15,6 +15,7 @@ from bison import (
     Series,
     Column,
     ColumnData,
+    NullMask,
     bool_,
     int64,
     float64,
@@ -449,7 +450,7 @@ def test_parquet_roundtrip_with_nulls() raises:
     d_a.append(0)
     d_a.append(30)
     var col_a = Column("a", ColumnData(d_a^), int64)
-    col_a._null_mask = List[Bool]()
+    col_a._null_mask = NullMask()
     col_a._null_mask.append(False)
     col_a._null_mask.append(True)
     col_a._null_mask.append(False)
@@ -459,7 +460,7 @@ def test_parquet_roundtrip_with_nulls() raises:
     d_b.append("")
     d_b.append("bye")
     var col_b = Column("b", ColumnData(d_b^), object_)
-    col_b._null_mask = List[Bool]()
+    col_b._null_mask = NullMask()
     col_b._null_mask.append(False)
     col_b._null_mask.append(True)
     col_b._null_mask.append(False)
@@ -595,7 +596,7 @@ def test_ipc_roundtrip_with_nulls() raises:
     d_a.append(0.0)
     d_a.append(30.0)
     var col_a = Column("a", ColumnData(d_a^), float64)
-    col_a._null_mask = List[Bool]()
+    col_a._null_mask = NullMask()
     col_a._null_mask.append(False)
     col_a._null_mask.append(True)
     col_a._null_mask.append(False)
@@ -605,7 +606,7 @@ def test_ipc_roundtrip_with_nulls() raises:
     d_b.append("")
     d_b.append("bye")
     var col_b = Column("b", ColumnData(d_b^), object_)
-    col_b._null_mask = List[Bool]()
+    col_b._null_mask = NullMask()
     col_b._null_mask.append(False)
     col_b._null_mask.append(True)
     col_b._null_mask.append(False)


### PR DESCRIPTION
## Summary

- Remove the `@implicit __init__(read mask: List[Bool])` bridge constructor from `NullMask`, replacing it with an explicit `NullMask.from_list()` for the remaining internal callers
- Migrate ~55 call sites across 8 source files and 4 test files to use native `NullMask` API (`append_null()`, `append_valid()`, `NullMask.all_null(n)`, `NullMask.all_valid(n)`)
- Migrate `_FfillVisitor`, `_BfillVisitor`, and `_TakeWithNullsVisitor` result masks from `List[Bool]` to `NullMask`

## Details

The `@implicit` bridge constructor (added in #618) allowed `List[Bool]` to be silently assigned to `NullMask` fields. This bridge allocated a temporary `List[Bool]`, scanned it for nulls, then rebuilt the bitmap — doubling the work. All call sites now build `NullMask` directly, eliminating this overhead.

### Key changes

| File | Sites | What changed |
|------|-------|-------------|
| `column.mojo` | 7 + 3 visitors + bridge deletion | `slice`/`take`/`take_with_nulls`/`concat`/`from_pandas`; `_FfillVisitor`/`_BfillVisitor` result masks; `_TakeWithNullsVisitor` switched to `ColumnDataVisitorRaises`; added `NullMask.from_list()` |
| `_frame.mojo` | ~21 | `from_records`, `shift`, `diff`, `pct_change`, `pivot`, `pivot_table`, `melt`, `stack`, `unstack`, `transpose`, `explode`, `_marrow_agg`, groupby `agg`, `dropna`, `rank` |
| `arrow.mojo` | 4 | `marrow_array_to_column` (int64/float64/bool/string) |
| `reshape/_concat.mojo` | 12 | `_append_piece_mask` signature, `_null_col` uses `all_null(n)`, 7 `_vstack` arms |
| `io/csv.mojo` | 4 | `_infer_and_build_column` (4 dtype branches) |
| `io/json.mojo` | 4 | `_json_build_column` (4 dtype branches) |
| `str_accessor.mojo` | 10 | Default init + 9 methods |
| `dt_accessor.mojo` | 5 | Default init + 4 methods |

### Signature changes

- `Column.slice()`, `Column.take()`, `Column.take_with_nulls()` now declare `raises` (required because `NullMask.append()` raises)
- `DataFrame.head()`, `DataFrame.tail()`, `_df_slice_rows()` propagate `raises` from `slice()`
- `_append_piece_mask` parameter changed from `mut mask: List[Bool]` to `mut mask: NullMask`

### `NullMask.from_list()` — explicit bridge for remaining visitors

The ~20 binary-op visitor structs (`_CmpOpVisitor`, `_ClipVisitor`, `_CumsumVisitor`, etc.) still produce `result_mask: List[Bool]` internally. Rather than migrating all of them in this PR, `_build_result_col` now calls the explicit `NullMask.from_list(result_mask)` conversion. This can be removed in a follow-up that migrates those visitor structs.

## Test plan

- [x] `pixi run test` — 21/21 test files pass (0 failures)
- [x] `pixi run check` — zero warnings (`--Werror`)
- [x] `pixi run lint` — all pre-commit hooks pass
- [x] `pixi run fmt` — no formatting changes

Closes #630

https://claude.ai/code/session_01HzUqA78pAZ1dGgAHhpNpik
