### PR TITLE
feat(#646): migrate _frame.mojo read sites off legacy _data to typed caches

### DIFF
--- a/bison/_frame.mojo
+++ b/bison/_frame.mojo
@@ -442,7 +442,7 @@ struct Series(Copyable, ImplicitlyCopyable, Movable):
             return Series(self._col._cmp_eq(rhs_col))
         var result = List[Bool]()
         if self._col.is_object():
-            ref d = self._col._obj_data()
+            ref d = self._col._storage_legacy().data
             for i in range(n):
                 if self._col._null_mask.is_null(i):
                     result.append(False)
@@ -466,7 +466,7 @@ struct Series(Copyable, ImplicitlyCopyable, Movable):
             return Series(self._col._cmp_ne(rhs_col))
         var result = List[Bool]()
         if self._col.is_object():
-            ref d = self._col._obj_data()
+            ref d = self._col._storage_legacy().data
             for i in range(n):
                 if self._col._null_mask.is_null(i):
                     result.append(True)
@@ -961,29 +961,14 @@ struct Series(Copyable, ImplicitlyCopyable, Movable):
         ref col = self._col
         var nan = Float64(0) / Float64(0)
         var n = col.__len__()
-        if col.is_int():
-            ref data = col._int64_data()
-            for i in range(n):
-                if col._null_mask.is_null(i):
-                    result.append(nan)
-                else:
-                    result.append(Float64(data[i]))
-        elif col.is_float():
-            ref data = col._float64_data()
-            for i in range(n):
-                if col._null_mask.is_null(i):
-                    result.append(nan)
-                else:
-                    result.append(data[i])
-        elif col.is_bool():
-            ref data = col._bool_data()
-            for i in range(n):
-                if col._null_mask.is_null(i):
-                    result.append(nan)
-                else:
-                    result.append(Float64(1.0) if data[i] else Float64(0.0))
-        else:
+        if not (col.is_int() or col.is_float() or col.is_bool()):
             raise Error("Series.to_numpy: non-numeric dtype is not supported")
+        ref data = col._f64_cache
+        for i in range(n):
+            if col._null_mask.is_null(i):
+                result.append(nan)
+            else:
+                result.append(data[i])
         return result^
 
     def to_frame(self, name: Optional[String] = None) raises -> DataFrame:
@@ -1084,7 +1069,7 @@ struct Series(Copyable, ImplicitlyCopyable, Movable):
     def str(self) raises -> StringMethods:
         if not self._col.is_string():
             raise Error("Series.str: accessor requires a string Series")
-        ref d = self._col._data[List[String]]
+        ref d = self._col._str_cache
         var data = d.copy()
         var null_mask = self._col._null_mask.copy()
         return StringMethods(data^, null_mask^, self._col.name)
@@ -1092,7 +1077,7 @@ struct Series(Copyable, ImplicitlyCopyable, Movable):
     def dt(self) raises -> DatetimeMethods:
         if self._col.dtype != datetime64_ns:
             raise Error("Series.dt: accessor requires a datetime Series")
-        ref d = self._col._data[List[PythonObject]]
+        ref d = self._col._storage_legacy().data
         var data = d.copy()
         var null_mask = self._col._null_mask.copy()
         return DatetimeMethods(data^, null_mask^, self._col.name)
@@ -1647,7 +1632,7 @@ struct DataFrame(Copyable, Movable):
             )
         var indices = List[Int]()
         if mask._col.is_bool():
-            ref d = mask._col._bool_data()
+            ref d = mask._col._bool_cache
             for i in range(mask_len):
                 if mask._col._null_mask.is_valid(i) and d[i]:
                     indices.append(i)
@@ -1882,10 +1867,7 @@ struct DataFrame(Copyable, Movable):
                 if not skipna:
                     vals.append(nan)
                 continue
-            if col.dtype.is_integer():
-                vals.append(Float64(col._int64_data()[row]))
-            else:
-                vals.append(col._float64_data()[row])
+            vals.append(col._f64_cache[row])
         return vals^
 
     def _row_non_null_count(self, row: Int) -> Int:
@@ -2085,18 +2067,15 @@ struct DataFrame(Copyable, Movable):
                     if col._null_mask.is_null(i):
                         continue
                     var key: String
-                    ref cd = col._data
-                    if cd.isa[List[Int64]]():
+                    if col.is_int() or col.is_float():
                         # Represent as Float64 so int 1 == float 1.0 (matches pandas)
-                        key = "n:" + String(Float64(Int(cd[List[Int64]][i])))
-                    elif cd.isa[List[Float64]]():
-                        key = "n:" + String(cd[List[Float64]][i])
-                    elif cd.isa[List[Bool]]():
-                        key = "b:" + ("1" if cd[List[Bool]][i] else "0")
-                    elif cd.isa[List[String]]():
-                        key = "s:" + cd[List[String]][i]
+                        key = "n:" + String(col._f64_cache[i])
+                    elif col.is_bool():
+                        key = "b:" + ("1" if col._bool_cache[i] else "0")
+                    elif col.is_string():
+                        key = "s:" + col._str_cache[i]
                     else:
-                        key = "o:" + String(cd[List[PythonObject]][i])
+                        key = "o:" + String(col._storage_legacy().data[i])
                     seen[key] = True
                 results.append(Float64(len(seen)))
             return Series(Column(None, results^, float64))
@@ -2263,9 +2242,7 @@ struct DataFrame(Copyable, Movable):
                         propagate_nan = True
                     result_lists[ci].append(nan if propagate_nan else running)
                 else:
-                    var v = Float64(
-                        col._int64_data()[i]
-                    ) if col.dtype.is_integer() else col._float64_data()[i]
+                    var v = col._f64_cache[i]
                     comptime if op == _CUM_SUM:
                         running += v
                     elif op == _CUM_PROD:
@@ -2579,11 +2556,8 @@ struct DataFrame(Copyable, Movable):
                         if is_null:
                             values.append(nan)
                             null_mask.append_null()
-                        elif src_col.dtype.is_integer():
-                            values.append(Float64(src_col._int64_data()[i]))
-                            null_mask.append_valid()
                         else:
-                            values.append(src_col._float64_data()[i])
+                            values.append(src_col._f64_cache[i])
                             null_mask.append_valid()
                 var col = Column(self._cols[j].name, values^, float64)
                 if null_mask.has_nulls():
@@ -2644,16 +2618,8 @@ struct DataFrame(Copyable, Movable):
                             values.append(nan)
                             null_mask.append_null()
                         else:
-                            var cur_val: Float64
-                            if cur_col.dtype.is_integer():
-                                cur_val = Float64(cur_col._int64_data()[i])
-                            else:
-                                cur_val = cur_col._float64_data()[i]
-                            var src_val: Float64
-                            if src_col.dtype.is_integer():
-                                src_val = Float64(src_col._int64_data()[i])
-                            else:
-                                src_val = src_col._float64_data()[i]
+                            var cur_val = cur_col._f64_cache[i]
+                            var src_val = src_col._f64_cache[i]
                             values.append(cur_val - src_val)
                             null_mask.append_valid()
                 var col = Column(self._cols[j].name, values^, float64)
@@ -2718,16 +2684,8 @@ struct DataFrame(Copyable, Movable):
                             values.append(nan)
                             null_mask.append_null()
                         else:
-                            var cur_val: Float64
-                            if cur_col.dtype.is_integer():
-                                cur_val = Float64(cur_col._int64_data()[i])
-                            else:
-                                cur_val = cur_col._float64_data()[i]
-                            var src_val: Float64
-                            if src_col.dtype.is_integer():
-                                src_val = Float64(src_col._int64_data()[i])
-                            else:
-                                src_val = src_col._float64_data()[i]
+                            var cur_val = cur_col._f64_cache[i]
+                            var src_val = src_col._f64_cache[i]
                             values.append((cur_val - src_val) / src_val)
                             null_mask.append_valid()
                 var col = Column(self._cols[j].name, values^, float64)
@@ -3144,7 +3102,7 @@ struct DataFrame(Copyable, Movable):
                 continue
             # Linear interpolation for Float64 columns.
             var n = len(col)
-            ref d = col._data[List[Float64]]
+            ref d = col._f64_cache
             var data = List[Float64]()
             var new_mask = List[Bool]()
             for j in range(n):
@@ -3782,7 +3740,7 @@ struct DataFrame(Copyable, Movable):
         and ``keep`` semantics.
         """
         var dup = self.duplicated(subset, keep)
-        ref dup_data = dup._col._data[List[Bool]]
+        ref dup_data = dup._col._bool_cache
         var keep_indices = List[Int]()
         for i in range(len(dup_data)):
             if not dup_data[i]:
@@ -4178,7 +4136,9 @@ struct DataFrame(Copyable, Movable):
                 var is_null = vcol._null_mask.is_null(r)
                 if not is_null and vcol.is_object():
                     is_null = (
-                        String(vcol._obj_data()[r].__class__.__name__)
+                        String(
+                            vcol._storage_legacy().data[r].__class__.__name__
+                        )
                         == "NoneType"
                     )
                 if is_null:
@@ -4188,13 +4148,8 @@ struct DataFrame(Copyable, Movable):
                     counts[rk][out_pos] += 1
                     continue
 
-                if vcol.is_int():
-                    sums[rk][out_pos] += Float64(vcol._int64_data()[r])
-                elif vcol.is_float():
-                    sums[rk][out_pos] += vcol._float64_data()[r]
-                elif vcol.is_bool():
-                    if vcol._bool_data()[r]:
-                        sums[rk][out_pos] += Float64(1.0)
+                if vcol.is_numeric() or vcol.is_bool():
+                    sums[rk][out_pos] += vcol._f64_cache[r]
                 else:
                     raise Error(
                         "DataFrame.pivot_table: aggfunc "
@@ -4735,7 +4690,7 @@ struct DataFrame(Copyable, Movable):
             # Try to treat the cell as an iterable list.
             var expanded = False
             if exp_col.is_object():
-                var cell = exp_col._obj_data()[r]
+                var cell = exp_col._storage_legacy().data[r]
                 try:
                     var cell_len = Int(cell.__len__())
                     for sub in range(cell_len):
@@ -4770,7 +4725,7 @@ struct DataFrame(Copyable, Movable):
                         null_mask.append_valid()
                     else:
                         # List element.
-                        var cell = exp_col._data[List[PythonObject]][r]
+                        var cell = exp_col._storage_legacy().data[r]
                         data.append(cell[sub])
                         null_mask.append_valid()
                 var new_col = Column(column, data^, object_)
@@ -5138,33 +5093,35 @@ struct DataFrame(Copyable, Movable):
                                     if out_left[r] < 0:
                                         key_col._int64_data()[
                                             r
-                                        ] = rk._int64_data()[out_right[r]]
+                                        ] = rk._int64_cache[out_right[r]]
                                         key_col._null_mask.set_valid(r)
                             elif key_col.is_float() and rk.is_float():
                                 for r in range(len(out_left)):
                                     if out_left[r] < 0:
                                         key_col._float64_data()[
                                             r
-                                        ] = rk._float64_data()[out_right[r]]
+                                        ] = rk._f64_cache[out_right[r]]
                                         key_col._null_mask.set_valid(r)
                             elif key_col.is_bool() and rk.is_bool():
                                 for r in range(len(out_left)):
                                     if out_left[r] < 0:
                                         key_col._bool_data()[
                                             r
-                                        ] = rk._bool_data()[out_right[r]]
+                                        ] = rk._bool_cache[out_right[r]]
                                         key_col._null_mask.set_valid(r)
                             elif key_col.is_string() and rk.is_string():
                                 for r in range(len(out_left)):
                                     if out_left[r] < 0:
-                                        key_col._str_data()[r] = rk._str_data()[
+                                        key_col._str_data()[r] = rk._str_cache[
                                             out_right[r]
                                         ]
                                         key_col._null_mask.set_valid(r)
                             elif key_col.is_object() and rk.is_object():
                                 for r in range(len(out_left)):
                                     if out_left[r] < 0:
-                                        key_col._obj_data()[r] = rk._obj_data()[
+                                        key_col._obj_data()[
+                                            r
+                                        ] = rk._storage_legacy().data[
                                             out_right[r]
                                         ]
                                         key_col._null_mask.set_valid(r)
@@ -5805,14 +5762,8 @@ struct DataFrame(Copyable, Movable):
                 ref col = self._cols[ci]
                 if col._null_mask.is_null(ri):
                     row.append(nan)
-                elif col.is_int():
-                    row.append(Float64(col._int64_data()[ri]))
-                elif col.is_float():
-                    row.append(col._float64_data()[ri])
                 else:
-                    row.append(
-                        Float64(1.0) if col._bool_data()[ri] else Float64(0.0)
-                    )
+                    row.append(col._f64_cache[ri])
             result.append(row^)
         return result^
 
@@ -6124,34 +6075,34 @@ def _groupby_row_less(
             return not left_is_null and right_is_null
 
         if col.is_int():
-            var left_val = col._int64_data()[left_row]
-            var right_val = col._int64_data()[right_row]
+            var left_val = col._int64_cache[left_row]
+            var right_val = col._int64_cache[right_row]
             if left_val < right_val:
                 return True
             if left_val > right_val:
                 return False
         elif col.is_float():
-            var left_val = col._float64_data()[left_row]
-            var right_val = col._float64_data()[right_row]
+            var left_val = col._f64_cache[left_row]
+            var right_val = col._f64_cache[right_row]
             if left_val < right_val:
                 return True
             if left_val > right_val:
                 return False
         elif col.is_bool():
-            var left_val = col._bool_data()[left_row]
-            var right_val = col._bool_data()[right_row]
+            var left_val = col._bool_cache[left_row]
+            var right_val = col._bool_cache[right_row]
             if left_val != right_val:
                 return not left_val and right_val
         elif col.is_string():
-            var left_val = col._str_data()[left_row]
-            var right_val = col._str_data()[right_row]
+            var left_val = col._str_cache[left_row]
+            var right_val = col._str_cache[right_row]
             if left_val < right_val:
                 return True
             if left_val > right_val:
                 return False
         else:
-            var left_val = String(col._obj_data()[left_row])
-            var right_val = String(col._obj_data()[right_row])
+            var left_val = String(col._storage_legacy().data[left_row])
+            var right_val = String(col._storage_legacy().data[right_row])
             if left_val < right_val:
                 return True
             if left_val > right_val:
@@ -6235,11 +6186,11 @@ def _groupby_indices(
                 ref col = df._cols[ci]
                 if col.is_int():
                     _insertion_sort_keys_by[Int64](
-                        group_keys, group_map, col._int64_data()
+                        group_keys, group_map, col._int64_cache
                     )
                 elif col.is_float():
                     _insertion_sort_keys_by[Float64](
-                        group_keys, group_map, col._float64_data()
+                        group_keys, group_map, col._f64_cache
                     )
                 else:
                     _sort_list(group_keys)
@@ -6348,13 +6299,13 @@ struct DataFrameGroupBy:
             var col_idx = self._col_name_index()
             var ci = col_idx.get(self._by[0], -1)
             if ci >= 0 and self._df._cols[ci].is_int():
-                ref d = self._df._cols[ci]._int64_data()
+                ref d = self._df._cols[ci]._int64_cache
                 var int_keys = List[Int64]()
                 for i in range(len(self._group_keys)):
                     int_keys.append(d[self._group_map[self._group_keys[i]][0]])
                 return ColumnIndex(int_keys^)
             elif ci >= 0 and self._df._cols[ci].is_float():
-                ref d = self._df._cols[ci]._float64_data()
+                ref d = self._df._cols[ci]._f64_cache
                 var flt_keys = List[Float64]()
                 for i in range(len(self._group_keys)):
                     flt_keys.append(d[self._group_map[self._group_keys[i]][0]])

--- a/bison/column.mojo
+++ b/bison/column.mojo
@@ -4803,6 +4803,10 @@ struct Column(Copyable, ImplicitlyCopyable, Movable, Sized):
         self._int64_cache = List[Int64]()
         self._bool_cache = List[Bool]()
         self._str_cache = List[String]()
+        # Populate typed caches and activate marrow storage (#646). Needed
+        # for read sites that consult ``_int64_cache`` / ``_f64_cache`` etc.
+        # directly rather than going through ``_data``.
+        self._try_activate_storage()
 
     def __init__(
         out self,
@@ -4824,6 +4828,10 @@ struct Column(Copyable, ImplicitlyCopyable, Movable, Sized):
         self._int64_cache = List[Int64]()
         self._bool_cache = List[Bool]()
         self._str_cache = List[String]()
+        # Populate typed caches and activate marrow storage (#646). Needed
+        # for read sites that consult ``_int64_cache`` / ``_f64_cache`` etc.
+        # directly rather than going through ``_data``.
+        self._try_activate_storage()
 
     # ------------------------------------------------------------------
     # Typed-list constructor overloads — let callers pass typed lists
@@ -5015,7 +5023,14 @@ struct Column(Copyable, ImplicitlyCopyable, Movable, Sized):
         return self._storage[AnyArray].copy()
 
     def _storage_legacy(ref self) -> ref[self._storage] LegacyObjectData:
-        """Return a borrow of the LegacyObjectData arm of the new storage."""
+        """Return a borrow of the LegacyObjectData arm of the new storage.
+
+        Read-side alternative to ``_obj_data()`` for object / datetime /
+        timedelta columns (#646).  Callers access ``.data`` on the result
+        to obtain the underlying ``List[PythonObject]``.  Caller must
+        verify the column is in the LegacyObjectData arm — i.e. the dtype
+        is ``object_``, ``datetime64_ns``, or ``timedelta64_ns``.
+        """
         return self._storage[LegacyObjectData]
 
     # The four typed-array accessors below return a *copy* of the typed
@@ -5124,53 +5139,57 @@ struct Column(Copyable, ImplicitlyCopyable, Movable, Sized):
     # can still produce a valid Column.
 
     def _try_activate_storage(mut self):
-        """Rebuild ``_storage`` from the current ``_data``/``_null_mask``.
+        """Rebuild ``_storage`` and the typed caches from ``_data``/``_null_mask``.
 
         Always resets and re-reads — idempotent-like-rebuild rather than
         idempotent-no-op.  Callers that mutate ``_null_mask`` or ``_data``
         after construction must call this again to keep the marrow
-        backend in sync.  Construction paths that never touch the
-        fields post-construction only need to call it once.
+        backend and caches in sync.  Construction paths that never touch
+        the fields post-construction only need to call it once.
 
-        Best-effort: sets ``_storage_active = True`` on marrow-convertible
-        columns and leaves it False on object / string-with-nulls columns
-        (they stay readable via the legacy fields).
+        Typed cache population is **unconditional** (#646): for any
+        non-object column we copy ``_data`` into the cache matching its
+        dtype, independent of whether marrow activation succeeds.  This
+        means ``_frame.mojo`` read sites can use the caches directly
+        without worrying about the string-with-nulls case where marrow
+        conversion raises.  Marrow activation itself remains best-effort
+        and only toggles ``_storage_active``.
         """
         self._storage_active = False
         self._f64_cache = List[Float64]()
         self._int64_cache = List[Int64]()
         self._bool_cache = List[Bool]()
         self._str_cache = List[String]()
+
+        # Unconditional cache population from _data (no marrow dependency).
+        # TODO(#642): Replace with direct AnyArray typed downcasts once
+        # the Mojo compiler fixes the typed-downcast deadlock.
+        if self.is_int():
+            ref src = self._data[List[Int64]]
+            self._int64_cache = src.copy()
+            for i in range(len(src)):
+                self._f64_cache.append(Float64(src[i]))
+        elif self.is_float():
+            ref src = self._data[List[Float64]]
+            self._f64_cache = src.copy()
+        elif self.is_bool():
+            ref src = self._data[List[Bool]]
+            self._bool_cache = src.copy()
+            for i in range(len(src)):
+                self._f64_cache.append(Float64(1.0) if src[i] else Float64(0.0))
+        elif self.is_string():
+            ref src = self._data[List[String]]
+            self._str_cache = src.copy()
+        # Object / datetime / timedelta: caches stay empty; readers use
+        # _storage[LegacyObjectData].data via _obj_storage_data().
+
+        # Marrow activation is best-effort: leaves ``_storage_active`` False
+        # on object / string-with-nulls columns or on any builder error.
         try:
             var arr = _column_to_marrow_array(self)
             self._storage = ColumnStorage(arr^)
             self._storage_active = True
-            # Pre-extract typed caches from the legacy _data fields (#642).
-            # TODO(#642): Replace with direct AnyArray typed downcasts once
-            # the Mojo compiler fixes the typed-downcast deadlock.
-            if self.is_int():
-                ref src = self._data[List[Int64]]
-                self._int64_cache = src.copy()
-                var visitor = _ToFloat64Visitor()
-                self._visit_raises(visitor)
-                self._f64_cache = visitor.result.copy()
-            elif self.is_float():
-                ref src = self._data[List[Float64]]
-                self._f64_cache = src.copy()
-            elif self.is_bool():
-                ref src = self._data[List[Bool]]
-                self._bool_cache = src.copy()
-                var visitor = _ToFloat64Visitor()
-                self._visit_raises(visitor)
-                self._f64_cache = visitor.result.copy()
-            elif self.is_string():
-                ref src = self._data[List[String]]
-                self._str_cache = src.copy()
         except:
-            # Object arm, string-with-nulls, or a marrow builder error —
-            # leave the column in legacy-only mode.  Downstream readers
-            # that consult ``_storage_active`` will see False and fall
-            # through to ``_data``/``_null_mask``.
             pass
 
     # ------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Part of the Phase 6c dual-backend Column storage migration (#619). Migrates read-side `_data` access in `bison/_frame.mojo` to the typed caches (`_int64_cache`, `_f64_cache`, `_bool_cache`, `_str_cache`) and `_storage_legacy().data`, unblocking half of the prerequisites for #647's final deletion of the legacy `_data: ColumnData` field.

- **46 unsafe accessor reads** (`_int64_data()`, `_float64_data()`, `_bool_data()`, `_str_data()`, `_obj_data()`) migrated to cache reads
- **6 direct `_data[List[...]]` indexing sites** replaced with cache reads
- Several numeric-promotion chains collapsed from `if is_int: Float64(_int64_data()[i]) else: _float64_data()[i]` to a single `_f64_cache[i]` read (diff, pct_change, cumulative, shift axis=1, pivot_table sum, to_numpy, etc.)

## Migration patterns

| Pattern | Sites |
|---|---|
| **Direct typed cache** — `col._int64_cache[i]` etc. at type-dispatched sites | `_groupby_row_less`, `_build_group_index`, `__getitem__` mask, `Series.to_numpy`, `Series.str`, `drop_duplicates`, `interpolate` |
| **`_f64_cache` collapse** — numeric dispatch unified since the cache is populated for int/float/bool | `_cumulatively_reduce`, `shift`, `diff`, `pct_change`, `pivot_table` sum, `_row_numeric_vals`, `to_numpy`, `Series.to_numpy`, `nunique` |
| **`_storage_legacy().data`** — object/datetime column reads | `SeriesStringOps.__eq__`/`__ne__`, `Series.dt`, `explode`, `pivot_table` null-detection, `_groupby_row_less` obj arm, `nunique` obj arm |

## Supporting changes in `column.mojo`

1. **`_try_activate_storage()`** restructured: typed-cache population from `_data` now runs unconditionally, independent of whether marrow activation succeeds. Fixes the string-with-nulls edge case where the marrow builder raises but a string cache is still useful.

2. **`Column.__init__(name, ColumnData, dtype)`** and its index-carrying overload now call `_try_activate_storage()` after the field initializers. Previously only the typed-list constructor overloads populated caches, so `DataFrame.from_dict(Dict[String, ColumnData])` left columns with empty caches — this bug surfaced when `test_marrow_sum` crashed on `_insertion_sort_keys_by` after the migration.

3. **`_storage_legacy()`** docstring updated to describe its new role as the object-column read accessor.

## Scope boundary

The 6 remaining `_data` references in `_frame.mojo` are all mutation-path LHS writes:
- 5 merge key-fill writes in `DataFrame.merge()`
- 1 write in `_set_series_scalar_in_col`
- 1 `visit_col_data_mut_raises(visitor, col._data)` in `_set_scalar_in_col`

These belong to #645 (invert mutation paths to cache-first writes). Together with #646, #645 completes the prerequisites for #647's deletion of `_data`, `ColumnDataVisitor` traits, and ~46 visitor structs (~3600 lines).

The RHS reads in merge key-fill (`rk._int64_data()[out_right[r]]` etc.) were migrated to cache reads in this PR since they are reads, not mutations — only the LHS mutation-target uses of the accessors remain.

## Test plan

- [x] `pixi run check` — `mojo package --Werror` passes cleanly
- [x] `pixi run lint` — all pre-commit hooks pass (trailing whitespace, mojo format, `mojo build --Werror`, etc.)
- [x] `pixi run test` — 21/21 test files pass (466 individual tests)
- [x] Residual-reads grep: `_frame.mojo` contains exactly 6 accessor calls, all LHS mutation-targets; zero `_data[List[` occurrences
- [x] Specific regressions covered: `test_groupby` (marrow fast path; caught the `_try_activate_storage` / `from_dict` interaction), `test_transform` (shift/diff/pct_change axis=1 patterns), `test_aggregation` (pivot_table sum collapse), `test_accessors` (Series.str cache, Series.dt legacy storage), `test_reshaping` (explode), `test_missing` (interpolate), `test_structural` (drop_duplicates)

Closes #646.

https://claude.ai/code/session_01TRFCFUwDYamvRnkwyR1iXB