### PR TITLE
chore: update marrow vendor to v0.0.7-197-g67f9feb

### DIFF
--- a/bison/_frame.mojo
+++ b/bison/_frame.mojo
@@ -6494,20 +6494,12 @@ struct DataFrameGroupBy:
                     if result_key.dtype() == _m_float64:
                         sort_vals.append(
                             rebind[Float64](
-                                result_key.as_primitive[
-                                    _m_float64
-                                ]().unsafe_get(i)
+                                result_key.as_float64().unsafe_get(i)
                             )
                         )
                     else:
                         sort_vals.append(
-                            Float64(
-                                Int(
-                                    result_key.as_primitive[
-                                        _m_int64
-                                    ]().unsafe_get(i)
-                                )
-                            )
+                            Float64(Int(result_key.as_int64().unsafe_get(i)))
                         )
             else:
                 for i in range(num_groups):
@@ -6541,20 +6533,14 @@ struct DataFrameGroupBy:
             var int_keys = List[Int64]()
             for i in range(n_keep):
                 int_keys.append(
-                    rebind[Int64](
-                        result_key.as_primitive[_m_int64]().unsafe_get(keep[i])
-                    )
+                    rebind[Int64](result_key.as_int64().unsafe_get(keep[i]))
                 )
             idx = ColumnIndex(int_keys^)
         elif result_key.dtype() == _m_float64:
             var flt_keys = List[Float64]()
             for i in range(n_keep):
                 flt_keys.append(
-                    rebind[Float64](
-                        result_key.as_primitive[_m_float64]().unsafe_get(
-                            keep[i]
-                        )
-                    )
+                    rebind[Float64](result_key.as_float64().unsafe_get(keep[i]))
                 )
             idx = ColumnIndex(flt_keys^)
         else:
@@ -6584,21 +6570,13 @@ struct DataFrameGroupBy:
                         null_mask.append_null()
                     elif is_count:
                         vals.append(
-                            rebind[Int64](
-                                rb_col.as_primitive[_m_int64]().unsafe_get(ri)
-                            )
+                            rebind[Int64](rb_col.as_int64().unsafe_get(ri))
                         )
                         null_mask.append_valid()
                     else:
                         # sum/min/max of integer col: marrow stores as float64.
                         vals.append(
-                            Int64(
-                                Float64(
-                                    rb_col.as_primitive[
-                                        _m_float64
-                                    ]().unsafe_get(ri)
-                                )
-                            )
+                            Int64(Float64(rb_col.as_float64().unsafe_get(ri)))
                         )
                         null_mask.append_valid()
                 var col = Column(value_names[v], vals^, int64, idx.copy())
@@ -6618,9 +6596,7 @@ struct DataFrameGroupBy:
                         null_mask.append_null()
                     else:
                         vals.append(
-                            rebind[Float64](
-                                rb_col.as_primitive[_m_float64]().unsafe_get(ri)
-                            )
+                            rebind[Float64](rb_col.as_float64().unsafe_get(ri))
                         )
                         null_mask.append_valid()
                 var col = Column(value_names[v], vals^, float64, idx.copy())
@@ -7238,19 +7214,11 @@ struct SeriesGroupBy:
                     vals.append(Int64(0))
                     null_mask.append_null()
                 elif is_count:
-                    vals.append(
-                        rebind[Int64](
-                            rb_col.as_primitive[_m_int64]().unsafe_get(ri)
-                        )
-                    )
+                    vals.append(rebind[Int64](rb_col.as_int64().unsafe_get(ri)))
                     null_mask.append_valid()
                 else:
                     vals.append(
-                        Int64(
-                            Float64(
-                                rb_col.as_primitive[_m_float64]().unsafe_get(ri)
-                            )
-                        )
+                        Int64(Float64(rb_col.as_float64().unsafe_get(ri)))
                     )
                     null_mask.append_valid()
             var col = Column(self._series.name, vals^, int64, idx^)
@@ -7268,9 +7236,7 @@ struct SeriesGroupBy:
                     null_mask.append_null()
                 else:
                     vals.append(
-                        rebind[Float64](
-                            rb_col.as_primitive[_m_float64]().unsafe_get(ri)
-                        )
+                        rebind[Float64](rb_col.as_float64().unsafe_get(ri))
                     )
                     null_mask.append_valid()
             var col = Column(self._series.name, vals^, float64, idx^)

--- a/bison/arrow.mojo
+++ b/bison/arrow.mojo
@@ -22,6 +22,8 @@ from marrow.dtypes import (
     string as _m_string,
     DataType as _MarrowDataType,
     Field as _MarrowField,
+    Float64Type,
+    Int64Type,
 )
 from marrow.schema import Schema as _MarrowSchema
 from marrow.tabular import RecordBatch, Table
@@ -62,7 +64,7 @@ def column_to_marrow_array(col: Column) raises -> AnyArray:
                 vals.append(None)
             else:
                 vals.append(Int(src[i]))
-        return AnyArray(array[_m_int64](vals^))
+        return AnyArray(array[Int64Type](vals^))
 
     elif col._data.isa[List[Float64]]():
         ref src = col._data[List[Float64]]
@@ -72,7 +74,7 @@ def column_to_marrow_array(col: Column) raises -> AnyArray:
                 vals.append(None)
             else:
                 vals.append(src[i])
-        return AnyArray(array[_m_float64](vals^))
+        return AnyArray(array[Float64Type](vals^))
 
     elif col._data.isa[List[Bool]]():
         ref src = col._data[List[Bool]]
@@ -163,7 +165,7 @@ def marrow_array_to_column(arr: AnyArray, name: String) raises -> Column:
                 data.append(False)
                 null_mask.append_null()
             else:
-                data.append(Bool(src.unsafe_get(i)))
+                data.append(src[i].value())
                 null_mask.append_valid()
         var col = Column(name, ColumnData(data^), bool_)
         if null_mask.has_nulls():

--- a/bison/column.mojo
+++ b/bison/column.mojo
@@ -11,7 +11,7 @@ from marrow.arrays import (
     PrimitiveArray,
     StringArray,
 )
-from marrow.bitmap import BitmapBuilder
+from marrow.buffers import Bitmap
 from marrow.builders import (
     array as _marrow_array,
 )
@@ -19,6 +19,8 @@ from marrow.dtypes import (
     bool_ as _m_bool_,
     float64 as _m_float64,
     int64 as _m_int64,
+    Float64Type,
+    Int64Type,
 )
 from marrow.kernels.aggregate import (
     sum_ as _marrow_sum,
@@ -1152,7 +1154,7 @@ def _column_to_marrow_array(col: Column) raises -> AnyArray:
                 vals.append(None)
             else:
                 vals.append(Int(src[i]))
-        return AnyArray(_marrow_array[_m_int64](vals^))
+        return AnyArray(_marrow_array[Int64Type](vals^))
 
     elif col.is_float():
         ref src = col._float64_data()
@@ -1162,7 +1164,7 @@ def _column_to_marrow_array(col: Column) raises -> AnyArray:
                 vals.append(None)
             else:
                 vals.append(src[i])
-        return AnyArray(_marrow_array[_m_float64](vals^))
+        return AnyArray(_marrow_array[Float64Type](vals^))
 
     elif col.is_bool():
         ref src = col._bool_data()
@@ -1198,9 +1200,9 @@ def _column_to_marrow_array(col: Column) raises -> AnyArray:
 def _marrow_scalar_to_float64(scalar: AnyScalar) -> Float64:
     """Extract a Float64 from a marrow AnyScalar (int64 or float64)."""
     if scalar.type() == _m_float64:
-        return Float64(scalar.as_primitive[_m_float64]().value())
+        return Float64(scalar.as_primitive[Float64Type]().value())
     else:
-        return Float64(scalar.as_primitive[_m_int64]().value())
+        return Float64(scalar.as_primitive[Int64Type]().value())
 
 
 # ------------------------------------------------------------------
@@ -4530,7 +4532,7 @@ struct NullMask(Copyable, Movable, Sized):
 
     # Always-allocated bit-packed buffer.  When ``_capacity == 0`` the
     # builder owns a sentinel allocation but its bytes are not read.
-    var _builder: BitmapBuilder
+    var _builder: Bitmap[mut=True]
     # Logical number of entries tracked (matches today's ``len`` semantics).
     var _length: Int
     # Number of bits the builder can currently hold (>= _length when set).
@@ -4541,7 +4543,7 @@ struct NullMask(Copyable, Movable, Sized):
 
     def __init__(out self):
         """Empty mask — no nulls."""
-        self._builder = BitmapBuilder.alloc(Self._EMPTY_ALLOC_BITS)
+        self._builder = Bitmap.alloc_zeroed(Self._EMPTY_ALLOC_BITS)
         self._length = 0
         self._capacity = 0
         self._has_nulls = False
@@ -4566,13 +4568,13 @@ struct NullMask(Copyable, Movable, Sized):
         result._has_nulls = any_null
         if any_null:
             result._capacity = n
-            result._builder = BitmapBuilder.alloc(n)
+            result._builder = Bitmap.alloc_zeroed(n)
             for i in range(n):
                 if mask[i]:
-                    result._builder.set_bit(i, True)
+                    result._builder.unsafe_set(i)
         else:
             result._capacity = 0
-            result._builder = BitmapBuilder.alloc(Self._EMPTY_ALLOC_BITS)
+            result._builder = Bitmap.alloc_zeroed(Self._EMPTY_ALLOC_BITS)
         return result^
 
     def __init__(out self, *, copy: Self):
@@ -4586,10 +4588,10 @@ struct NullMask(Copyable, Movable, Sized):
         var alloc_bits = (
             copy._capacity if copy._capacity > 0 else Self._EMPTY_ALLOC_BITS
         )
-        self._builder = BitmapBuilder.alloc(alloc_bits)
+        self._builder = Bitmap.alloc_zeroed(alloc_bits)
         if copy._capacity > 0 and copy._has_nulls and copy._length > 0:
-            self._builder.copy_bits(
-                copy._builder.unsafe_ptr(), 0, 0, copy._length
+            self._builder.extend(
+                copy._builder.view(0, copy._length), 0, copy._length
             )
 
     def __init__(out self, *, deinit take: Self):
@@ -4614,8 +4616,7 @@ struct NullMask(Copyable, Movable, Sized):
 
     @always_inline
     def _bit_at(self, index: Int) -> Bool:
-        var ptr = self._builder.unsafe_ptr()
-        return Bool((ptr[index >> 3] >> UInt8(index & 7)) & 1)
+        return self._builder.unsafe_test(index)
 
     def __len__(self) -> Int:
         return self._length
@@ -4628,7 +4629,7 @@ struct NullMask(Copyable, Movable, Sized):
         self._length += 1
         if value:
             self._ensure_capacity(self._length)
-            self._builder.set_bit(self._length - 1, True)
+            self._builder.unsafe_set(self._length - 1)
             self._has_nulls = True
         elif self._has_nulls:
             # Already allocated — must explicitly write a 0 bit so a
@@ -4638,7 +4639,7 @@ struct NullMask(Copyable, Movable, Sized):
             # is now growing back into reused capacity, but we keep the
             # branch defensive.
             if self._length <= self._capacity:
-                self._builder.set_bit(self._length - 1, False)
+                self._builder.unsafe_clear(self._length - 1)
 
     def append_null(mut self) raises:
         """Append a null marker to the mask."""
@@ -4668,14 +4669,14 @@ struct NullMask(Copyable, Movable, Sized):
     def set_null(mut self, index: Int) raises:
         """Mark the element at *index* as null."""
         self._ensure_capacity(index + 1)
-        self._builder.set_bit(index, True)
+        self._builder.unsafe_set(index)
         self._has_nulls = True
 
     def set_valid(mut self, index: Int):
         """Mark the element at *index* as valid (not null)."""
         if not self._has_nulls:
             return
-        self._builder.set_bit(index, False)
+        self._builder.unsafe_clear(index)
 
     def len(self) -> Int:
         """Return the number of elements tracked by this mask."""
@@ -5040,13 +5041,13 @@ struct Column(Copyable, ImplicitlyCopyable, Movable, Sized):
     # avoids the nested-origin path that Mojo cannot express for chained
     # ``Variant[...]`` + ``AnyArray.as_*`` reference returns.
     def _int64_array(self) -> Int64Array:
-        return self._storage[AnyArray].as_primitive[_m_int64]().copy()
+        return self._storage[AnyArray].as_int64().copy()
 
     def _float64_array(self) -> Float64Array:
-        return self._storage[AnyArray].as_primitive[_m_float64]().copy()
+        return self._storage[AnyArray].as_float64().copy()
 
     def _bool_array(self) -> BoolArray:
-        return self._storage[AnyArray].as_primitive[_m_bool_]().copy()
+        return self._storage[AnyArray].as_bool().copy()
 
     def _string_array(self) -> StringArray:
         return self._storage[AnyArray].as_string().copy()


### PR DESCRIPTION
## Summary

- Advances the `vendor/marrow` submodule from `7610fee` to `67f9feb` (69 commits), picking up BoolArray refactor, BufferView/BitmapView abstractions, variant-based DataType dispatch, SwissHashTable, hash join, and more
- Adapts all bison call sites to marrow's updated API (type-level `PrimitiveType` parameters, merged `bitmap.mojo` → `buffers.mojo`, removed `BitmapBuilder`)

## API changes adapted

| Old | New | Files |
|-----|-----|-------|
| `as_primitive[_m_int64/float64]()` on `AnyArray` | `as_int64()` / `as_float64()` | `column.mojo`, `_frame.mojo` |
| `as_primitive[_m_bool_]()` | `as_bool()` | `column.mojo` |
| `scalar.as_primitive[_m_int64/float64]()` | `as_primitive[Int64Type/Float64Type]()` | `column.mojo` |
| `array[_m_int64/float64](vals)` builder | `array[Int64Type/Float64Type](vals)` | `column.mojo`, `arrow.mojo` |
| `from marrow.bitmap import BitmapBuilder` | `from marrow.buffers import Bitmap` | `column.mojo` |
| `BitmapBuilder.alloc(n)` | `Bitmap.alloc_zeroed(n)` | `column.mojo` |
| `set_bit(i, True/False)` | `unsafe_set(i)` / `unsafe_clear(i)` | `column.mojo` |
| `copy_bits(ptr, 0, 0, n)` | `extend(src.view(0, n), 0, n)` | `column.mojo` |
| `unsafe_ptr()` + manual bit shift | `unsafe_test(index)` | `column.mojo` |
| `BoolArray.unsafe_get(i)` | `src[i].value()` | `arrow.mojo` |

## Test plan

- [x] `pixi run build-marrow` — marrow package builds cleanly
- [x] `pixi run test` — all 96 tests pass, 0 failures
- [x] `pixi run check` — zero warnings (enforced by pre-commit hook)