### PR TITLE
feat(#644): add string_ BisonDtype to disambiguate string from object columns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ Versions follow [Semantic Versioning](https://semver.org/).
 ## [Unreleased]
 
 ### Added
+- New `string_` BisonDtype constant (distinct from `object_`) for columns
+  backed by `List[String]`. `DataFrame.dtypes` and `Series.dtype` now return
+  `"string"` for string columns instead of `"object"`. Round-trips through
+  `to_pandas()` still produce pandas `"object"` dtype for compatibility, and
+  `from_pandas()` ingests pandas string / pure-string-object columns as
+  `string_`. `Column.is_string()` and `Column.is_object()` now dispatch on
+  `dtype` (matching the other type predicates); `is_object()` returns `False`
+  for `datetime64_ns` / `timedelta64_ns` columns, matching pandas
+  `dtype == object` semantics. Closes #644.
 - `DataFrame.query()` and `DataFrame.eval()` are now implemented natively in
   Mojo via the `bison.expr` parser and evaluator. Supported grammar: column
   references, integer/float/bool/string/null literals, comparison operators

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -80,6 +80,12 @@ Dtype promotion happens automatically (e.g. mixing int64 + float64 → float64 c
 | `col.is_object()` | `col._data.isa[List[PythonObject]]()` |
 | `col.is_numeric()` | `col._data.isa[List[Int64]]() or col._data.isa[List[Float64]]()` |
 
+After #644, `is_string()` and `is_object()` dispatch on `self.dtype` like the
+other predicates — `is_string()` ⟺ `dtype == string_`, `is_object()` ⟺
+`dtype == object_`. Note that `is_object()` returns `False` for
+`datetime64_ns` / `timedelta64_ns` columns even though they are backed by
+`List[PythonObject]`; this matches pandas `dtype == object` semantics.
+
 For single-cell extraction use `_series_scalar_at(col, row)` or `_scalar_from_col(col, row)` — these read from typed caches when available.
 
 For multi-arm algorithmic dispatch, use `Column._visit_raises[V]()` or `Column._visit[V]()` which route through typed caches when `_storage_active`, falling back to the legacy `visit_col_data_raises()` dispatcher. Visitor structs still implement `ColumnDataVisitorRaises` — the cache dispatch calls their `on_*` methods with cache data instead of `_data`.
@@ -96,7 +102,7 @@ After a predicate check, access the typed data via the unsafe accessors: `col._i
 | `Index` | `index.mojo` | `List[String]` backed with name attribute |
 | `RangeIndex` | `index.mojo` | `start, stop, step` — like pandas |
 | `ColumnIndex` | `index.mojo` | Variant: `Index | List[Int64] | List[Float64] | List[PythonObject]` |
-| `BisonDtype` | `dtypes.mojo` | 14 comptime constants: `int8` … `uint64`, `float32/64`, `bool_`, `object_`, `datetime64_ns`, `timedelta64_ns` |
+| `BisonDtype` | `dtypes.mojo` | 15 comptime constants: `int8` … `uint64`, `float32/64`, `bool_`, `string_`, `object_`, `datetime64_ns`, `timedelta64_ns` |
 
 ### I/O dtype inference order
 

--- a/bison/__init__.mojo
+++ b/bison/__init__.mojo
@@ -14,6 +14,7 @@ from .dtypes import (
     float64,
     bool_,
     object_,
+    string_,
     datetime64_ns,
     timedelta64_ns,
     dtype_from_string,

--- a/bison/_frame.mojo
+++ b/bison/_frame.mojo
@@ -11,6 +11,7 @@ from .dtypes import (
     bool_,
     int64,
     float64,
+    string_,
     dtype_from_string,
     datetime64_ns,
 )
@@ -437,7 +438,7 @@ struct Series(Copyable, ImplicitlyCopyable, Movable):
             var rhs = List[String]()
             for _ in range(n):
                 rhs.append(other)
-            var rhs_col = Column(self._col.name, rhs^, object_)
+            var rhs_col = Column(self._col.name, rhs^, string_)
             return Series(self._col._cmp_eq(rhs_col))
         var result = List[Bool]()
         if self._col.is_object():
@@ -461,7 +462,7 @@ struct Series(Copyable, ImplicitlyCopyable, Movable):
             var rhs = List[String]()
             for _ in range(n):
                 rhs.append(other)
-            var rhs_col = Column(self._col.name, rhs^, object_)
+            var rhs_col = Column(self._col.name, rhs^, string_)
             return Series(self._col._cmp_ne(rhs_col))
         var result = List[Bool]()
         if self._col.is_object():
@@ -1377,7 +1378,7 @@ struct DataFrame(Copyable, Movable):
                         null_mask.append_null()
                     else:
                         null_mask.append_valid()
-                var col = Column(col_name, data^, object_)
+                var col = Column(col_name, data^, string_)
                 col._null_mask = null_mask^
                 col._try_activate_storage()
                 cols.append(col^)
@@ -1522,7 +1523,7 @@ struct DataFrame(Copyable, Movable):
         for i in range(n):
             dtype_names.append(self._cols[i].dtype.name)
             idx.append(PythonObject(self._cols[i].name.value()))
-        var result_col = Column(None, dtype_names^, object_, idx^)
+        var result_col = Column(None, dtype_names^, string_, idx^)
         return Series(result_col^)
 
     def info(self) raises:
@@ -3375,7 +3376,7 @@ struct DataFrame(Copyable, Movable):
                 for i in range(n_idx):
                     str_data.append(str_idx[i])
                 new_cols.append(
-                    Column("index", str_data^, object_, empty_col_idx^)
+                    Column("index", str_data^, string_, empty_col_idx^)
                 )
             elif self._cols[0]._index.isa[List[Int64]]():
                 ref int_idx = self._cols[0]._index[List[Int64]]
@@ -4300,7 +4301,7 @@ struct DataFrame(Copyable, Movable):
         for v in range(n_val):
             for _ in range(nrows):
                 var_data.append(val_names[v])
-        result_cols.append(Column(var_name, var_data^, object_))
+        result_cols.append(Column(var_name, var_data^, string_))
 
         # Value column: concat all value columns row-by-row.
         var val_data = List[PythonObject]()

--- a/bison/accessors/str_accessor.mojo
+++ b/bison/accessors/str_accessor.mojo
@@ -2,7 +2,7 @@ from std.python import Python, PythonObject
 from std.collections import Optional
 from .._errors import _not_implemented
 from ..column import Column, NullMask
-from ..dtypes import BisonDtype, object_, bool_, int64
+from ..dtypes import BisonDtype, object_, bool_, int64, string_
 
 
 struct StringMethods:
@@ -45,7 +45,7 @@ struct StringMethods:
                 result.append(String(""))
             else:
                 result.append(self._data[i].upper())
-        var col = Column(self._name, result^, object_)
+        var col = Column(self._name, result^, string_)
         col._null_mask = self._null_mask.copy()
         return col^
 
@@ -56,7 +56,7 @@ struct StringMethods:
                 result.append(String(""))
             else:
                 result.append(self._data[i].lower())
-        var col = Column(self._name, result^, object_)
+        var col = Column(self._name, result^, string_)
         col._null_mask = self._null_mask.copy()
         return col^
 
@@ -73,7 +73,7 @@ struct StringMethods:
                 result.append(String(self._data[i].strip()))
             else:
                 result.append(String(self._data[i].strip(to_strip)))
-        var col = Column(self._name, result^, object_)
+        var col = Column(self._name, result^, string_)
         col._null_mask = self._null_mask.copy()
         return col^
 
@@ -86,7 +86,7 @@ struct StringMethods:
                 result.append(String(self._data[i].lstrip()))
             else:
                 result.append(String(self._data[i].lstrip(to_strip)))
-        var col = Column(self._name, result^, object_)
+        var col = Column(self._name, result^, string_)
         col._null_mask = self._null_mask.copy()
         return col^
 
@@ -99,7 +99,7 @@ struct StringMethods:
                 result.append(String(self._data[i].rstrip()))
             else:
                 result.append(String(self._data[i].rstrip(to_strip)))
-        var col = Column(self._name, result^, object_)
+        var col = Column(self._name, result^, string_)
         col._null_mask = self._null_mask.copy()
         return col^
 
@@ -172,7 +172,7 @@ struct StringMethods:
                 result.append(String(sub_result))
             else:
                 result.append(self._data[i].replace(pat, repl))
-        var col = Column(self._name, result^, object_)
+        var col = Column(self._name, result^, string_)
         col._null_mask = self._null_mask.copy()
         return col^
 
@@ -278,7 +278,7 @@ struct StringMethods:
                         j += 1
                     result.append(char_val)
                     new_mask.append_valid()
-        var col = Column(self._name, result^, object_)
+        var col = Column(self._name, result^, string_)
         col._null_mask = new_mask^
         return col^
 
@@ -305,7 +305,7 @@ struct StringMethods:
                     j += 1
                 result.append(sub)
                 new_mask.append_valid()
-        var col = Column(self._name, result^, object_)
+        var col = Column(self._name, result^, string_)
         col._null_mask = new_mask^
         return col^
 

--- a/bison/arrow.mojo
+++ b/bison/arrow.mojo
@@ -27,7 +27,7 @@ from marrow.schema import Schema as _MarrowSchema
 from marrow.tabular import RecordBatch, Table
 from .column import Column, ColumnData, ColumnStorage, NullMask
 from .dataframe import DataFrame
-from .dtypes import int64, float64, bool_, object_
+from .dtypes import int64, float64, bool_, object_, string_
 
 
 # ------------------------------------------------------------------
@@ -84,7 +84,7 @@ def column_to_marrow_array(col: Column) raises -> AnyArray:
                 vals.append(src[i])
         return AnyArray(array(vals^))
 
-    elif col._data.isa[List[String]]():
+    elif col.is_string():
         ref src = col._data[List[String]]
         var b = StringBuilder(capacity=n)
         for i in range(n):
@@ -183,7 +183,8 @@ def marrow_array_to_column(arr: AnyArray, name: String) raises -> Column:
             else:
                 data.append(String(src.unsafe_get(UInt(i))))
                 null_mask.append_valid()
-        var col = Column(name, ColumnData(data^), object_)
+        # #644: string-backed columns carry string_ dtype.
+        var col = Column(name, ColumnData(data^), string_)
         if null_mask.has_nulls():
             col._null_mask = null_mask^
         col._storage = ColumnStorage(arr.copy())

--- a/bison/column.mojo
+++ b/bison/column.mojo
@@ -41,6 +41,7 @@ from .dtypes import (
     float64,
     bool_,
     object_,
+    string_,
     datetime64_ns,
     timedelta64_ns,
     dtype_from_string,
@@ -566,8 +567,8 @@ struct _DtypeSniffVisitor(ColumnDataVisitor, Copyable, Movable):
 
     var result: BisonDtype
 
-    # object_ is the safe fallback: both List[String] and List[PythonObject]
-    # map to object_.  The field is always overwritten by on_*.
+    # object_ is the safe fallback; the field is always overwritten by on_*.
+    # #644: List[String] → string_, List[PythonObject] → object_.
     def __init__(out self):
         self.result = object_
 
@@ -581,7 +582,7 @@ struct _DtypeSniffVisitor(ColumnDataVisitor, Copyable, Movable):
         self.result = bool_
 
     def on_str(mut self, data: List[String]):
-        self.result = object_
+        self.result = string_
 
     def on_obj(mut self, data: List[PythonObject]):
         self.result = object_
@@ -620,7 +621,7 @@ struct _FillScalarVisitor(Copyable, DFScalarVisitorRaises, Movable):
     After visiting, construct the Column via
     ``Column(name, visitor._col_data^, visitor._dtype, index)``.
     The dtype is inferred from the DFScalar arm: Int64 → int64,
-    Float64 → float64, Bool → bool_, String → object_.
+    Float64 → float64, Bool → bool_, String → string_ (#644).
     ``on_null`` raises because a null fill value is not meaningful here.
     ``_col_data`` is initialised with the List[PythonObject] fallback arm
     (following _CopyDataVisitor), but it is always replaced by an ``on_*``
@@ -662,7 +663,7 @@ struct _FillScalarVisitor(Copyable, DFScalarVisitorRaises, Movable):
         for _ in range(self._n):
             data.append(value)
         self._col_data = ColumnData(data^)
-        self._dtype = object_
+        self._dtype = string_
 
     def on_null(mut self) raises:
         raise Error("_fill_scalar: fill value cannot be null")
@@ -4893,7 +4894,11 @@ struct Column(Copyable, ImplicitlyCopyable, Movable, Sized):
         var data: List[String],
         dtype: BisonDtype,
     ):
-        self = Self(name, ColumnData(data^), dtype)
+        # #644: List[String] columns always carry string_ dtype. The dtype
+        # parameter is preserved for caller compatibility but ignored here
+        # to keep the invariant dtype == string_ ⟺ _data is List[String].
+        _ = dtype
+        self = Self(name, ColumnData(data^), string_)
         self._try_activate_storage()
 
     def __init__(
@@ -4903,7 +4908,9 @@ struct Column(Copyable, ImplicitlyCopyable, Movable, Sized):
         dtype: BisonDtype,
         var index: ColumnIndex,
     ):
-        self = Self(name, ColumnData(data^), dtype, index^)
+        # #644: see note above — dtype arg is ignored, forced to string_.
+        _ = dtype
+        self = Self(name, ColumnData(data^), string_, index^)
         self._try_activate_storage()
 
     def __init__(
@@ -5035,8 +5042,15 @@ struct Column(Copyable, ImplicitlyCopyable, Movable, Sized):
     # ------------------------------------------------------------------
 
     def is_object(self) -> Bool:
-        """Return True if the active storage arm is ``List[PythonObject]``."""
-        return self._data.isa[List[PythonObject]]()
+        """Return True if this column has ``object_`` dtype.
+
+        After #644, this is a dtype-based check (matching the other
+        type predicates). Note that ``datetime64_ns`` / ``timedelta64_ns``
+        columns are backed by ``List[PythonObject]`` but carry their own
+        dtype, so they return ``False`` here — matching pandas
+        ``dtype == object`` semantics, which also excludes datetimes.
+        """
+        return self.dtype == object_
 
     def is_numeric(self) -> Bool:
         """Return True if the active storage arm is int64 or float64."""
@@ -5055,8 +5069,13 @@ struct Column(Copyable, ImplicitlyCopyable, Movable, Sized):
         return self.dtype == bool_
 
     def is_string(self) -> Bool:
-        """Return True if the active storage arm is ``List[String]``."""
-        return self._data.isa[List[String]]()
+        """Return True if this column has ``string_`` dtype.
+
+        After #644, this is a dtype-based check (matching the other
+        type predicates). Equivalent to the active ``_data`` arm being
+        ``List[String]``.
+        """
+        return self.dtype == string_
 
     # ------------------------------------------------------------------
     # Dual-backend null/validity helpers (#619, Phase 1)
@@ -7594,7 +7613,8 @@ struct Column(Copyable, ImplicitlyCopyable, Movable, Sized):
                     data.append(String(""))  # placeholder for null
                 else:
                     data.append(String(py_list[i]))
-            var col = Column(name, ColumnData(data^), object_, bison_idx^)
+            # #644: string-backed columns carry string_ dtype.
+            var col = Column(name, ColumnData(data^), string_, bison_idx^)
             col._null_mask = null_mask.copy()
             col._index_name = idx_name
             col._try_activate_storage()
@@ -7620,8 +7640,9 @@ struct Column(Copyable, ImplicitlyCopyable, Movable, Sized):
                             str_data.append(String(""))
                         else:
                             str_data.append(String(py_list[i]))
+                    # #644: promoted string columns carry string_ dtype.
                     var col = Column(
-                        name, ColumnData(str_data^), object_, bison_idx^
+                        name, ColumnData(str_data^), string_, bison_idx^
                     )
                     col._null_mask = null_mask^
                     col._index_name = idx_name
@@ -7682,6 +7703,13 @@ struct Column(Copyable, ImplicitlyCopyable, Movable, Sized):
             for _ in range(n):
                 data.append(False)
             c = Column(name, ColumnData(data^), bool_, index^)
+        elif dtype == string_:
+            # #644: string_ columns must be backed by List[String] to
+            # preserve the dtype == string_ ⟺ _data is List[String] invariant.
+            var data = List[String]()
+            for _ in range(n):
+                data.append(String(""))
+            c = Column(name, ColumnData(data^), string_, index^)
         else:
             var data = List[PythonObject]()
             var py_none = Python.evaluate("None")
@@ -7698,7 +7726,7 @@ struct Column(Copyable, ImplicitlyCopyable, Movable, Sized):
         """Create a Column of length *n* with every element equal to *value*.
 
         The dtype is inferred from the DFScalar arm: Int64 → int64, Float64 → float64,
-        Bool → bool_, String → object (matching pandas string storage).
+        Bool → bool_, String → string_ (#644).
         Raises if *value* is null — use the null-mask path instead.
         """
         var visitor = _FillScalarVisitor(n)
@@ -7717,6 +7745,12 @@ struct Column(Copyable, ImplicitlyCopyable, Movable, Sized):
         # corresponding pandas nullable integer dtype (e.g. "Int64") so that
         # the None entries in py_list are accepted without raising.
         var dtype_name = self.dtype.name
+        # #644: map string_ → pandas "object" so to_pandas / from_pandas
+        # round-trips are idempotent. Pandas "string" dtype is the nullable
+        # StringDtype with pd.NA semantics; keeping "object" preserves
+        # existing behaviour.
+        if dtype_name == "string":
+            dtype_name = "object"
         if self.dtype.is_integer():
             var has_nulls = False
             for i in range(len(self._null_mask)):

--- a/bison/dtypes.mojo
+++ b/bison/dtypes.mojo
@@ -55,6 +55,7 @@ comptime float32 = BisonDtype("float32", 4)
 comptime float64 = BisonDtype("float64", 8)
 comptime bool_ = BisonDtype("bool", 1)
 comptime object_ = BisonDtype("object", 8)
+comptime string_ = BisonDtype("string", 8)
 comptime datetime64_ns = BisonDtype("datetime64[ns]", 8)
 comptime timedelta64_ns = BisonDtype("timedelta64[ns]", 8)
 
@@ -88,6 +89,8 @@ def dtype_from_string(name: String) raises -> BisonDtype:
         return bool_
     if name == "object":
         return object_
+    if name == "string":
+        return string_
     if name == "datetime64[ns]":
         return datetime64_ns
     if name == "timedelta64[ns]":

--- a/bison/io/csv.mojo
+++ b/bison/io/csv.mojo
@@ -2,7 +2,7 @@ from std.python import Python, PythonObject
 from std.collections import Optional
 from ..dataframe import DataFrame
 from ..column import Column, NullMask
-from ..dtypes import int64, float64, object_, bool_
+from ..dtypes import int64, float64, object_, bool_, string_
 
 
 # ------------------------------------------------------------------
@@ -42,7 +42,7 @@ def _infer_and_build_column(
     var n = len(raw)
 
     if n == 0:
-        var empty = Column(name, List[String](), object_)
+        var empty = Column(name, List[String](), string_)
         empty._try_activate_storage()
         return empty^
 
@@ -132,7 +132,7 @@ def _infer_and_build_column(
         return col^
 
     # ------------------------------------------------------------------
-    # Default: String (stored as List[String] with object_ dtype)
+    # Default: String (stored as List[String] with string_ dtype, #644)
     # ------------------------------------------------------------------
     var data = List[String]()
     var null_mask = NullMask()
@@ -143,7 +143,7 @@ def _infer_and_build_column(
         else:
             data.append(raw[i])
             null_mask.append_valid()
-    var col = Column(name, data^, object_)
+    var col = Column(name, data^, string_)
     if null_mask.has_nulls():
         col._null_mask = null_mask^
     col._try_activate_storage()

--- a/bison/io/json.mojo
+++ b/bison/io/json.mojo
@@ -2,7 +2,7 @@ from std.python import Python, PythonObject
 from std.collections import Optional
 from ..dataframe import DataFrame
 from ..column import Column, NullMask
-from ..dtypes import int64, float64, object_, bool_
+from ..dtypes import int64, float64, object_, bool_, string_
 
 
 # ------------------------------------------------------------------
@@ -123,7 +123,7 @@ def _json_build_column(
             else:
                 data.append(String(val))
                 null_mask.append_valid()
-        var col = Column(name, data^, object_)
+        var col = Column(name, data^, string_)
         if null_mask.has_nulls():
             col._null_mask = null_mask^
         col._try_activate_storage()

--- a/bison/reshape/_concat.mojo
+++ b/bison/reshape/_concat.mojo
@@ -2,7 +2,7 @@ from std.python import Python, PythonObject
 from std.collections import Optional
 from ..dataframe import DataFrame, _sort_col_names
 from ..column import Column, NullMask
-from ..dtypes import BisonDtype, int64, float64, bool_, object_
+from ..dtypes import BisonDtype, int64, float64, bool_, object_, string_
 from .._errors import _not_implemented
 
 
@@ -123,6 +123,16 @@ def _null_col(
         col._null_mask = NullMask.all_null(n)
         col._try_activate_storage()
         return col^
+    elif dtype == string_:
+        # #644: preserve the string_ ⟺ List[String] invariant for all-null
+        # string columns inserted by outer joins / aligns.
+        var data = List[String]()
+        for _ in range(n):
+            data.append(String(""))
+        var col = Column(name, data^, string_)
+        col._null_mask = NullMask.all_null(n)
+        col._try_activate_storage()
+        return col^
     else:
         var data = List[PythonObject]()
         for _ in range(n):
@@ -140,7 +150,7 @@ def _build_key_col(keys: List[String], counts: List[Int]) raises -> Column:
     for i in range(len(keys)):
         for _ in range(counts[i]):
             data.append(keys[i])
-    var col = Column(Optional[String]("__key__"), data^, object_)
+    var col = Column(Optional[String]("__key__"), data^, string_)
     col._try_activate_storage()
     return col^
 
@@ -206,7 +216,7 @@ def _common_dtype(pieces: List[Column]) -> Optional[BisonDtype]:
     * ``int64``   — every piece holds ``List[Int64]``
     * ``float64`` — every piece holds ``List[Float64]``
     * ``bool_``   — every piece holds ``List[Bool]``
-    * ``object_`` — every piece holds ``List[String]``
+    * ``string_`` — every piece holds ``List[String]``
     """
     if len(pieces) == 0:
         return None
@@ -230,7 +240,7 @@ def _common_dtype(pieces: List[Column]) -> Optional[BisonDtype]:
     if is_bool:
         return bool_
     if is_str:
-        return object_
+        return string_
     return None
 
 
@@ -305,8 +315,8 @@ def _vstack(pieces: List[Column]) raises -> Column:
             col._null_mask = mask^
         col._try_activate_storage()
         return col^
-    elif common and common.value() == object_:
-        # All pieces hold List[String]; keep the string arm intact.
+    elif common and common.value() == string_:
+        # #644: All pieces hold List[String]; keep the string arm intact.
         var data = List[String]()
         var mask = NullMask()
         for i in range(len(pieces)):

--- a/tests/test_arrow.mojo
+++ b/tests/test_arrow.mojo
@@ -9,6 +9,7 @@ from bison import (
     float64,
     bool_,
     object_,
+    string_,
     column_to_marrow_array,
     marrow_array_to_column,
     dataframe_to_record_batch,
@@ -64,12 +65,12 @@ def test_bool_round_trip_no_nulls() raises:
 
 
 def test_string_round_trip_no_nulls() raises:
-    """String column survives Arrow round-trip (uses object_ dtype)."""
+    """String column survives Arrow round-trip (uses string_ dtype, #644)."""
     var data = List[String]()
     data.append("x")
     data.append("y")
     data.append("z")
-    var col = Column("d", ColumnData(data^), object_)
+    var col = Column("d", ColumnData(data^), string_)
     var arr = column_to_marrow_array(col)
     var col2 = marrow_array_to_column(arr^, "d")
     assert_equal(len(col2), 3)
@@ -105,7 +106,7 @@ def test_null_mask_preserved_string() raises:
     data.append("hello")
     data.append("")
     data.append("world")
-    var col = Column("s", ColumnData(data^), object_)
+    var col = Column("s", ColumnData(data^), string_)
     col._null_mask = NullMask()
     col._null_mask.append(False)
     col._null_mask.append(True)
@@ -138,7 +139,7 @@ def test_dataframe_round_trip() raises:
     var cols = List[Column]()
     cols.append(Column("a", ColumnData(d1^), int64))
     cols.append(Column("b", ColumnData(d2^), float64))
-    cols.append(Column("c", ColumnData(d3^), object_))
+    cols.append(Column("c", ColumnData(d3^), string_))
     var df = DataFrame(cols^)
 
     var rb = dataframe_to_record_batch(df)
@@ -174,7 +175,7 @@ def test_dataframe_round_trip_with_nulls() raises:
     d_b.append("hi")
     d_b.append("bye")
     d_b.append("")
-    var col_b = Column("b", ColumnData(d_b^), object_)
+    var col_b = Column("b", ColumnData(d_b^), string_)
     col_b._null_mask = NullMask()
     col_b._null_mask.append(False)
     col_b._null_mask.append(False)

--- a/tests/test_concat.mojo
+++ b/tests/test_concat.mojo
@@ -1,7 +1,7 @@
 """Tests for bison.concat."""
 from std.python import Python, PythonObject
 from std.testing import assert_true, assert_equal, TestSuite
-from bison import DataFrame, concat, int64, float64
+from bison import DataFrame, Column, concat, int64, float64, string_
 
 
 def test_concat_empty_list() raises:
@@ -276,6 +276,28 @@ def test_concat_dtype_promotion_outer_join() raises:
     # y is only present in df2, so it must be int64 (no promotion needed)
     var s_y = result["y"]
     assert_equal(s_y.iloc(1)[Int64], Int64(10))
+
+
+def test_concat_string_columns_preserves_string_dtype() raises:
+    """Concatenating two string DataFrames produces a string_ column (#644)."""
+    var d1 = List[String]()
+    d1.append("a")
+    d1.append("b")
+    var d2 = List[String]()
+    d2.append("c")
+    d2.append("d")
+    var cols1 = List[Column]()
+    cols1.append(Column("s", d1^, string_))
+    var cols2 = List[Column]()
+    cols2.append(Column("s", d2^, string_))
+    var df1 = DataFrame(cols1^)
+    var df2 = DataFrame(cols2^)
+    var frames = List[DataFrame]()
+    frames.append(df1^)
+    frames.append(df2^)
+    var df3 = concat(frames^)
+    assert_equal(df3._cols[0].dtype.name, "string")
+    assert_equal(df3._cols[0].__len__(), 4)
 
 
 def main() raises:

--- a/tests/test_interop.mojo
+++ b/tests/test_interop.mojo
@@ -1,7 +1,7 @@
 """Tests for from_pandas / to_pandas interop (these work at stub stage)."""
 from std.python import Python, PythonObject
-from std.testing import assert_equal, assert_true, TestSuite
-from bison import DataFrame, Series, Column, ColumnData, NullMask, int64, float64, object_
+from std.testing import assert_equal, assert_true, assert_false, TestSuite
+from bison import DataFrame, Series, Column, ColumnData, NullMask, int64, float64, object_, string_
 from _helpers import assert_frame_equal, assert_series_equal
 
 
@@ -90,7 +90,8 @@ def test_column_typed_storage() raises:
     var col_obj = Column.from_pandas(s_obj, "o")
     assert_true(col_obj._data.isa[List[String]](), "pure-string object column should be promoted to List[String]")
     assert_equal(col_obj.__len__(), 2)
-    assert_equal(col_obj.dtype.name, "object")
+    # #644: promoted string columns carry string_ dtype (not object_).
+    assert_equal(col_obj.dtype.name, "string")
 
 
 def test_series_index_roundtrip() raises:
@@ -236,7 +237,10 @@ def test_string_promotion_from_pandas() raises:
         name_col._data.isa[List[String]](),
         "pure-string column should be promoted to List[String]",
     )
-    assert_equal(name_col.dtype.name, "object")
+    # #644: promoted string columns now carry string_ dtype.
+    assert_equal(name_col.dtype.name, "string")
+    assert_true(name_col.is_string())
+    assert_false(name_col.is_object())
     # 'val' column should remain List[Int64]
     ref val_col = df._cols[1]
     assert_true(
@@ -268,6 +272,8 @@ def test_string_promotion_with_nulls() raises:
         col._data.isa[List[String]](),
         "string column with nulls should promote to List[String]",
     )
+    # #644: promoted string column carries string_ dtype.
+    assert_equal(col.dtype.name, "string")
     assert_equal(col.__len__(), 3)
     # Null mask: position 1 should be null
     assert_true(not col._null_mask[0], "position 0 should not be null")
@@ -287,6 +293,8 @@ def test_string_promotion_roundtrip() raises:
         df._cols[0]._data.isa[List[String]](),
         "city column should be promoted to List[String]",
     )
+    # #644: promoted string column carries string_ dtype.
+    assert_equal(df._cols[0].dtype.name, "string")
     # Round-trip back to pandas — verify values match
     var back = df.to_pandas()
     assert_equal(Int(py=back.shape[0]), 3)
@@ -324,7 +332,71 @@ def test_empty_object_column_promoted() raises:
         col._data.isa[List[String]](),
         "empty object column should promote to List[String]",
     )
+    # #644: empty promoted string column carries string_ dtype.
+    assert_equal(col.dtype.name, "string")
     assert_equal(col.__len__(), 0)
+
+
+def test_string_dtype_distinct_from_object() raises:
+    """A List[String] column carries string_ dtype, distinct from object_ (#644)."""
+    var data = List[String]()
+    data.append("a")
+    data.append("b")
+    # Note: the dtype arg is intentionally ``object_`` to verify that the
+    # List[String] constructor force-overrides it to ``string_``.
+    var col = Column("x", data^, object_)
+    assert_equal(col.dtype.name, "string")
+    assert_true(col.is_string())
+    assert_false(col.is_object())
+    assert_true(col.dtype == string_)
+    assert_false(col.dtype == object_)
+
+
+def test_object_dtype_distinct_from_string() raises:
+    """A List[PythonObject] column carries object_ dtype, distinct from string_ (#644).
+    """
+    var raw = List[PythonObject]()
+    raw.append(Python.evaluate("'a'"))
+    raw.append(Python.evaluate("42"))
+    var col = Column("x", ColumnData(raw^), object_)
+    assert_equal(col.dtype.name, "object")
+    assert_true(col.is_object())
+    assert_false(col.is_string())
+
+
+def test_string_dtype_round_trip_pandas() raises:
+    """A string_ column round-trips through to_pandas → from_pandas (#644)."""
+    var data = List[String]()
+    data.append("x")
+    data.append("y")
+    data.append("z")
+    var col = Column("s", data^, string_)
+    assert_equal(col.dtype.name, "string")
+    var ser = col.to_pandas()
+    # to_pandas maps string_ → pandas "object" for round-trip stability.
+    assert_equal(String(ser.dtype), "object")
+    var col2 = Column.from_pandas(ser, "s")
+    assert_equal(col2.dtype.name, "string")
+    assert_true(col2.is_string())
+
+
+def test_dataframe_dtypes_renders_string() raises:
+    """DataFrame.dtypes renders string columns as 'string' (#644)."""
+    var d_str = List[String]()
+    d_str.append("a")
+    d_str.append("b")
+    var d_int = List[Int64]()
+    d_int.append(Int64(1))
+    d_int.append(Int64(2))
+    var cols = List[Column]()
+    cols.append(Column("s", d_str^, string_))
+    cols.append(Column("i", d_int^, int64))
+    var df = DataFrame(cols^)
+    var dts = df.dtypes()
+    var back = dts.to_pandas()
+    # back is a pandas Series indexed by column name.
+    assert_equal(String(py=back["s"]), "string")
+    assert_equal(String(py=back["i"]), "int64")
 
 
 def main() raises:

--- a/tests/test_io.mojo
+++ b/tests/test_io.mojo
@@ -20,6 +20,7 @@ from bison import (
     int64,
     float64,
     object_,
+    string_,
 )
 
 
@@ -425,7 +426,7 @@ def test_parquet_roundtrip_bool_string() raises:
     d_name.append("carol")
     var cols = List[Column]()
     cols.append(Column("flag", ColumnData(d_flag^), bool_))
-    cols.append(Column("name", ColumnData(d_name^), object_))
+    cols.append(Column("name", ColumnData(d_name^), string_))
     var df = DataFrame(cols^)
 
     df.to_parquet(path)
@@ -459,7 +460,7 @@ def test_parquet_roundtrip_with_nulls() raises:
     d_b.append("hi")
     d_b.append("")
     d_b.append("bye")
-    var col_b = Column("b", ColumnData(d_b^), object_)
+    var col_b = Column("b", ColumnData(d_b^), string_)
     col_b._null_mask = NullMask()
     col_b._null_mask.append(False)
     col_b._null_mask.append(True)
@@ -570,7 +571,7 @@ def test_ipc_roundtrip_bool_string() raises:
     d_name.append("carol")
     var cols = List[Column]()
     cols.append(Column("flag", ColumnData(d_flag^), bool_))
-    cols.append(Column("name", ColumnData(d_name^), object_))
+    cols.append(Column("name", ColumnData(d_name^), string_))
     var df = DataFrame(cols^)
 
     write_ipc(df, path)
@@ -605,7 +606,7 @@ def test_ipc_roundtrip_with_nulls() raises:
     d_b.append("hi")
     d_b.append("")
     d_b.append("bye")
-    var col_b = Column("b", ColumnData(d_b^), object_)
+    var col_b = Column("b", ColumnData(d_b^), string_)
     col_b._null_mask = NullMask()
     col_b._null_mask.append(False)
     col_b._null_mask.append(True)


### PR DESCRIPTION
## Summary

Closes #644. Part of the Phase 6c dual-backend Column storage migration (#619) — a prerequisite for deleting `Column._data` in #647.

Introduces a distinct `string_ = BisonDtype("string", 8)` constant so `Column.is_string()` and `Column.is_object()` can dispatch on `self.dtype` like the other type predicates. These were previously the only two predicates relying on raw `_data.isa[...]()` checks, blocking the removal of `_data` as a type discriminant.

**Invariants established:**
- `dtype == string_` ⟺ `_data` arm is `List[String]`
- `dtype == object_` ⟺ `_data` arm is `List[PythonObject]` (and **not** `datetime64_ns` / `timedelta64_ns`)

## User-visible behaviour changes

- `Series.dtype` and `DataFrame.dtypes` now render string columns as `"string"` instead of `"object"`.
- `to_pandas()` still maps `string_` → pandas `"object"` to preserve round-trip stability (pandas' nullable `StringDtype` uses `pd.NA` semantics).
- `is_object()` now returns `False` for `datetime64_ns` / `timedelta64_ns` columns — matching pandas `dtype == object` semantics, which also excludes datetimes.

## Implementation notes

- **Force-override in `List[String]` constructors** (`column.mojo:4890-4907`): the typed overloads ignore the `dtype` argument and always pass `string_` to the canonical constructor. This is defense-in-depth so a stray caller passing `object_` cannot silently violate the invariant. The `dtype` parameter is left in place for caller-signature compatibility; dropping it is queued as a follow-up.
- **Predicates** (`column.mojo:5037, 5057`): `is_string()` → `self.dtype == string_`, `is_object()` → `self.dtype == object_`. Docstrings updated to spell out the dtype-based semantics and the datetime/timedelta exclusion.
- **`to_pandas` mapping** (`column.mojo:~7740`): after reading `self.dtype.name`, remap `"string"` → `"object"` before constructing the pandas Series.
- **Null-column builders**: `_null_column` and `reshape/_concat.mojo::_null_col` now have explicit `string_` branches that build `List[String]` (filled with `""` plus null mask) instead of falling through to `List[PythonObject]`, preserving the invariant for joins/aligns that insert null rows.
- **Concat promotion** (`reshape/_concat.mojo`): `_common_dtype` returns `string_` for homogeneous string pieces, and `_vstack` selects its string branch on `common.value() == string_`.
- **arrow.mojo:87**: swapped a direct `_data.isa[List[String]]()` check for `col.is_string()` for consistency with `column.mojo`'s internal dispatch.

## What is out of scope

- Deletion of `Column._data` (#647).
- Migrating the canonical `visit_col_data*` dispatchers and other cross-arm `isa` chains — these need `_data` to stay around until #647.
- Mapping `string_` → pandas `"string"` (nullable StringDtype). Explicitly rejected; would break round-trip.
- Dropping the now-vestigial `dtype` parameter from the `List[String]` typed overloads — queued as a follow-up.

## Test plan

- [x] `pixi run fmt` — clean, no diffs
- [x] `pixi run check` — `mojo package bison/ --Werror`, zero warnings
- [x] `pixi run test` — full suite, **940 tests pass, 0 failures, 0 skipped**
- [x] New tests added in `tests/test_interop.mojo`:
  - `test_string_dtype_distinct_from_object` — verifies force-override and dtype-based predicates
  - `test_object_dtype_distinct_from_string` — verifies object columns still carry `object_`
  - `test_string_dtype_round_trip_pandas` — verifies `string_` → pandas `"object"` → `string_`
  - `test_dataframe_dtypes_renders_string` — verifies user-visible rendering
- [x] New test in `tests/test_concat.mojo`:
  - `test_concat_string_columns_preserves_string_dtype` — verifies concat promotion
- [x] Pre-commit hooks all green (trailing whitespace, EOF, merge-conflict, `_not_implemented` enforcement, `mojo format`, `mojo build --Werror`)

https://claude.ai/code/session_01CYp86SduHwoV6mQndgcHHi