### PR TITLE
feat(#645): invert mutation paths to cache-first writes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -61,7 +61,7 @@ Supported platforms: `linux-64`, `osx-arm64`. Requires `pixi >= 0.41.0`, `max >=
 
 1. **Legacy backend** (`_data: ColumnData`): A `Variant[List[Int64], List[Float64], List[Bool], List[String], List[PythonObject]]` with a parallel `List[Bool]` null mask.
 2. **Marrow backend** (`_storage: ColumnStorage`): An `AnyArray` (Apache Arrow for Mojo) for SIMD aggregation kernels, or `LegacyObjectData` for `PythonObject` columns.
-3. **Typed caches** (`_int64_cache`, `_f64_cache`, `_bool_cache`, `_str_cache`): Pre-extracted typed lists populated from `_data` at construction time. At most one typed cache plus `_f64_cache` is non-empty.
+3. **Typed caches** (`_int64_cache`, `_f64_cache`, `_bool_cache`, `_str_cache`): Pre-extracted typed lists populated from `_data` at construction time. At most one typed cache plus `_f64_cache` is non-empty. After #645, caches are also the **write target** for all mutations — `_data` is only written during construction and is stale afterward.
 
 The typed caches exist as a workaround for the Mojo compiler deadlock (#642): typed `AnyArray` downcasts (`arr.as_int64()` etc.) cannot co-exist on the same call graph as `df.query()` in `column.mojo`. All high-traffic operations (comparison, aggregation, transforms, extraction) read from caches instead of `_data`. See TODO(#642) comments throughout.
 
@@ -90,7 +90,7 @@ For single-cell extraction use `_series_scalar_at(col, row)` or `_scalar_from_co
 
 For multi-arm algorithmic dispatch, use `Column._visit_raises[V]()` or `Column._visit[V]()` which route through typed caches when `_storage_active`, falling back to the legacy `visit_col_data_raises()` dispatcher. Visitor structs still implement `ColumnDataVisitorRaises` — the cache dispatch calls their `on_*` methods with cache data instead of `_data`.
 
-After a predicate check, access the typed data via the unsafe accessors: `col._int64_data()`, `col._float64_data()`, `col._bool_data()`, `col._str_data()`, `col._obj_data()`. **Important:** These return refs to `_data` (legacy backend). If you mutate values through these refs, call `col._try_activate_storage()` afterward to rebuild caches.
+After a predicate check, access the typed data via the unsafe accessors: `col._int64_data()`, `col._float64_data()`, `col._bool_data()`, `col._str_data()`, `col._obj_data()`. **Important:** After #645, `_int64_data()` / `_float64_data()` / `_bool_data()` / `_str_data()` return refs directly into the typed caches — mutations go to the cache. `_obj_data()` still returns a ref into `_data` (object columns have no typed cache). After any cache mutation call `col._rebuild_marrow_only()` to sync the secondary `_f64_cache` (for int/bool) and rebuild the marrow backend. Do **not** call `_try_activate_storage()` from mutation paths — it reads from `_data` and will overwrite cache mutations.
 
 ### Core types
 

--- a/bison/_frame.mojo
+++ b/bison/_frame.mojo
@@ -30,13 +30,11 @@ from .column import (
     _col_cell_pyobj,
     _scalar_from_col,
     _series_scalar_at,
-    _SetScalarInColMutVisitor,
     ColumnDataVisitorRaises,
     _FillnaVisitor,
     _FfillVisitor,
     _BfillVisitor,
     visit_col_data_raises,
-    visit_col_data_mut_raises,
 )
 from .accessors.str_accessor import StringMethods
 from .accessors.dt_accessor import DatetimeMethods
@@ -5126,8 +5124,9 @@ struct DataFrame(Copyable, Movable):
                                         ]
                                         key_col._null_mask.set_valid(r)
                             break
-                    # Rebuild caches after in-place key fill (#619 Phase 6b).
-                    key_col._try_activate_storage()
+                    # Sync secondary caches and rebuild marrow after
+                    # cache-first key fill (#645).
+                    key_col._rebuild_marrow_only()
                     result_cols.append(key_col^)
                     break
 
@@ -7653,11 +7652,45 @@ def _df_row_index(df: DataFrame, label: String) raises -> Int:
 
 
 def _set_scalar_in_col(mut col: Column, row: Int, value: DFScalar) raises:
-    """Write *value* into *col* at integer position *row*."""
-    var visitor = _SetScalarInColMutVisitor(row, value)
-    visit_col_data_mut_raises(visitor, col._data)
-    # Rebuild typed caches after in-place mutation (#619 Phase 6b).
-    col._try_activate_storage()
+    """Write *value* into *col* at integer position *row* via typed caches (#645).
+    """
+    if col.is_int():
+        if value.isa[Int64]():
+            col._int64_cache[row] = value[Int64]
+        elif value.isa[Float64]():
+            col._int64_cache[row] = Int64(Int(value[Float64]))
+        elif value.isa[Bool]():
+            col._int64_cache[row] = Int64(1) if value[Bool] else Int64(0)
+        else:
+            raise Error("iat/at: cannot assign String to int column")
+    elif col.is_float():
+        if value.isa[Float64]():
+            col._f64_cache[row] = value[Float64]
+        elif value.isa[Int64]():
+            col._f64_cache[row] = Float64(Int(value[Int64]))
+        elif value.isa[Bool]():
+            col._f64_cache[row] = Float64(1) if value[Bool] else Float64(0)
+        else:
+            raise Error("iat/at: cannot assign String to float column")
+    elif col.is_bool():
+        if value.isa[Bool]():
+            col._bool_cache[row] = value[Bool]
+        elif value.isa[Int64]():
+            col._bool_cache[row] = value[Int64] != 0
+        elif value.isa[Float64]():
+            col._bool_cache[row] = value[Float64] != 0.0
+        else:
+            raise Error("iat/at: cannot assign String to bool column")
+    elif col.is_string():
+        if value.isa[String]():
+            col._str_cache[row] = value[String]
+        else:
+            raise Error("iat/at: cannot assign non-String to string column")
+    else:
+        raise Error(
+            "iat/at: scalar write not supported for object/datetime columns"
+        )
+    col._rebuild_marrow_only()
 
 
 def _set_series_scalar_in_col(
@@ -7669,7 +7702,7 @@ def _set_series_scalar_in_col(
             col._obj_data()[row] = value[PythonObject]
         else:
             raise Error("iloc: cannot assign PythonObject to typed column")
-        col._try_activate_storage()
+        col._rebuild_marrow_only()
         return
     var ds: DFScalar
     if value.isa[Int64]():

--- a/bison/column.mojo
+++ b/bison/column.mojo
@@ -383,59 +383,6 @@ def visit_col_data_raises[
 
 
 # ------------------------------------------------------------------
-# Mutable raises-capable visitor — for in-place writes to ColumnData
-# ------------------------------------------------------------------
-
-
-trait ColumnDataMutVisitorRaises:
-    """Mutable raises-capable visitor for in-place writes to a ``ColumnData`` arm.
-
-    Implement one ``on_*`` method per arm.  Each method receives a *mutable*
-    reference to the underlying list, allowing O(1) element writes without
-    copying the whole list.  Pass an instance to
-    ``visit_col_data_mut_raises``.
-    """
-
-    def on_int64(mut self, mut data: List[Int64]) raises:
-        ...
-
-    def on_float64(mut self, mut data: List[Float64]) raises:
-        ...
-
-    def on_bool(mut self, mut data: List[Bool]) raises:
-        ...
-
-    def on_str(mut self, mut data: List[String]) raises:
-        ...
-
-    def on_obj(mut self, mut data: List[PythonObject]) raises:
-        ...
-
-
-def visit_col_data_mut_raises[
-    V: ColumnDataMutVisitorRaises
-](mut visitor: V, mut data: ColumnData) raises:
-    """Mutable raises-capable dispatch that passes each arm by mutable reference.
-
-    Because *data* is ``mut``, each ``data[ArmType]`` subscript yields a
-    mutable reference, enabling O(1) in-place element writes inside ``on_*``
-    methods.  Add new ``ColumnData`` arms here, in
-    ``ColumnDataMutVisitorRaises``, ``visit_col_data``, and
-    ``visit_col_data_raises``.
-    """
-    if data.isa[List[Int64]]():
-        visitor.on_int64(data[List[Int64]])
-    elif data.isa[List[Float64]]():
-        visitor.on_float64(data[List[Float64]])
-    elif data.isa[List[Bool]]():
-        visitor.on_bool(data[List[Bool]])
-    elif data.isa[List[String]]():
-        visitor.on_str(data[List[String]])
-    else:
-        visitor.on_obj(data[List[PythonObject]])
-
-
-# ------------------------------------------------------------------
 # DFScalar visit primitive — single canonical dispatch site
 # ------------------------------------------------------------------
 
@@ -3789,66 +3736,6 @@ struct _ScalarFromColVisitor(ColumnDataVisitorRaises, Copyable, Movable):
         self.result = DFScalar(String(data[self.row]))
 
 
-struct _SetScalarInColMutVisitor(ColumnDataMutVisitorRaises, Copyable, Movable):
-    """Visitor that writes a ``DFScalar`` in-place at position *row* of a column.
-
-    Mutates the ``ColumnData`` arm directly (O(1)) without copying the list.
-    Type-coercion mirrors pandas ``at`` / ``iat`` behaviour.
-
-    The caller is responsible for bounds-checking *row* before constructing
-    this visitor.  Out-of-bounds access will raise at the list subscript site,
-    which is the same observable behaviour as the previous copy-based approach.
-    """
-
-    var row: Int
-    var value: DFScalar
-
-    def __init__(out self, row: Int, value: DFScalar):
-        self.row = row
-        self.value = value
-
-    def on_int64(mut self, mut data: List[Int64]) raises:
-        if self.value.isa[Int64]():
-            data[self.row] = self.value[Int64]
-        elif self.value.isa[Float64]():
-            data[self.row] = Int64(Int(self.value[Float64]))
-        elif self.value.isa[Bool]():
-            data[self.row] = Int64(1) if self.value[Bool] else Int64(0)
-        else:
-            raise Error("iat/at: cannot assign String to int column")
-
-    def on_float64(mut self, mut data: List[Float64]) raises:
-        if self.value.isa[Float64]():
-            data[self.row] = self.value[Float64]
-        elif self.value.isa[Int64]():
-            data[self.row] = Float64(Int(self.value[Int64]))
-        elif self.value.isa[Bool]():
-            data[self.row] = Float64(1) if self.value[Bool] else Float64(0)
-        else:
-            raise Error("iat/at: cannot assign String to float column")
-
-    def on_bool(mut self, mut data: List[Bool]) raises:
-        if self.value.isa[Bool]():
-            data[self.row] = self.value[Bool]
-        elif self.value.isa[Int64]():
-            data[self.row] = self.value[Int64] != 0
-        elif self.value.isa[Float64]():
-            data[self.row] = self.value[Float64] != 0.0
-        else:
-            raise Error("iat/at: cannot assign String to bool column")
-
-    def on_str(mut self, mut data: List[String]) raises:
-        if self.value.isa[String]():
-            data[self.row] = self.value[String]
-        else:
-            raise Error("iat/at: cannot assign non-String to string column")
-
-    def on_obj(mut self, mut data: List[PythonObject]) raises:
-        raise Error(
-            "iat/at: scalar write not supported for object/datetime columns"
-        )
-
-
 # ------------------------------------------------------------------
 # Cumulative operation visitors
 # ------------------------------------------------------------------
@@ -4979,26 +4866,26 @@ struct Column(Copyable, ImplicitlyCopyable, Movable, Sized):
         self._str_cache = take._str_cache^
 
     # ------------------------------------------------------------------
-    # Typed accessor helpers — return mutable refs to the legacy _data
-    # Variant arms.  Used by mutation paths (merge key fill, set_scalar).
-    # Callers MUST call _try_activate_storage() after mutating through
-    # these refs to rebuild typed caches.
+    # Typed accessor helpers — return mutable refs to the typed caches
+    # (#645: cache-first writes).  Mutation via these refs targets the
+    # cache directly; callers MUST call _rebuild_marrow_only() afterward
+    # to sync the secondary _f64_cache (for int/bool) and rebuild marrow.
     #
-    # Read-only access should prefer _visit_raises/_visit (cache-aware)
-    # or the typed caches directly.
+    # _obj_data() is unchanged — object columns have no typed cache and
+    # still route through _data.
     # ------------------------------------------------------------------
 
-    def _int64_data(ref self) -> ref[self._data] List[Int64]:
-        return self._data[List[Int64]]
+    def _int64_data(ref self) -> ref[self._int64_cache] List[Int64]:
+        return self._int64_cache
 
-    def _float64_data(ref self) -> ref[self._data] List[Float64]:
-        return self._data[List[Float64]]
+    def _float64_data(ref self) -> ref[self._f64_cache] List[Float64]:
+        return self._f64_cache
 
-    def _bool_data(ref self) -> ref[self._data] List[Bool]:
-        return self._data[List[Bool]]
+    def _bool_data(ref self) -> ref[self._bool_cache] List[Bool]:
+        return self._bool_cache
 
-    def _str_data(ref self) -> ref[self._data] List[String]:
-        return self._data[List[String]]
+    def _str_data(ref self) -> ref[self._str_cache] List[String]:
+        return self._str_cache
 
     def _obj_data(ref self) -> ref[self._data] List[PythonObject]:
         return self._data[List[PythonObject]]
@@ -5186,6 +5073,41 @@ struct Column(Copyable, ImplicitlyCopyable, Movable, Sized):
 
         # Marrow activation is best-effort: leaves ``_storage_active`` False
         # on object / string-with-nulls columns or on any builder error.
+        try:
+            var arr = _column_to_marrow_array(self)
+            self._storage = ColumnStorage(arr^)
+            self._storage_active = True
+        except:
+            pass
+
+    def _rebuild_marrow_only(mut self):
+        """Sync secondary caches and rebuild marrow from typed caches (#645).
+
+        Call after any direct in-place mutation of a typed cache field
+        (``_int64_cache``, ``_f64_cache``, ``_bool_cache``, ``_str_cache``).
+        Unlike ``_try_activate_storage()``, this method does NOT read from
+        ``_data`` or reset the typed caches — caches are the source of truth.
+
+        For int/bool columns it rebuilds ``_f64_cache`` from the primary
+        cache, then attempts marrow activation (best-effort, same as
+        ``_try_activate_storage()``).
+        """
+        # Sync secondary _f64_cache for types that populate it.
+        if self.is_int():
+            self._f64_cache = List[Float64]()
+            for i in range(len(self._int64_cache)):
+                self._f64_cache.append(Float64(self._int64_cache[i]))
+        elif self.is_bool():
+            self._f64_cache = List[Float64]()
+            for i in range(len(self._bool_cache)):
+                self._f64_cache.append(
+                    Float64(1.0) if self._bool_cache[i] else Float64(0.0)
+                )
+        # Float: _f64_cache is already the primary cache (mutation went there).
+        # String/Object: no _f64_cache to sync.
+
+        # Rebuild marrow storage (best-effort).
+        self._storage_active = False
         try:
             var arr = _column_to_marrow_array(self)
             self._storage = ColumnStorage(arr^)


### PR DESCRIPTION
## Summary

Closes #645. Part of the #619 dual-backend migration arc; unblocks #647.

- `_int64_data()` / `_float64_data()` / `_bool_data()` / `_str_data()` now return refs into typed caches instead of `_data` — mutations go directly to the cache. `_obj_data()` is unchanged (object columns have no typed cache).
- New `Column._rebuild_marrow_only()`: syncs the secondary `_f64_cache` for int/bool columns, then rebuilds marrow storage from caches — without reading from or resetting `_data`.
- `_set_scalar_in_col()`: replaced `_SetScalarInColMutVisitor` visitor dispatch with a direct predicate-chain that writes to typed caches.
- Merge key fill and `_set_series_scalar_in_col` obj path: swapped `_try_activate_storage()` → `_rebuild_marrow_only()`.
- Deleted `ColumnDataMutVisitorRaises` trait, `visit_col_data_mut_raises()` dispatcher, and `_SetScalarInColMutVisitor` struct — all now dead code.
- Updated `CLAUDE.md` to document the new accessor semantics and warn against calling `_try_activate_storage()` from mutation paths.

`_data` is now only written during construction; it is stale after any mutation. This is the final step before #647 can delete `_data` and the remaining visitor infrastructure entirely.

## Test plan

- [x] `pixi run test` — 96 tests, 0 failures
- [x] `pixi run check` — zero warnings from bison source
- Key paths exercised: `test_indexing.mojo` (`.at[]`/`.iat[]` → `_set_scalar_in_col`), `test_combining.mojo` (outer/right joins → merge key fill)