### PR TITLE
feat(#656): delete _null_mask field and retarget _obj_data

### DIFF
--- a/bison/_frame.mojo
+++ b/bison/_frame.mojo
@@ -441,7 +441,7 @@ struct Series(Copyable, ImplicitlyCopyable, Movable):
         if self._col.is_object():
             ref d = self._col._storage_legacy().data
             for i in range(n):
-                if self._col._null_mask.is_null(i):
+                if self._col.is_null(i):
                     result.append(False)
                 else:
                     result.append(String(d[i]) == other)
@@ -465,7 +465,7 @@ struct Series(Copyable, ImplicitlyCopyable, Movable):
         if self._col.is_object():
             ref d = self._col._storage_legacy().data
             for i in range(n):
-                if self._col._null_mask.is_null(i):
+                if self._col.is_null(i):
                     result.append(True)
                 else:
                     result.append(String(d[i]) != other)
@@ -607,7 +607,7 @@ struct Series(Copyable, ImplicitlyCopyable, Movable):
         var n = len(self._col)
         var result = List[Bool]()
         for i in range(n):
-            result.append(self._col._null_mask.is_null(i))
+            result.append(self._col.is_null(i))
         var col = Column(self._col.name, result^, bool_)
         return Series(col^)
 
@@ -621,7 +621,7 @@ struct Series(Copyable, ImplicitlyCopyable, Movable):
         var n = len(self._col)
         var result = List[Bool]()
         for i in range(n):
-            result.append(self._col._null_mask.is_valid(i))
+            result.append(self._col.is_valid(i))
         var col = Column(self._col.name, result^, bool_)
         return Series(col^)
 
@@ -634,10 +634,10 @@ struct Series(Copyable, ImplicitlyCopyable, Movable):
         """
         if value.is_null():
             raise Error("fillna: fill value cannot be null")
-        var has_mask = self._col._null_mask.has_nulls()
+        var has_mask = self._col.has_nulls()
         if not has_mask:
             return Series(self._col.copy())
-        var visitor = _FillnaVisitor(self._col._null_mask, value)
+        var visitor = _FillnaVisitor(self._col.null_mask_copy(), value)
         self._col._visit_raises(visitor)
         var dtype = self._col.dtype
         var idx = self._col._index.copy()
@@ -647,51 +647,48 @@ struct Series(Copyable, ImplicitlyCopyable, Movable):
 
     def dropna(self) raises -> Series:
         """Return a new Series with null/NaN elements removed."""
-        var has_mask = self._col._null_mask.has_nulls()
+        var has_mask = self._col.has_nulls()
         if not has_mask:
             return Series(self._col.copy())
         var keep = List[Int]()
-        for i in range(len(self._col._null_mask)):
-            if self._col._null_mask.is_valid(i):
+        for i in range(len(self._col)):
+            if self._col.is_valid(i):
                 keep.append(i)
         var result_col = self._col.take(keep)
         # All kept elements are non-null; clear the mask.
-        result_col._null_mask = NullMask()
-        result_col._try_activate_storage()
+        result_col.clear_null_mask()
         return Series(result_col^)
 
     def ffill(self) raises -> Series:
         """Forward-fill: propagate the last non-null value forward over nulls.
         """
-        var has_mask = self._col._null_mask.has_nulls()
+        var has_mask = self._col.has_nulls()
         if not has_mask:
             return Series(self._col.copy())
-        var visitor = _FfillVisitor(self._col._null_mask)
+        var visitor = _FfillVisitor(self._col.null_mask_copy())
         self._col._visit_raises(visitor)
         var idx = self._col._index.copy()
         var col = Column(
             self._col.name, visitor.col_data.copy(), self._col.dtype, idx^
         )
         if visitor.has_any_null:
-            col._null_mask = visitor.result_mask.copy()
-            col._try_activate_storage()
+            col.set_null_mask(visitor.result_mask.copy())
         return Series(col^)
 
     def bfill(self) raises -> Series:
         """Backward-fill: propagate the next non-null value backward over nulls.
         """
-        var has_mask = self._col._null_mask.has_nulls()
+        var has_mask = self._col.has_nulls()
         if not has_mask:
             return Series(self._col.copy())
-        var visitor = _BfillVisitor(self._col._null_mask)
+        var visitor = _BfillVisitor(self._col.null_mask_copy())
         self._col._visit_raises(visitor)
         var idx = self._col._index.copy()
         var col = Column(
             self._col.name, visitor.col_data.copy(), self._col.dtype, idx^
         )
         if visitor.has_any_null:
-            col._null_mask = visitor.result_mask.copy()
-            col._try_activate_storage()
+            col.set_null_mask(visitor.result_mask.copy())
         return Series(col^)
 
     # ------------------------------------------------------------------
@@ -777,7 +774,7 @@ struct Series(Copyable, ImplicitlyCopyable, Movable):
         # Determine whether any element is actually null; only then use Float64.
         var has_any_null = False
         for i in range(n):
-            if self._col._null_mask.is_null(i):
+            if self._col.is_null(i):
                 has_any_null = True
                 break
         var idx = self._col._index.copy()
@@ -793,7 +790,7 @@ struct Series(Copyable, ImplicitlyCopyable, Movable):
         var result_mask = NullMask()
         for i in range(n):
             var orig_pos = perm[i]
-            if self._col._null_mask.is_null(orig_pos):
+            if self._col.is_null(orig_pos):
                 result_data.append(Float64(0))
                 result_mask.append_null()
             else:
@@ -801,8 +798,7 @@ struct Series(Copyable, ImplicitlyCopyable, Movable):
                 result_mask.append_valid()
         var col = Column(self._col.name, result_data^, float64, idx^)
         if result_mask.has_nulls():
-            col._null_mask = result_mask^
-        col._try_activate_storage()
+            col.set_null_mask(result_mask^)
         return Series(col^)
 
     def rank(self) raises -> Series:
@@ -812,13 +808,13 @@ struct Series(Copyable, ImplicitlyCopyable, Movable):
         if n == 0:
             return Series(self._col.copy())
         var perm = self._sort_perm(True)
-        var has_mask = self._col._null_mask.has_nulls()
+        var has_mask = self._col.has_nulls()
         # Count non-null elements (null elements sit at the tail of perm).
         var n_non_null = n
         if has_mask:
             n_non_null = 0
             for i in range(n):
-                if self._col._null_mask.is_valid(i):
+                if self._col.is_valid(i):
                     n_non_null += 1
         # Prepare Float64 result; null slots are marked in rank_mask.
         var ranks = List[Float64]()
@@ -837,8 +833,7 @@ struct Series(Copyable, ImplicitlyCopyable, Movable):
         var col = Column(self._col.name, ranks^, float64, idx^)
         # n_non_null < n iff there are nulls — no need to re-scan the mask.
         if n_non_null < n:
-            col._null_mask = rank_mask^
-            col._try_activate_storage()
+            col.set_null_mask(rank_mask^)
         return Series(col^)
 
     # ------------------------------------------------------------------
@@ -962,7 +957,7 @@ struct Series(Copyable, ImplicitlyCopyable, Movable):
             raise Error("Series.to_numpy: non-numeric dtype is not supported")
         ref data = col._f64_cache
         for i in range(n):
-            if col._null_mask.is_null(i):
+            if col.is_null(i):
                 result.append(nan)
             else:
                 result.append(data[i])
@@ -1068,7 +1063,7 @@ struct Series(Copyable, ImplicitlyCopyable, Movable):
             raise Error("Series.str: accessor requires a string Series")
         ref d = self._col._str_cache
         var data = d.copy()
-        var null_mask = self._col._null_mask.copy()
+        var null_mask = self._col.null_mask_copy()
         return StringMethods(data^, null_mask^, self._col.name)
 
     def dt(self) raises -> DatetimeMethods:
@@ -1076,7 +1071,7 @@ struct Series(Copyable, ImplicitlyCopyable, Movable):
             raise Error("Series.dt: accessor requires a datetime Series")
         ref d = self._col._storage_legacy().data
         var data = d.copy()
-        var null_mask = self._col._null_mask.copy()
+        var null_mask = self._col.null_mask_copy()
         return DatetimeMethods(data^, null_mask^, self._col.name)
 
     # ------------------------------------------------------------------
@@ -1326,8 +1321,7 @@ struct DataFrame(Copyable, Movable):
                     data.append(py_none)
                     null_mask.append_null()
                 var col = Column(col_name, data^, object_)
-                col._null_mask = null_mask^
-                col._try_activate_storage()
+                col.set_null_mask(null_mask^)
                 cols.append(col^)
                 continue
 
@@ -1361,8 +1355,7 @@ struct DataFrame(Copyable, Movable):
                     else:
                         null_mask.append_valid()
                 var col = Column(col_name, data^, string_)
-                col._null_mask = null_mask^
-                col._try_activate_storage()
+                col.set_null_mask(null_mask^)
                 cols.append(col^)
             elif has_float:
                 # Float64 dominates Int64 and Bool
@@ -1390,8 +1383,7 @@ struct DataFrame(Copyable, Movable):
                     else:
                         null_mask.append_valid()
                 var col = Column(col_name, data^, float64)
-                col._null_mask = null_mask^
-                col._try_activate_storage()
+                col.set_null_mask(null_mask^)
                 cols.append(col^)
             elif has_int:
                 # Int64 (Bool values are promoted to Int64)
@@ -1422,13 +1414,11 @@ struct DataFrame(Copyable, Movable):
                     for i in range(len(data)):
                         fdata.append(Float64(data[i]))
                     var col = Column(col_name, fdata^, float64)
-                    col._null_mask = null_mask^
-                    col._try_activate_storage()
+                    col.set_null_mask(null_mask^)
                     cols.append(col^)
                     continue
                 var col = Column(col_name, data^, int64)
-                col._null_mask = null_mask^
-                col._try_activate_storage()
+                col.set_null_mask(null_mask^)
                 cols.append(col^)
             else:  # Bool only
                 var data = List[Bool]()
@@ -1457,13 +1447,11 @@ struct DataFrame(Copyable, Movable):
                         else:
                             odata.append(PythonObject(data[i]))
                     var col = Column(col_name, odata^, object_)
-                    col._null_mask = null_mask^
-                    col._try_activate_storage()
+                    col.set_null_mask(null_mask^)
                     cols.append(col^)
                     continue
                 var col = Column(col_name, data^, bool_)
-                col._null_mask = null_mask^
-                col._try_activate_storage()
+                col.set_null_mask(null_mask^)
                 cols.append(col^)
 
         return DataFrame(cols^)
@@ -1631,7 +1619,7 @@ struct DataFrame(Copyable, Movable):
         if mask._col.is_bool():
             ref d = mask._col._bool_cache
             for i in range(mask_len):
-                if mask._col._null_mask.is_valid(i) and d[i]:
+                if mask._col.is_valid(i) and d[i]:
                     indices.append(i)
         else:
             raise Error(
@@ -1860,7 +1848,7 @@ struct DataFrame(Copyable, Movable):
             ref col = self._cols[ci]
             if not (col.dtype.is_integer() or col.dtype.is_float()):
                 continue
-            if col._null_mask.is_null(row):
+            if col.is_null(row):
                 if not skipna:
                     vals.append(nan)
                 continue
@@ -1872,7 +1860,7 @@ struct DataFrame(Copyable, Movable):
         """
         var cnt = 0
         for ci in range(len(self._cols)):
-            if self._cols[ci]._null_mask.is_valid(row):
+            if self._cols[ci].is_valid(row):
                 cnt += 1
         return cnt
 
@@ -2061,7 +2049,7 @@ struct DataFrame(Copyable, Movable):
                 var seen = Dict[String, Bool]()
                 for ci in range(len(self._cols)):
                     ref col = self._cols[ci]
-                    if col._null_mask.is_null(i):
+                    if col.is_null(i):
                         continue
                     var key: String
                     if col.is_int() or col.is_float():
@@ -2232,7 +2220,7 @@ struct DataFrame(Copyable, Movable):
             var propagate_nan = False
             for ci in range(ncols):
                 ref col = self._cols[ci]
-                if col._null_mask.is_null(i) or not (
+                if col.is_null(i) or not (
                     col.dtype.is_integer() or col.dtype.is_float()
                 ):
                     if not skipna:
@@ -2549,7 +2537,7 @@ struct DataFrame(Copyable, Movable):
                             "DataFrame.shift(axis=1) requires numeric columns"
                         )
                     for i in range(nrows):
-                        var is_null = src_col._null_mask.is_null(i)
+                        var is_null = src_col.is_null(i)
                         if is_null:
                             values.append(nan)
                             null_mask.append_null()
@@ -2558,8 +2546,7 @@ struct DataFrame(Copyable, Movable):
                             null_mask.append_valid()
                 var col = Column(self._cols[j].name, values^, float64)
                 if null_mask.has_nulls():
-                    col._null_mask = null_mask^
-                    col._try_activate_storage()
+                    col.set_null_mask(null_mask^)
                 result_cols.append(col^)
             return DataFrame(result_cols^)
         elif axis != 0:
@@ -2609,8 +2596,8 @@ struct DataFrame(Copyable, Movable):
                             "DataFrame.diff(axis=1) requires numeric columns"
                         )
                     for i in range(nrows):
-                        var cur_null = cur_col._null_mask.is_null(i)
-                        var src_null = src_col._null_mask.is_null(i)
+                        var cur_null = cur_col.is_null(i)
+                        var src_null = src_col.is_null(i)
                         if cur_null or src_null:
                             values.append(nan)
                             null_mask.append_null()
@@ -2621,8 +2608,7 @@ struct DataFrame(Copyable, Movable):
                             null_mask.append_valid()
                 var col = Column(self._cols[j].name, values^, float64)
                 if null_mask.has_nulls():
-                    col._null_mask = null_mask^
-                    col._try_activate_storage()
+                    col.set_null_mask(null_mask^)
                 result_cols.append(col^)
             return DataFrame(result_cols^)
         elif axis != 0:
@@ -2675,8 +2661,8 @@ struct DataFrame(Copyable, Movable):
                             " columns"
                         )
                     for i in range(nrows):
-                        var cur_null = cur_col._null_mask.is_null(i)
-                        var src_null = src_col._null_mask.is_null(i)
+                        var cur_null = cur_col.is_null(i)
+                        var src_null = src_col.is_null(i)
                         if cur_null or src_null:
                             values.append(nan)
                             null_mask.append_null()
@@ -2687,8 +2673,7 @@ struct DataFrame(Copyable, Movable):
                             null_mask.append_valid()
                 var col = Column(self._cols[j].name, values^, float64)
                 if null_mask.has_nulls():
-                    col._null_mask = null_mask^
-                    col._try_activate_storage()
+                    col.set_null_mask(null_mask^)
                 result_cols.append(col^)
             return DataFrame(result_cols^)
         elif axis != 0:
@@ -2991,20 +2976,20 @@ struct DataFrame(Copyable, Movable):
             var result_cols = List[Column]()
             for i in range(len(self._cols)):
                 var col = self._cols[i].copy()
-                var mask_len = len(col._null_mask)
                 var has_null = False
-                if mask_len > 0:
+                if col.has_nulls():
+                    var col_len = len(col)
                     if how == "all":
                         # Drop only when every value is null.
                         var all_null = True
-                        for j in range(mask_len):
-                            if col._null_mask.is_valid(j):
+                        for j in range(col_len):
+                            if col.is_valid(j):
                                 all_null = False
                                 break
                         has_null = all_null
                     else:
-                        for j in range(mask_len):
-                            if col._null_mask.is_null(j):
+                        for j in range(col_len):
+                            if col.is_null(j):
                                 has_null = True
                                 break
                 if not has_null:
@@ -3037,7 +3022,7 @@ struct DataFrame(Copyable, Movable):
             var check_count = len(check_indices)
             for ki in range(check_count):
                 var ci = check_indices[ki]
-                if self._cols[ci]._null_mask.is_null(r):
+                if self._cols[ci].is_null(r):
                     null_count += 1
 
             var keep: Bool
@@ -3093,7 +3078,7 @@ struct DataFrame(Copyable, Movable):
         var result_cols = List[Column]()
         for i in range(len(self._cols)):
             var col = self._cols[i].copy()
-            var has_mask = col._null_mask.has_nulls()
+            var has_mask = col.has_nulls()
             if not has_mask or not col.dtype.is_float():
                 result_cols.append(col^)
                 continue
@@ -3104,7 +3089,7 @@ struct DataFrame(Copyable, Movable):
             var new_mask = List[Bool]()
             for j in range(n):
                 data.append(d[j])
-                new_mask.append(col._null_mask.is_null(j))
+                new_mask.append(col.is_null(j))
             # Fill leading nulls with the first non-null value.
             var first_valid = -1
             for j in range(n):
@@ -3933,8 +3918,7 @@ struct DataFrame(Copyable, Movable):
             var col = Column(col_keys[ck], data^, object_)
             col._index = result_idx.copy()
             if null_mask.has_nulls():
-                col._null_mask = null_mask^
-                col._try_activate_storage()
+                col.set_null_mask(null_mask^)
             result_cols.append(col^)
 
         return DataFrame(result_cols^)
@@ -4130,7 +4114,7 @@ struct DataFrame(Copyable, Movable):
                         out_pos = vi * n_ck + ck
 
                 ref vcol = self._cols[name_to_ci[val_names[vi]]]
-                var is_null = vcol._null_mask.is_null(r)
+                var is_null = vcol.is_null(r)
                 if not is_null and vcol.is_object():
                     is_null = (
                         String(
@@ -4183,8 +4167,7 @@ struct DataFrame(Copyable, Movable):
             var col = Column(out_names[out_i], data^, object_)
             col._index = result_idx.copy()
             if null_mask.has_nulls():
-                col._null_mask = null_mask^
-                col._try_activate_storage()
+                col.set_null_mask(null_mask^)
             result_cols.append(col^)
 
         return DataFrame(result_cols^)
@@ -4270,7 +4253,7 @@ struct DataFrame(Copyable, Movable):
                 )
             ref vcol = self._cols[val_ci]
             for r in range(nrows):
-                var is_null = vcol._null_mask.is_null(r)
+                var is_null = vcol.is_null(r)
                 if is_null:
                     val_data.append(py_none)
                     val_null_mask.append_null()
@@ -4279,8 +4262,7 @@ struct DataFrame(Copyable, Movable):
                     val_data.append(_frame_cell_as_python(vcol, r))
         var val_col = Column(value_name, val_data^, object_)
         if val_null_mask.has_nulls():
-            val_col._null_mask = val_null_mask^
-            val_col._try_activate_storage()
+            val_col.set_null_mask(val_null_mask^)
         result_cols.append(val_col^)
 
         return DataFrame(result_cols^)
@@ -4313,7 +4295,7 @@ struct DataFrame(Copyable, Movable):
                 row_label = PythonObject(r)
             for j in range(ncols):
                 ref col = self._cols[j]
-                var is_null = col._null_mask.is_null(r)
+                var is_null = col.is_null(r)
                 var tup_items = py.list()
                 _ = tup_items.append(row_label)
                 _ = tup_items.append(PythonObject(col.name.value()))
@@ -4328,8 +4310,7 @@ struct DataFrame(Copyable, Movable):
 
         var result_col = Column("", val_data^, object_, ColumnIndex(idx_objs^))
         if null_mask.has_nulls():
-            result_col._null_mask = null_mask^
-            result_col._try_activate_storage()
+            result_col.set_null_mask(null_mask^)
         return Series(result_col^)
 
     def unstack(self, level: Int = -1) raises -> DataFrame:
@@ -4471,8 +4452,7 @@ struct DataFrame(Copyable, Movable):
                     col._index_names = List[String]()
                     col._index_name = rem_idx_names[0]
                 if null_mask.has_nulls():
-                    col._null_mask = null_mask^
-                    col._try_activate_storage()
+                    col.set_null_mask(null_mask^)
                 result_cols.append(col^)
 
         return DataFrame(result_cols^)
@@ -4510,7 +4490,7 @@ struct DataFrame(Copyable, Movable):
                     row_label = PythonObject(self._cols[0]._index_label(r))
                 else:
                     row_label = PythonObject(r)
-                var is_null = col._null_mask.is_null(r)
+                var is_null = col.is_null(r)
                 var tup_items = py.list()
                 _ = tup_items.append(col_label)
                 _ = tup_items.append(row_label)
@@ -4524,8 +4504,7 @@ struct DataFrame(Copyable, Movable):
 
         var result_col = Column("", val_data^, object_, ColumnIndex(idx_objs^))
         if null_mask.has_nulls():
-            result_col._null_mask = null_mask^
-            result_col._try_activate_storage()
+            result_col.set_null_mask(null_mask^)
         return Series(result_col^)
 
     def transpose(self) raises -> DataFrame:
@@ -4562,7 +4541,7 @@ struct DataFrame(Copyable, Movable):
             var null_mask = NullMask()
             for j in range(ncols):
                 ref col = self._cols[j]
-                var is_null = col._null_mask.is_null(r)
+                var is_null = col.is_null(r)
                 if is_null:
                     data.append(py_none)
                     null_mask.append_null()
@@ -4573,8 +4552,7 @@ struct DataFrame(Copyable, Movable):
             var new_col = Column(col_name, data^, object_)
             new_col._index = shared_idx.copy()
             if null_mask.has_nulls():
-                new_col._null_mask = null_mask^
-                new_col._try_activate_storage()
+                new_col.set_null_mask(null_mask^)
             result_cols.append(new_col^)
 
         return DataFrame(result_cols^)
@@ -4679,7 +4657,7 @@ struct DataFrame(Copyable, Movable):
         ]()  # position within expanded cell (-1 = scalar)
         ref exp_col = self._cols[col_ci]
         for r in range(nrows):
-            var is_null = exp_col._null_mask.is_null(r)
+            var is_null = exp_col.is_null(r)
             if is_null:
                 src_indices.append(r)
                 sub_indices.append(-1)
@@ -4712,7 +4690,7 @@ struct DataFrame(Copyable, Movable):
                 for k in range(n_out):
                     var r = src_indices[k]
                     var sub = sub_indices[k]
-                    var is_null = exp_col._null_mask.is_null(r)
+                    var is_null = exp_col.is_null(r)
                     if is_null:
                         data.append(py_none)
                         null_mask.append_null()
@@ -4727,8 +4705,7 @@ struct DataFrame(Copyable, Movable):
                         null_mask.append_valid()
                 var new_col = Column(column, data^, object_)
                 if null_mask.has_nulls():
-                    new_col._null_mask = null_mask^
-                    new_col._try_activate_storage()
+                    new_col.set_null_mask(null_mask^)
                 result_cols.append(new_col^)
             else:
                 # Other columns: repeat values by source row index.
@@ -5091,37 +5068,37 @@ struct DataFrame(Copyable, Movable):
                                         key_col._int64_data()[
                                             r
                                         ] = rk._int64_cache[out_right[r]]
-                                        key_col._null_mask.set_valid(r)
+                                        key_col.set_valid_at(r)
                             elif key_col.is_float() and rk.is_float():
                                 for r in range(len(out_left)):
                                     if out_left[r] < 0:
                                         key_col._float64_data()[
                                             r
                                         ] = rk._f64_cache[out_right[r]]
-                                        key_col._null_mask.set_valid(r)
+                                        key_col.set_valid_at(r)
                             elif key_col.is_bool() and rk.is_bool():
                                 for r in range(len(out_left)):
                                     if out_left[r] < 0:
                                         key_col._bool_data()[
                                             r
                                         ] = rk._bool_cache[out_right[r]]
-                                        key_col._null_mask.set_valid(r)
+                                        key_col.set_valid_at(r)
                             elif key_col.is_string() and rk.is_string():
                                 for r in range(len(out_left)):
                                     if out_left[r] < 0:
                                         key_col._str_data()[r] = rk._str_cache[
                                             out_right[r]
                                         ]
-                                        key_col._null_mask.set_valid(r)
+                                        key_col.set_valid_at(r)
                             elif key_col.is_object() and rk.is_object():
                                 for r in range(len(out_left)):
                                     if out_left[r] < 0:
-                                        key_col._obj_data()[
+                                        key_col._storage_legacy().data[
                                             r
                                         ] = rk._storage_legacy().data[
                                             out_right[r]
                                         ]
-                                        key_col._null_mask.set_valid(r)
+                                        key_col.set_valid_at(r)
                             break
                     # Sync secondary caches and rebuild marrow after
                     # cache-first key fill (#645).
@@ -5758,7 +5735,7 @@ struct DataFrame(Copyable, Movable):
             var row = List[Float64]()
             for ci in range(ncols):
                 ref col = self._cols[ci]
-                if col._null_mask.is_null(ri):
+                if col.is_null(ri):
                     row.append(nan)
                 else:
                     row.append(col._f64_cache[ri])
@@ -6065,8 +6042,8 @@ def _groupby_row_less(
     for key_i in range(len(by)):
         var ci = col_idx[by[key_i]]
         ref col = df._cols[ci]
-        var left_is_null = col._null_mask.is_null(left_row)
-        var right_is_null = col._null_mask.is_null(right_row)
+        var left_is_null = col.is_null(left_row)
+        var right_is_null = col.is_null(right_row)
         if left_is_null or right_is_null:
             if left_is_null and right_is_null:
                 continue
@@ -6161,7 +6138,7 @@ def _groupby_indices(
             for j in range(len(by)):
                 var ci = col_idx[by[j]]
                 ref col = df._cols[ci]
-                if col._null_mask.is_null(i):
+                if col.is_null(i):
                     skip = True
                     break
             if skip:
@@ -6580,8 +6557,7 @@ struct DataFrameGroupBy:
                 var col = Column(value_names[v], vals^, int64, idx.copy())
                 col._index_name = key_col_name
                 if null_mask.has_nulls():
-                    col._null_mask = null_mask^
-                    col._try_activate_storage()
+                    col.set_null_mask(null_mask^)
                 result_cols.append(col^)
             else:
                 # float64 result: mean, or float col sum/min/max.
@@ -6600,8 +6576,7 @@ struct DataFrameGroupBy:
                 var col = Column(value_names[v], vals^, float64, idx.copy())
                 col._index_name = key_col_name
                 if null_mask.has_nulls():
-                    col._null_mask = null_mask^
-                    col._try_activate_storage()
+                    col.set_null_mask(null_mask^)
                 result_cols.append(col^)
 
         return DataFrame(result_cols^)
@@ -6812,7 +6787,7 @@ struct DataFrameGroupBy:
                 ref indices = self._group_map[self._group_keys[j]]
                 var found = -1
                 for k in range(len(indices)):
-                    if col._null_mask.is_valid(indices[k]):
+                    if col.is_valid(indices[k]):
                         found = indices[k]
                         break
                 selected.append(found)
@@ -6840,7 +6815,7 @@ struct DataFrameGroupBy:
                 ref indices = self._group_map[self._group_keys[j]]
                 var found = -1
                 for k in range(len(indices) - 1, -1, -1):
-                    if col._null_mask.is_valid(indices[k]):
+                    if col.is_valid(indices[k]):
                         found = indices[k]
                         break
                 selected.append(found)
@@ -6941,7 +6916,7 @@ struct DataFrameGroupBy:
                     var step = 1 if want_first else -1
                     var ii = start
                     while ii != stop:
-                        if col._null_mask.is_valid(indices[ii]):
+                        if col.is_valid(indices[ii]):
                             found = indices[ii]
                             break
                         ii += step
@@ -7031,8 +7006,7 @@ struct DataFrameGroupBy:
                     null_mask.append_null()
             var result_col = Column(col.name, vals^, float64)
             if null_mask.has_nulls():
-                result_col._null_mask = null_mask^
-                result_col._try_activate_storage()
+                result_col.set_null_mask(null_mask^)
             result_cols.append(result_col^)
         return DataFrame(result_cols^)
 
@@ -7221,8 +7195,7 @@ struct SeriesGroupBy:
                     null_mask.append_valid()
             var col = Column(self._series.name, vals^, int64, idx^)
             if null_mask.has_nulls():
-                col._null_mask = null_mask^
-                col._try_activate_storage()
+                col.set_null_mask(null_mask^)
             return Series(col^)
         else:
             var vals = List[Float64]()
@@ -7239,8 +7212,7 @@ struct SeriesGroupBy:
                     null_mask.append_valid()
             var col = Column(self._series.name, vals^, float64, idx^)
             if null_mask.has_nulls():
-                col._null_mask = null_mask^
-                col._try_activate_storage()
+                col.set_null_mask(null_mask^)
             return Series(col^)
 
     def sum(self) raises -> Series:
@@ -7344,7 +7316,7 @@ struct SeriesGroupBy:
             ref indices = self._group_map[self._group_keys[i]]
             var found = -1
             for j in range(len(indices)):
-                if col._null_mask.is_valid(indices[j]):
+                if col.is_valid(indices[j]):
                     found = indices[j]
                     break
             selected.append(found)
@@ -7360,7 +7332,7 @@ struct SeriesGroupBy:
             ref indices = self._group_map[self._group_keys[i]]
             var found = -1
             for j in range(len(indices) - 1, -1, -1):
-                if col._null_mask.is_valid(indices[j]):
+                if col.is_valid(indices[j]):
                     found = indices[j]
                     break
             selected.append(found)
@@ -7503,8 +7475,7 @@ struct SeriesGroupBy:
                     null_mask.append_valid()
             var result_col = Column(self._series.name, result_vals^, float64)
             if null_mask.has_nulls():
-                result_col._null_mask = null_mask^
-                result_col._try_activate_storage()
+                result_col.set_null_mask(null_mask^)
             result_col._index = self._series._col._index.copy()
             result_col._index_name = self._series._col._index_name
             return Series(result_col^)
@@ -7531,8 +7502,7 @@ struct SeriesGroupBy:
                 var result_col = Column(
                     self._series.name, result_vals^, float64
                 )
-                result_col._null_mask = null_mask^
-                result_col._try_activate_storage()
+                result_col.set_null_mask(null_mask^)
                 result_col._index = self._series._col._index.copy()
                 result_col._index_name = self._series._col._index_name
                 return Series(result_col^)
@@ -7557,7 +7527,7 @@ struct SeriesGroupBy:
                 var step = 1 if want_first else -1
                 var j = start
                 while j != stop:
-                    if col._null_mask.is_valid(indices[j]):
+                    if col.is_valid(indices[j]):
                         found = indices[j]
                         break
                     j += step
@@ -7698,7 +7668,7 @@ def _set_series_scalar_in_col(
     """Write a ``SeriesScalar`` cell into *col* at position *row*."""
     if value.isa[PythonObject]():
         if col.is_object():
-            col._obj_data()[row] = value[PythonObject]
+            col._storage_legacy().data[row] = value[PythonObject]
         else:
             raise Error("iloc: cannot assign PythonObject to typed column")
         col._rebuild_marrow_only()

--- a/bison/accessors/dt_accessor.mojo
+++ b/bison/accessors/dt_accessor.mojo
@@ -54,7 +54,7 @@ struct DatetimeMethods:
                 result.append(Int64(Int(py=self._data[i].__getattr__(attr))))
                 new_mask.append_valid()
         var col = Column(self._name, result^, int64)
-        col._null_mask = new_mask^
+        col.set_null_mask(new_mask^)
         return col^
 
     def year(self) raises -> Column:
@@ -99,7 +99,7 @@ struct DatetimeMethods:
                 result.append(self._data[i].date())
                 new_mask.append_valid()
         var col = Column(self._name, result^, object_)
-        col._null_mask = new_mask^
+        col.set_null_mask(new_mask^)
         return col^
 
     def time(self) raises -> Column:
@@ -113,7 +113,7 @@ struct DatetimeMethods:
                 result.append(self._data[i].time())
                 new_mask.append_valid()
         var col = Column(self._name, result^, object_)
-        col._null_mask = new_mask^
+        col.set_null_mask(new_mask^)
         return col^
 
     # ------------------------------------------------------------------
@@ -139,7 +139,7 @@ struct DatetimeMethods:
                 result.append(self._data[i].__getattr__(method)(arg))
                 new_mask.append_valid()
         var col = Column(self._name, result^, datetime64_ns)
-        col._null_mask = new_mask^
+        col.set_null_mask(new_mask^)
         return col^
 
     def tz_localize(self, tz: String) raises -> Column:

--- a/bison/accessors/str_accessor.mojo
+++ b/bison/accessors/str_accessor.mojo
@@ -46,7 +46,7 @@ struct StringMethods:
             else:
                 result.append(self._data[i].upper())
         var col = Column(self._name, result^, string_)
-        col._null_mask = self._null_mask.copy()
+        col.set_null_mask(self._null_mask.copy())
         return col^
 
     def lower(self) raises -> Column:
@@ -57,7 +57,7 @@ struct StringMethods:
             else:
                 result.append(self._data[i].lower())
         var col = Column(self._name, result^, string_)
-        col._null_mask = self._null_mask.copy()
+        col.set_null_mask(self._null_mask.copy())
         return col^
 
     # ------------------------------------------------------------------
@@ -74,7 +74,7 @@ struct StringMethods:
             else:
                 result.append(String(self._data[i].strip(to_strip)))
         var col = Column(self._name, result^, string_)
-        col._null_mask = self._null_mask.copy()
+        col.set_null_mask(self._null_mask.copy())
         return col^
 
     def lstrip(self, to_strip: String = "") raises -> Column:
@@ -87,7 +87,7 @@ struct StringMethods:
             else:
                 result.append(String(self._data[i].lstrip(to_strip)))
         var col = Column(self._name, result^, string_)
-        col._null_mask = self._null_mask.copy()
+        col.set_null_mask(self._null_mask.copy())
         return col^
 
     def rstrip(self, to_strip: String = "") raises -> Column:
@@ -100,7 +100,7 @@ struct StringMethods:
             else:
                 result.append(String(self._data[i].rstrip(to_strip)))
         var col = Column(self._name, result^, string_)
-        col._null_mask = self._null_mask.copy()
+        col.set_null_mask(self._null_mask.copy())
         return col^
 
     # ------------------------------------------------------------------
@@ -123,7 +123,7 @@ struct StringMethods:
                     result.append(self._data[i].lower().find(pat.lower()) != -1)
                 new_mask.append_valid()
         var col = Column(self._name, result^, bool_)
-        col._null_mask = new_mask^
+        col.set_null_mask(new_mask^)
         return col^
 
     def startswith(self, pat: String) raises -> Column:
@@ -137,7 +137,7 @@ struct StringMethods:
                 result.append(self._data[i].startswith(pat))
                 new_mask.append_valid()
         var col = Column(self._name, result^, bool_)
-        col._null_mask = new_mask^
+        col.set_null_mask(new_mask^)
         return col^
 
     def endswith(self, pat: String) raises -> Column:
@@ -151,7 +151,7 @@ struct StringMethods:
                 result.append(self._data[i].endswith(pat))
                 new_mask.append_valid()
         var col = Column(self._name, result^, bool_)
-        col._null_mask = new_mask^
+        col.set_null_mask(new_mask^)
         return col^
 
     # ------------------------------------------------------------------
@@ -173,7 +173,7 @@ struct StringMethods:
             else:
                 result.append(self._data[i].replace(pat, repl))
         var col = Column(self._name, result^, string_)
-        col._null_mask = self._null_mask.copy()
+        col.set_null_mask(self._null_mask.copy())
         return col^
 
     def split(
@@ -214,7 +214,7 @@ struct StringMethods:
                 result.append(Int64(len(self._data[i])))
                 new_mask.append_valid()
         var col = Column(self._name, result^, int64)
-        col._null_mask = new_mask^
+        col.set_null_mask(new_mask^)
         return col^
 
     def find(self, sub: String, start: Int = 0, end: Int = -1) raises -> Column:
@@ -232,7 +232,7 @@ struct StringMethods:
                 result.append(Int64(pos))
                 new_mask.append_valid()
         var col = Column(self._name, result^, int64)
-        col._null_mask = new_mask^
+        col.set_null_mask(new_mask^)
         return col^
 
     def count(self, pat: String) raises -> Column:
@@ -249,7 +249,7 @@ struct StringMethods:
                 result.append(Int64(Int(py=matches.__len__())))
                 new_mask.append_valid()
         var col = Column(self._name, result^, int64)
-        col._null_mask = new_mask^
+        col.set_null_mask(new_mask^)
         return col^
 
     # ------------------------------------------------------------------
@@ -279,7 +279,7 @@ struct StringMethods:
                     result.append(char_val)
                     new_mask.append_valid()
         var col = Column(self._name, result^, string_)
-        col._null_mask = new_mask^
+        col.set_null_mask(new_mask^)
         return col^
 
     def slice(
@@ -306,7 +306,7 @@ struct StringMethods:
                 result.append(sub)
                 new_mask.append_valid()
         var col = Column(self._name, result^, string_)
-        col._null_mask = new_mask^
+        col.set_null_mask(new_mask^)
         return col^
 
     # ------------------------------------------------------------------
@@ -343,5 +343,5 @@ struct StringMethods:
                 result.append(Bool(m.__bool__()))
                 new_mask.append_valid()
         var col = Column(self._name, result^, bool_)
-        col._null_mask = new_mask^
+        col.set_null_mask(new_mask^)
         return col^

--- a/bison/arrow.mojo
+++ b/bison/arrow.mojo
@@ -38,8 +38,8 @@ from .dtypes import int64, float64, bool_, object_, string_
 
 
 def _is_null(col: Column, i: Int) -> Bool:
-    """Return True if element i is null in col._null_mask."""
-    return len(col._null_mask) > 0 and col._null_mask[i]
+    """Return True if element i is null."""
+    return col.is_null(i)
 
 
 # ------------------------------------------------------------------
@@ -50,9 +50,8 @@ def _is_null(col: Column, i: Int) -> Bool:
 def column_to_marrow_array(col: Column) raises -> AnyArray:
     """Convert a bison Column to a marrow AnyArray.
 
-    Null elements (where _null_mask[i] is True) become Arrow null values.
-    An empty _null_mask means no nulls. List[PythonObject] columns raise
-    an error — Arrow has no object type.
+    Null elements become Arrow null values.
+    List[PythonObject] columns raise an error — Arrow has no object type.
     """
     var n = len(col)
 
@@ -106,16 +105,14 @@ def column_to_marrow_array(col: Column) raises -> AnyArray:
 def marrow_array_to_column(arr: AnyArray, name: String) raises -> Column:
     """Convert a marrow AnyArray to a bison Column.
 
-    Arrow null elements (validity bit = 0) become True entries in
-    _null_mask. A fully-valid array leaves _null_mask empty (bison's
+    Arrow null elements (validity bit = 0) are recorded via the column's
+    null mask. A fully-valid array leaves the mask empty (bison's
     no-nulls sentinel). Only int64, float64, bool, and string Arrow
     types are supported.
 
     The input ``arr`` is also stored directly on the returned column's
     ``_storage`` field (zero-copy via ArcPointer ref-bump) so
     dual-backend readers can use the marrow representation immediately.
-    The legacy ``_data``/``_null_mask`` fields are populated in parallel
-    until the Phase 6-7 cleanup removes them.
     """
     var dt = arr.dtype()
     var n = arr.length()
@@ -133,7 +130,7 @@ def marrow_array_to_column(arr: AnyArray, name: String) raises -> Column:
                 null_mask.append_valid()
         var col = Column(name, ColumnData(data^), int64)
         if null_mask.has_nulls():
-            col._null_mask = null_mask^
+            col.set_null_mask(null_mask^)
         col._storage = ColumnStorage(arr.copy())
         return col^
 
@@ -150,7 +147,7 @@ def marrow_array_to_column(arr: AnyArray, name: String) raises -> Column:
                 null_mask.append_valid()
         var col = Column(name, ColumnData(data^), float64)
         if null_mask.has_nulls():
-            col._null_mask = null_mask^
+            col.set_null_mask(null_mask^)
         col._storage = ColumnStorage(arr.copy())
         return col^
 
@@ -167,7 +164,7 @@ def marrow_array_to_column(arr: AnyArray, name: String) raises -> Column:
                 null_mask.append_valid()
         var col = Column(name, ColumnData(data^), bool_)
         if null_mask.has_nulls():
-            col._null_mask = null_mask^
+            col.set_null_mask(null_mask^)
         col._storage = ColumnStorage(arr.copy())
         return col^
 
@@ -185,7 +182,7 @@ def marrow_array_to_column(arr: AnyArray, name: String) raises -> Column:
         # #644: string-backed columns carry string_ dtype.
         var col = Column(name, ColumnData(data^), string_)
         if null_mask.has_nulls():
-            col._null_mask = null_mask^
+            col.set_null_mask(null_mask^)
         col._storage = ColumnStorage(arr.copy())
         return col^
 

--- a/bison/column.mojo
+++ b/bison/column.mojo
@@ -1000,13 +1000,13 @@ def _column_to_marrow_array(col: Column) raises -> AnyArray:
     ``array[_m_int64]`` / ``array[_m_float64]`` specialisations.
     """
     var n = len(col)
-    var has_mask = col._null_mask.has_nulls()
+    var has_mask = col.has_nulls()
 
     if col.is_int():
         ref src = col._int64_data()
         var vals = List[Optional[Int]](capacity=n)
         for i in range(n):
-            if has_mask and col._null_mask.is_null(i):
+            if has_mask and col.is_null(i):
                 vals.append(None)
             else:
                 vals.append(Int(src[i]))
@@ -1016,7 +1016,7 @@ def _column_to_marrow_array(col: Column) raises -> AnyArray:
         ref src = col._float64_data()
         var vals = List[Optional[Float64]](capacity=n)
         for i in range(n):
-            if has_mask and col._null_mask.is_null(i):
+            if has_mask and col.is_null(i):
                 vals.append(None)
             else:
                 vals.append(src[i])
@@ -1026,7 +1026,7 @@ def _column_to_marrow_array(col: Column) raises -> AnyArray:
         ref src = col._bool_data()
         var vals = List[Optional[Bool]](capacity=n)
         for i in range(n):
-            if has_mask and col._null_mask.is_null(i):
+            if has_mask and col.is_null(i):
                 vals.append(None)
             else:
                 vals.append(src[i])
@@ -2809,7 +2809,7 @@ struct _CmpOpVisitor[op: Int](ColumnDataVisitorRaises, Copyable, Movable):
 
     def __init__(out self, self_null_mask: NullMask, other: Column) raises:
         self.self_null_mask = self_null_mask.copy()
-        self.other_null_mask = other._null_mask.copy()
+        self.other_null_mask = other.null_mask_copy()
         self.result = List[Bool]()
         self.result_mask = List[Bool]()
         self.has_any_null = False
@@ -3191,7 +3191,7 @@ struct _BoolOpVisitor[op: Int](ColumnDataVisitorRaises, Copyable, Movable):
         if not other._data.isa[List[Bool]]():
             raise Error("bool_op: non-bool column type on right-hand side")
         self.self_null_mask = self_null_mask.copy()
-        self.other_null_mask = other._null_mask.copy()
+        self.other_null_mask = other.null_mask_copy()
         self.other_bool = other._data[List[Bool]].copy()
         self.result = List[Bool]()
         self.result_mask = List[Bool]()
@@ -4514,15 +4514,15 @@ struct Column(Copyable, ImplicitlyCopyable, Movable, Sized):
     pandas-compatible dtype string so that round-trips through ``to_pandas``
     preserve the original dtype.
 
-    Null tracking: ``_null_mask`` is a ``NullMask`` where each ``True`` entry
-    marks a null/NaN element.  An empty mask means no nulls are present.
+    Null tracking is handled by the ``_storage`` Variant.  ``AnyArray``
+    columns store nulls in the Arrow validity bitmap; ``LegacyObjectData``
+    columns carry a ``NullMask`` inside the struct.
     """
 
     var name: Optional[String]
     var dtype: BisonDtype
     var _data: ColumnData
     var _index: ColumnIndex
-    var _null_mask: NullMask
     # Level names for a multi-key index set via DataFrame.set_index.
     # Empty when the index is a single-key or default RangeIndex.
     var _index_names: List[String]
@@ -4534,7 +4534,7 @@ struct Column(Copyable, ImplicitlyCopyable, Movable, Sized):
     # Dual-backend storage scaffolding (#619, Phase 1)
     # ------------------------------------------------------------------
     # ``_storage`` is the *new* representation that will eventually replace
-    # ``_data`` + ``_null_mask`` (see the LegacyObjectData / ColumnStorage
+    # ``_data`` (see the LegacyObjectData / ColumnStorage
     # comment block at the top of this file).  Post-#647 every constructor
     # populates ``_storage`` with a concrete arm (``AnyArray`` or
     # ``LegacyObjectData``) — the redundant ``_storage_active`` flag is
@@ -4565,7 +4565,7 @@ struct Column(Copyable, ImplicitlyCopyable, Movable, Sized):
         self.dtype = object_
         self._data = ColumnData(List[PythonObject]())
         self._index = ColumnIndex(List[PythonObject]())
-        self._null_mask = NullMask()
+
         self._index_names = List[String]()
         self._index_name = String("")
         # Empty LegacyObjectData arm — matches _data's initial state so
@@ -4586,7 +4586,7 @@ struct Column(Copyable, ImplicitlyCopyable, Movable, Sized):
         self.dtype = dtype
         self._data = data^
         self._index = ColumnIndex(List[PythonObject]())
-        self._null_mask = NullMask()
+
         self._index_names = List[String]()
         self._index_name = String("")
         self._storage = ColumnStorage(LegacyObjectData())
@@ -4610,7 +4610,7 @@ struct Column(Copyable, ImplicitlyCopyable, Movable, Sized):
         self.dtype = dtype
         self._data = data^
         self._index = index^
-        self._null_mask = NullMask()
+
         self._index_names = List[String]()
         self._index_name = String("")
         self._storage = ColumnStorage(LegacyObjectData())
@@ -4734,7 +4734,7 @@ struct Column(Copyable, ImplicitlyCopyable, Movable, Sized):
     # Traits
     # NOTE: ColumnData and ColumnIndex are Variant types. Nightly Mojo no
     # longer allows implicit copies of Variant, so both require explicit
-    # .copy() calls. _null_mask: NullMask also requires explicit .copy().
+    # .copy() calls.
     # ------------------------------------------------------------------
 
     def __init__(out self, *, copy: Self):
@@ -4742,7 +4742,6 @@ struct Column(Copyable, ImplicitlyCopyable, Movable, Sized):
         self.dtype = copy.dtype
         self._data = copy._data.copy()
         self._index = copy._index.copy()
-        self._null_mask = copy._null_mask.copy()
         self._index_names = copy._index_names.copy()
         self._index_name = copy._index_name
         self._storage = copy._storage.copy()
@@ -4756,7 +4755,6 @@ struct Column(Copyable, ImplicitlyCopyable, Movable, Sized):
         self.dtype = take.dtype^
         self._data = take._data^
         self._index = take._index^
-        self._null_mask = take._null_mask^
         self._index_names = take._index_names^
         self._index_name = take._index_name^
         self._storage = take._storage^
@@ -4787,8 +4785,8 @@ struct Column(Copyable, ImplicitlyCopyable, Movable, Sized):
     def _str_data(ref self) -> ref[self._str_cache] List[String]:
         return self._str_cache
 
-    def _obj_data(ref self) -> ref[self._data] List[PythonObject]:
-        return self._data[List[PythonObject]]
+    # _obj_data() removed in #656 Part 2b — callers now use
+    # _storage_legacy().data directly.
 
     # ------------------------------------------------------------------
     # Typed-array accessor helpers — read from the ``AnyArray`` arm of
@@ -4894,6 +4892,102 @@ struct Column(Copyable, ImplicitlyCopyable, Movable, Sized):
         """Return True if element at *index* is non-null."""
         return not self.is_null(index)
 
+    def null_mask_copy(self) raises -> NullMask:
+        """Return a NullMask materialised from the active storage arm.
+
+        ``AnyArray`` columns convert the Arrow validity bitmap (set = valid)
+        to bison semantics (set = null).  ``LegacyObjectData`` columns
+        return a copy of the bundled ``NullMask``.
+        """
+        if self._storage.isa[AnyArray]():
+            ref arr = self._storage[AnyArray]
+            var n = len(self)
+            var mask = NullMask()
+            for i in range(n):
+                if arr.is_valid(i):
+                    mask.append_valid()
+                else:
+                    mask.append_null()
+            return mask^
+        return self._storage[LegacyObjectData].null_mask.copy()
+
+    def set_null_mask(mut self, var mask: NullMask) raises:
+        """Set the null mask on the active storage arm.
+
+        For ``LegacyObjectData`` columns the mask is stored directly.
+        For ``AnyArray`` columns the marrow array is rebuilt from typed
+        caches incorporating the new mask (string-with-nulls columns
+        are demoted to ``LegacyObjectData`` because marrow lacks a
+        public string+null builder).
+        """
+        if self._storage.isa[LegacyObjectData]():
+            self._storage[LegacyObjectData].null_mask = mask^
+            return
+
+        # AnyArray arm — rebuild from typed caches + new mask.
+        if not mask.has_nulls():
+            # No nulls: keep the existing AnyArray as-is.
+            return
+
+        # String-with-nulls: demote to LegacyObjectData.
+        if self.is_string():
+            self._storage = ColumnStorage(
+                LegacyObjectData(List[PythonObject](), mask^)
+            )
+            return
+
+        # Numeric / bool with nulls: rebuild marrow array from caches + mask.
+        var n = len(self)
+        if self.is_int():
+            ref src = self._int64_cache
+            var vals = List[Optional[Int]](capacity=n)
+            for i in range(n):
+                if mask.is_null(i):
+                    vals.append(None)
+                else:
+                    vals.append(Int(src[i]))
+            self._storage = ColumnStorage(
+                AnyArray(_marrow_array[Int64Type](vals^))
+            )
+        elif self.is_float():
+            ref src = self._f64_cache
+            var vals = List[Optional[Float64]](capacity=n)
+            for i in range(n):
+                if mask.is_null(i):
+                    vals.append(None)
+                else:
+                    vals.append(src[i])
+            self._storage = ColumnStorage(
+                AnyArray(_marrow_array[Float64Type](vals^))
+            )
+        elif self.is_bool():
+            ref src = self._bool_cache
+            var vals = List[Optional[Bool]](capacity=n)
+            for i in range(n):
+                if mask.is_null(i):
+                    vals.append(None)
+                else:
+                    vals.append(src[i])
+            self._storage = ColumnStorage(AnyArray(_marrow_array(vals^)))
+
+    def clear_null_mask(mut self) raises:
+        """Reset all null bits — marks every element as valid."""
+        self.set_null_mask(NullMask())
+
+    def set_valid_at(mut self, index: Int) raises:
+        """Mark a single element as valid (not null).
+
+        For ``LegacyObjectData`` columns this updates the ``NullMask``
+        in place.  For ``AnyArray`` columns the array is rebuilt.
+        """
+        if self._storage.isa[LegacyObjectData]():
+            self._storage[LegacyObjectData].null_mask.set_valid(index)
+            return
+        # AnyArray — materialise mask, flip the bit, rebuild.
+        var mask = self.null_mask_copy()
+        mask.set_valid(index)
+        self.set_null_mask(mask^)
+
     # ------------------------------------------------------------------
     # Storage activation (#619, Phase 6c)
     # ------------------------------------------------------------------
@@ -4901,7 +4995,7 @@ struct Column(Copyable, ImplicitlyCopyable, Movable, Sized):
     # the ``_storage`` field from an already-constructed legacy Column.
     # Construction paths (``from_pandas``, CSV/JSON readers, ``arrow.mojo``
     # converters, aggregation-output helpers) call this after writing
-    # ``_data`` and ``_null_mask`` so the storage backend becomes live.
+    # ``_data`` so the storage backend becomes live.
     #
     # Post-#647, this method **always** populates ``_storage`` with a
     # concrete arm:
@@ -4916,12 +5010,12 @@ struct Column(Copyable, ImplicitlyCopyable, Movable, Sized):
     # column simply rebuilds the storage and caches from scratch.
 
     def _try_activate_storage(mut self):
-        """Rebuild ``_storage`` and the typed caches from ``_data``/``_null_mask``.
+        """Rebuild ``_storage`` and the typed caches from ``_data``.
 
         Always resets and re-reads — idempotent-like-rebuild rather than
-        idempotent-no-op.  Callers that mutate ``_null_mask`` or ``_data``
-        after construction must call this again to keep the storage
-        backend and caches in sync.
+        idempotent-no-op.  Callers that mutate ``_data`` after construction
+        must call this again to keep the storage backend and caches in sync.
+        Null mask updates should go through ``set_null_mask()`` instead.
 
         Post-#647: This method **always** populates ``_storage`` with a
         concrete arm:
@@ -4981,7 +5075,7 @@ struct Column(Copyable, ImplicitlyCopyable, Movable, Sized):
                 self._storage = ColumnStorage(
                     LegacyObjectData(
                         self._data[List[PythonObject]].copy(),
-                        self._null_mask.copy(),
+                        NullMask(),
                     )
                 )
             else:
@@ -4990,7 +5084,7 @@ struct Column(Copyable, ImplicitlyCopyable, Movable, Sized):
                 self._storage = ColumnStorage(
                     LegacyObjectData(
                         List[PythonObject](),
-                        self._null_mask.copy(),
+                        NullMask(),
                     )
                 )
 
@@ -5020,6 +5114,14 @@ struct Column(Copyable, ImplicitlyCopyable, Movable, Sized):
         # Float: _f64_cache is already the primary cache (mutation went there).
         # String/Object: no _f64_cache to sync.
 
+        # Save the old null mask / object data from _storage before
+        # overwriting — needed for the LegacyObjectData fallback path.
+        var old_obj_data = List[PythonObject]()
+        var old_mask = NullMask()
+        if self._storage.isa[LegacyObjectData]():
+            old_obj_data = self._storage[LegacyObjectData].data.copy()
+            old_mask = self._storage[LegacyObjectData].null_mask.copy()
+
         # Rebuild storage — try marrow first, fall back to LegacyObjectData.
         var marrow_ok = False
         try:
@@ -5034,17 +5136,11 @@ struct Column(Copyable, ImplicitlyCopyable, Movable, Sized):
                 self.dtype == datetime64_ns or self.dtype == timedelta64_ns
             ):
                 self._storage = ColumnStorage(
-                    LegacyObjectData(
-                        self._data[List[PythonObject]].copy(),
-                        self._null_mask.copy(),
-                    )
+                    LegacyObjectData(old_obj_data^, old_mask^)
                 )
             else:
                 self._storage = ColumnStorage(
-                    LegacyObjectData(
-                        List[PythonObject](),
-                        self._null_mask.copy(),
-                    )
+                    LegacyObjectData(List[PythonObject](), old_mask^)
                 )
 
     # ------------------------------------------------------------------
@@ -5166,9 +5262,7 @@ struct Column(Copyable, ImplicitlyCopyable, Movable, Sized):
         var visitor = _CopyDataVisitor()
         self._visit(visitor)
         var idx = self._index.copy()
-        var mask = self._null_mask.copy()
         var col = Column(self.name, visitor^.result.copy(), self.dtype, idx^)
-        col._null_mask = mask^
         col._index_names = self._index_names.copy()
         col._index_name = self._index_name
         # Copy storage backend and typed caches (always populated post-#647).
@@ -5257,7 +5351,7 @@ struct Column(Copyable, ImplicitlyCopyable, Movable, Sized):
             perm.append(i)
         if n <= 1:
             return perm^
-        ref null_mask = self._null_mask
+        var null_mask = self.null_mask_copy()
         # Prefer typed caches for sorting (#619 Phase 6c).
         if len(self._int64_cache) > 0:
             _merge_sort_perm_comparable(
@@ -5363,9 +5457,9 @@ struct Column(Copyable, ImplicitlyCopyable, Movable, Sized):
         if e > n:
             e = n
         var new_mask = NullMask()
-        if self._null_mask.has_nulls():
+        if self.has_nulls():
             for i in range(s, e):
-                new_mask.append(self._null_mask[i])
+                new_mask.append(self.is_null(i))
         # Fast path: slice from typed caches when available (#619 Phase 6b).
         var col: Column
         if len(self._int64_cache) > 0:
@@ -5393,17 +5487,17 @@ struct Column(Copyable, ImplicitlyCopyable, Movable, Sized):
             self._visit(visitor)
             col = Column(self.name, visitor^.result.copy(), self.dtype)
         if new_mask.has_nulls():
-            col._null_mask = new_mask^
+            col.set_null_mask(new_mask^)
         return col^
 
     def take(self, indices: List[Int]) raises -> Column:
         """Return a new Column with rows selected by *indices* (arbitrary order).
         """
-        var has_mask = self._null_mask.has_nulls()
+        var has_mask = self.has_nulls()
         var new_mask = NullMask()
         if has_mask:
             for k in range(len(indices)):
-                new_mask.append(self._null_mask[indices[k]])
+                new_mask.append(self.is_null(indices[k]))
         # Fast path: take from typed caches when available (#619 Phase 6b).
         var col: Column
         if len(self._int64_cache) > 0:
@@ -5431,22 +5525,18 @@ struct Column(Copyable, ImplicitlyCopyable, Movable, Sized):
             self._visit(visitor)
             col = Column(self.name, visitor^.result.copy(), self.dtype)
         if new_mask.has_nulls():
-            col._null_mask = new_mask^
-        # Activate storage on the new column (#619 Phase 4).
-        col._try_activate_storage()
+            col.set_null_mask(new_mask^)
         return col^
 
     def take_with_nulls(self, indices: List[Int]) raises -> Column:
         """Like take() but index -1 inserts a null placeholder row."""
-        var visitor = _TakeWithNullsVisitor(indices, self._null_mask)
+        var visitor = _TakeWithNullsVisitor(indices, self.null_mask_copy())
         self._visit_raises(visitor)
         # Save out_mask before consuming visitor to avoid partial-move issues.
         var out_mask = visitor.out_mask.copy()
         var col = Column(self.name, visitor^.result.copy(), self.dtype)
         if out_mask.has_nulls():
-            col._null_mask = out_mask^
-        # Activate storage on the new column (#619 Phase 4).
-        col._try_activate_storage()
+            col.set_null_mask(out_mask^)
         return col^
 
     def concat(self, other: Column) raises -> Column:
@@ -5455,20 +5545,16 @@ struct Column(Copyable, ImplicitlyCopyable, Movable, Sized):
         self._visit_raises(visitor)
         var col = Column(self.name, visitor^.result.copy(), self.dtype)
         # Merge null masks only when at least one side has nulls
-        if self._null_mask.has_nulls() or other._null_mask.has_nulls():
+        if self.has_nulls() or other.has_nulls():
             var n_self = len(self)
             var n_other = len(other)
             var merged = NullMask()
             for i in range(n_self):
-                merged.append(
-                    self._null_mask.has_nulls() and self._null_mask[i]
-                )
+                merged.append(self.has_nulls() and self.is_null(i))
             for i in range(n_other):
-                merged.append(
-                    other._null_mask.has_nulls() and other._null_mask[i]
-                )
+                merged.append(other.has_nulls() and other.is_null(i))
             if merged.has_nulls():
-                col._null_mask = merged^
+                col.set_null_mask(merged^)
         return col^
 
     # ------------------------------------------------------------------
@@ -5512,18 +5598,18 @@ struct Column(Copyable, ImplicitlyCopyable, Movable, Sized):
             var arr = _to_numeric_marrow_array(self)
             return _marrow_scalar_to_float64(_marrow_sum(arr))
         # Fall back to visitor for Bool/String/PythonObject or legacy mode.
-        var visitor = _SumVisitor(self._null_mask)
+        var visitor = _SumVisitor(self.null_mask_copy())
         self._visit_raises(visitor)
         return visitor.result
 
     def count(self) -> Int:
         """Return the number of non-null elements."""
         var n = len(self)
-        if not self._null_mask.has_nulls():
+        if not self.has_nulls():
             return n
         var result = 0
         for i in range(n):
-            if not self._null_mask[i]:
+            if not self.is_null(i):
                 result += 1
         return result
 
@@ -5565,7 +5651,7 @@ struct Column(Copyable, ImplicitlyCopyable, Movable, Sized):
             var arr = _to_numeric_marrow_array(self)
             return _marrow_scalar_to_float64(_marrow_min(arr))
         # Fall back to visitor for Bool/String/PythonObject or legacy mode.
-        var visitor = _ExtremumVisitor[True](self._null_mask)
+        var visitor = _ExtremumVisitor[True](self.null_mask_copy())
         self._visit_raises(visitor)
         if not visitor.found:
             var zero = Float64(0)
@@ -5598,7 +5684,7 @@ struct Column(Copyable, ImplicitlyCopyable, Movable, Sized):
             var arr = _to_numeric_marrow_array(self)
             return _marrow_scalar_to_float64(_marrow_max(arr))
         # Fall back to visitor for Bool/String/PythonObject or legacy mode.
-        var visitor = _ExtremumVisitor[False](self._null_mask)
+        var visitor = _ExtremumVisitor[False](self.null_mask_copy())
         self._visit_raises(visitor)
         if not visitor.found:
             var zero = Float64(0)
@@ -5608,10 +5694,10 @@ struct Column(Copyable, ImplicitlyCopyable, Movable, Sized):
     def sum_int64(self) raises -> Int64:
         """Return the sum of an Int64 column as Int64, skipping nulls."""
         ref data = self._int64_data()
-        var has_mask = self._null_mask.has_nulls()
+        var has_mask = self.has_nulls()
         var result = Int64(0)
         for i in range(len(data)):
-            if has_mask and self._null_mask[i]:
+            if has_mask and self.is_null(i):
                 continue
             result += data[i]
         return result
@@ -5619,11 +5705,11 @@ struct Column(Copyable, ImplicitlyCopyable, Movable, Sized):
     def min_int64(self) raises -> Int64:
         """Return the minimum of an Int64 column as Int64, skipping nulls."""
         ref data = self._int64_data()
-        var has_mask = self._null_mask.has_nulls()
+        var has_mask = self.has_nulls()
         var found = False
         var result = Int64(0)
         for i in range(len(data)):
-            if has_mask and self._null_mask[i]:
+            if has_mask and self.is_null(i):
                 continue
             if not found or data[i] < result:
                 result = data[i]
@@ -5633,11 +5719,11 @@ struct Column(Copyable, ImplicitlyCopyable, Movable, Sized):
     def max_int64(self) raises -> Int64:
         """Return the maximum of an Int64 column as Int64, skipping nulls."""
         ref data = self._int64_data()
-        var has_mask = self._null_mask.has_nulls()
+        var has_mask = self.has_nulls()
         var found = False
         var result = Int64(0)
         for i in range(len(data)):
-            if has_mask and self._null_mask[i]:
+            if has_mask and self.is_null(i):
                 continue
             if not found or data[i] > result:
                 result = data[i]
@@ -5658,14 +5744,14 @@ struct Column(Copyable, ImplicitlyCopyable, Movable, Sized):
         # Fast path: compute variance directly from _f64_cache (#619).
         if len(self._f64_cache) > 0:
             var total = Float64(0)
-            var has_mask = self._null_mask.has_nulls()
+            var has_mask = self.has_nulls()
             for i in range(len(self._f64_cache)):
-                if has_mask and self._null_mask[i]:
+                if has_mask and self.is_null(i):
                     continue
                 var diff = self._f64_cache[i] - m
                 total += diff * diff
             return total / Float64(n - ddof)
-        var visitor = _VarVisitor(m, self._null_mask)
+        var visitor = _VarVisitor(m, self.null_mask_copy())
         self._visit_raises(visitor)
         return visitor.total / Float64(n - ddof)
 
@@ -5692,15 +5778,15 @@ struct Column(Copyable, ImplicitlyCopyable, Movable, Sized):
         var skew_total: Float64
         if len(self._f64_cache) > 0:
             var total = Float64(0)
-            var has_mask = self._null_mask.has_nulls()
+            var has_mask = self.has_nulls()
             for i in range(len(self._f64_cache)):
-                if has_mask and self._null_mask[i]:
+                if has_mask and self.is_null(i):
                     continue
                 var diff = self._f64_cache[i] - m
                 total += diff * diff * diff
             skew_total = total
         else:
-            var visitor = _MomentVisitor(m, 3, self._null_mask)
+            var visitor = _MomentVisitor(m, 3, self.null_mask_copy())
             self._visit_raises(visitor)
             skew_total = visitor.total
         return (
@@ -5727,16 +5813,16 @@ struct Column(Copyable, ImplicitlyCopyable, Movable, Sized):
         var kurt_total: Float64
         if len(self._f64_cache) > 0:
             var total = Float64(0)
-            var has_mask = self._null_mask.has_nulls()
+            var has_mask = self.has_nulls()
             for i in range(len(self._f64_cache)):
-                if has_mask and self._null_mask[i]:
+                if has_mask and self.is_null(i):
                     continue
                 var diff = self._f64_cache[i] - m
                 var d2 = diff * diff
                 total += d2 * d2
             kurt_total = total
         else:
-            var visitor = _MomentVisitor(m, 4, self._null_mask)
+            var visitor = _MomentVisitor(m, 4, self.null_mask_copy())
             self._visit_raises(visitor)
             kurt_total = visitor.total
         var fn_ = Float64(n)
@@ -5762,7 +5848,7 @@ struct Column(Copyable, ImplicitlyCopyable, Movable, Sized):
             raise Error(
                 "argmin: cannot compute with NaN values when skipna=False"
             )
-        var visitor = _ArgExtremumVisitor[True](self._null_mask)
+        var visitor = _ArgExtremumVisitor[True](self.null_mask_copy())
         self._visit_raises(visitor)
         if not visitor.found:
             return -1
@@ -5778,7 +5864,7 @@ struct Column(Copyable, ImplicitlyCopyable, Movable, Sized):
             raise Error(
                 "argmax: cannot compute with NaN values when skipna=False"
             )
-        var visitor = _ArgExtremumVisitor[False](self._null_mask)
+        var visitor = _ArgExtremumVisitor[False](self.null_mask_copy())
         self._visit_raises(visitor)
         if not visitor.found:
             return -1
@@ -5797,14 +5883,14 @@ struct Column(Copyable, ImplicitlyCopyable, Movable, Sized):
             raise Error("cov: columns must be the same length")
         var xs = self._to_float64_list()
         var ys = other._to_float64_list()
-        var has_x_mask = self._null_mask.has_nulls()
-        var has_y_mask = other._null_mask.has_nulls()
+        var has_x_mask = self.has_nulls()
+        var has_y_mask = other.has_nulls()
         var sum_x = Float64(0)
         var sum_y = Float64(0)
         var count = 0
         for i in range(n):
-            var x_null = has_x_mask and self._null_mask[i]
-            var y_null = has_y_mask and other._null_mask[i]
+            var x_null = has_x_mask and self.is_null(i)
+            var y_null = has_y_mask and other.is_null(i)
             if x_null or y_null:
                 if not skipna:
                     var zero = Float64(0)
@@ -5820,8 +5906,8 @@ struct Column(Copyable, ImplicitlyCopyable, Movable, Sized):
         var mean_y = sum_y / Float64(count)
         var total = Float64(0)
         for i in range(n):
-            var x_null = has_x_mask and self._null_mask[i]
-            var y_null = has_y_mask and other._null_mask[i]
+            var x_null = has_x_mask and self.is_null(i)
+            var y_null = has_y_mask and other.is_null(i)
             if x_null or y_null:
                 continue
             total += (xs[i] - mean_x) * (ys[i] - mean_y)
@@ -5838,14 +5924,14 @@ struct Column(Copyable, ImplicitlyCopyable, Movable, Sized):
             raise Error("corr: columns must be the same length")
         var xs = self._to_float64_list()
         var ys = other._to_float64_list()
-        var has_x_mask = self._null_mask.has_nulls()
-        var has_y_mask = other._null_mask.has_nulls()
+        var has_x_mask = self.has_nulls()
+        var has_y_mask = other.has_nulls()
         var sum_x = Float64(0)
         var sum_y = Float64(0)
         var count = 0
         for i in range(n):
-            var x_null = has_x_mask and self._null_mask[i]
-            var y_null = has_y_mask and other._null_mask[i]
+            var x_null = has_x_mask and self.is_null(i)
+            var y_null = has_y_mask and other.is_null(i)
             if x_null or y_null:
                 if not skipna:
                     var zero = Float64(0)
@@ -5863,8 +5949,8 @@ struct Column(Copyable, ImplicitlyCopyable, Movable, Sized):
         var sum_x2 = Float64(0)
         var sum_y2 = Float64(0)
         for i in range(n):
-            var x_null = has_x_mask and self._null_mask[i]
-            var y_null = has_y_mask and other._null_mask[i]
+            var x_null = has_x_mask and self.is_null(i)
+            var y_null = has_y_mask and other.is_null(i)
             if x_null or y_null:
                 continue
             var dx = xs[i] - mean_x
@@ -5885,14 +5971,14 @@ struct Column(Copyable, ImplicitlyCopyable, Movable, Sized):
         """
         # Fast path: count unique Float64 values from cache (#619).
         if len(self._f64_cache) > 0:
-            var has_mask = self._null_mask.has_nulls()
+            var has_mask = self.has_nulls()
             var seen = Set[Float64]()
             for i in range(len(self._f64_cache)):
-                if has_mask and self._null_mask[i]:
+                if has_mask and self.is_null(i):
                     continue
                 seen.add(self._f64_cache[i])
             return len(seen)
-        var visitor = _NuniqueVisitor(self._null_mask)
+        var visitor = _NuniqueVisitor(self.null_mask_copy())
         self._visit_raises(visitor)
         return visitor.result
 
@@ -5910,13 +5996,13 @@ struct Column(Copyable, ImplicitlyCopyable, Movable, Sized):
         var vals: List[Float64]
         if len(self._f64_cache) > 0:
             vals = List[Float64]()
-            var has_mask = self._null_mask.has_nulls()
+            var has_mask = self.has_nulls()
             for i in range(len(self._f64_cache)):
-                if has_mask and self._null_mask[i]:
+                if has_mask and self.is_null(i):
                     continue
                 vals.append(self._f64_cache[i])
         else:
-            var visitor = _QuantileCollectVisitor(self._null_mask)
+            var visitor = _QuantileCollectVisitor(self.null_mask_copy())
             self._visit_raises(visitor)
             vals = visitor.vals.copy()
         if len(vals) == 0:
@@ -5984,10 +6070,12 @@ struct Column(Copyable, ImplicitlyCopyable, Movable, Sized):
         sort=True (default) orders results by count descending.
         Raises for object/datetime column types.
         """
-        var has_mask = self._null_mask.has_nulls()
+        var has_mask = self.has_nulls()
 
         # Phase 1: count unique values (raises for unsupported arms).
-        var count_visitor = _ValueCountsCountVisitor(has_mask, self._null_mask)
+        var count_visitor = _ValueCountsCountVisitor(
+            has_mask, self.null_mask_copy()
+        )
         self._visit_raises(count_visitor)
         var n = len(count_visitor.unique_keys)
 
@@ -6050,15 +6138,13 @@ struct Column(Copyable, ImplicitlyCopyable, Movable, Sized):
         var col_data: ColumnData,
         var result_mask: List[Bool],
         has_any_null: Bool,
-    ) -> Column:
+    ) raises -> Column:
         """Wrap a computed ColumnData into a Column, attaching mask only if needed.
         """
         var dtype = Column._sniff_dtype(col_data)
         var col = Column(self.name, col_data^, dtype)
         if has_any_null:
-            col._null_mask = NullMask.from_list(result_mask)
-        # Activate storage on the result (#619 Phase 4).
-        col._try_activate_storage()
+            col.set_null_mask(NullMask.from_list(result_mask))
         return col^
 
     def _binary_op_prepare_unchecked(
@@ -6073,9 +6159,7 @@ struct Column(Copyable, ImplicitlyCopyable, Movable, Sized):
         """
         var a = self._to_float64_list()
         var b = other._to_float64_list()
-        return _BinOpInputs(
-            a^, b^, self._null_mask.has_nulls(), other._null_mask.has_nulls()
-        )
+        return _BinOpInputs(a^, b^, self.has_nulls(), other.has_nulls())
 
     def _arith_op[
         op: Int
@@ -6106,14 +6190,14 @@ struct Column(Copyable, ImplicitlyCopyable, Movable, Sized):
             if self.dtype == int64 and other.dtype == int64:
                 ref a = self._int64_data()
                 ref b = other._int64_data()
-                var has_a_mask = self._null_mask.has_nulls()
-                var has_b_mask = other._null_mask.has_nulls()
+                var has_a_mask = self.has_nulls()
+                var has_b_mask = other.has_nulls()
                 var result = List[Int64]()
                 var result_mask = List[Bool]()
                 var has_any_null = False
                 for i in range(len(a)):
-                    var is_null = (has_a_mask and self._null_mask[i]) or (
-                        has_b_mask and other._null_mask[i]
+                    var is_null = (has_a_mask and self.is_null(i)) or (
+                        has_b_mask and other.is_null(i)
                     )
                     if is_null:
                         result.append(Int64(0))
@@ -6148,8 +6232,8 @@ struct Column(Copyable, ImplicitlyCopyable, Movable, Sized):
         var has_any_null = False
         var nan = Float64(0) / Float64(0)
         for i in range(len(inp.a)):
-            var is_null = (inp.has_a_mask and self._null_mask[i]) or (
-                inp.has_b_mask and other._null_mask[i]
+            var is_null = (inp.has_a_mask and self.is_null(i)) or (
+                inp.has_b_mask and other.is_null(i)
             )
             if is_null:
                 result.append(nan)
@@ -6229,12 +6313,12 @@ struct Column(Copyable, ImplicitlyCopyable, Movable, Sized):
             var n = len(self._f64_cache)
             var result = List[Bool](capacity=n)
             var result_mask = List[Bool]()
-            var has_a_mask = self._null_mask.has_nulls()
-            var has_b_mask = other._null_mask.has_nulls()
+            var has_a_mask = self.has_nulls()
+            var has_b_mask = other.has_nulls()
             var has_any_null = False
             for i in range(n):
-                var is_null = (has_a_mask and self._null_mask[i]) or (
-                    has_b_mask and other._null_mask[i]
+                var is_null = (has_a_mask and self.is_null(i)) or (
+                    has_b_mask and other.is_null(i)
                 )
                 if is_null:
                     result.append(False)
@@ -6259,7 +6343,7 @@ struct Column(Copyable, ImplicitlyCopyable, Movable, Sized):
             return self._build_result_col(
                 ColumnData(result^), result_mask^, has_any_null
             )
-        var visitor = _CmpOpVisitor[op](self._null_mask, other)
+        var visitor = _CmpOpVisitor[op](self.null_mask_copy(), other)
         self._visit_raises(visitor)
         return self._build_result_col(
             ColumnData(visitor.result.copy()),
@@ -6303,9 +6387,9 @@ struct Column(Copyable, ImplicitlyCopyable, Movable, Sized):
             var n = len(self._f64_cache)
             var result = List[Bool](capacity=n)
             var result_mask = List[Bool]()
-            var has_any_null = self._null_mask.has_nulls()
+            var has_any_null = self.has_nulls()
             for i in range(n):
-                if has_any_null and self._null_mask.is_null(i):
+                if has_any_null and self.is_null(i):
                     result.append(False)
                     result_mask.append(True)
                 else:
@@ -6328,7 +6412,7 @@ struct Column(Copyable, ImplicitlyCopyable, Movable, Sized):
             return self._build_result_col(
                 ColumnData(result^), result_mask^, has_any_null
             )
-        var visitor = _CmpScalarVisitor[op](self._null_mask, scalar)
+        var visitor = _CmpScalarVisitor[op](self.null_mask_copy(), scalar)
         self._visit_raises(visitor)
         return self._build_result_col(
             ColumnData(visitor.result.copy()),
@@ -6374,9 +6458,9 @@ struct Column(Copyable, ImplicitlyCopyable, Movable, Sized):
                 var n = len(self._f64_cache)
                 var result = List[Bool](capacity=n)
                 var result_mask = List[Bool]()
-                var has_any_null = self._null_mask.has_nulls()
+                var has_any_null = self.has_nulls()
                 for i in range(n):
-                    if has_any_null and self._null_mask.is_null(i):
+                    if has_any_null and self.is_null(i):
                         result.append(False)
                         result_mask.append(True)
                     else:
@@ -6399,7 +6483,7 @@ struct Column(Copyable, ImplicitlyCopyable, Movable, Sized):
                 return self._build_result_col(
                     ColumnData(result^), result_mask^, has_any_null
                 )
-        var visitor = _CmpScalarInt64Visitor[op](self._null_mask, scalar)
+        var visitor = _CmpScalarInt64Visitor[op](self.null_mask_copy(), scalar)
         self._visit_raises(visitor)
         return self._build_result_col(
             ColumnData(visitor.result.copy()),
@@ -6453,14 +6537,14 @@ struct Column(Copyable, ImplicitlyCopyable, Movable, Sized):
         # Fast path: use _bool_cache when both columns have it (#619 Phase 6b).
         if len(self._bool_cache) > 0 and len(other._bool_cache) > 0:
             var n = len(self._bool_cache)
-            var has_a_mask = self._null_mask.has_nulls()
-            var has_b_mask = other._null_mask.has_nulls()
+            var has_a_mask = self.has_nulls()
+            var has_b_mask = other.has_nulls()
             var result = List[Bool](capacity=n)
             var result_mask = List[Bool]()
             var has_any_null = False
             for i in range(n):
-                var a_null = has_a_mask and self._null_mask[i]
-                var b_null = has_b_mask and other._null_mask[i]
+                var a_null = has_a_mask and self.is_null(i)
+                var b_null = has_b_mask and other.is_null(i)
                 comptime if op == _BOOL_AND:
                     if a_null:
                         if (not b_null) and (not other._bool_cache[i]):
@@ -6523,7 +6607,7 @@ struct Column(Copyable, ImplicitlyCopyable, Movable, Sized):
             )
         if not self._data.isa[List[Bool]]():
             raise Error("bool_op: non-bool column type on left-hand side")
-        var visitor = _BoolOpVisitor[op](self._null_mask, other)
+        var visitor = _BoolOpVisitor[op](self.null_mask_copy(), other)
         self._visit_raises(visitor)
         return self._build_result_col(
             ColumnData(visitor.result.copy()),
@@ -6550,9 +6634,9 @@ struct Column(Copyable, ImplicitlyCopyable, Movable, Sized):
             var result = List[Bool](capacity=n)
             var result_mask = List[Bool]()
             var has_any_null = False
-            var has_input_mask = self._null_mask.has_nulls()
+            var has_input_mask = self.has_nulls()
             for i in range(n):
-                if has_input_mask and self._null_mask[i]:
+                if has_input_mask and self.is_null(i):
                     result.append(False)
                     result_mask.append(True)
                     has_any_null = True
@@ -6568,9 +6652,9 @@ struct Column(Copyable, ImplicitlyCopyable, Movable, Sized):
         var result = List[Bool]()
         var result_mask = List[Bool]()
         var has_any_null = False
-        var has_input_mask = self._null_mask.has_nulls()
+        var has_input_mask = self.has_nulls()
         for i in range(len(src)):
-            if has_input_mask and self._null_mask[i]:
+            if has_input_mask and self.is_null(i):
                 result.append(False)
                 result_mask.append(True)
                 has_any_null = True
@@ -6596,12 +6680,12 @@ struct Column(Copyable, ImplicitlyCopyable, Movable, Sized):
         # Fast path: use typed caches when available (#619 Phase 6b).
         if len(self._int64_cache) > 0:
             var n = len(self._int64_cache)
-            var has_mask = self._null_mask.has_nulls()
+            var has_mask = self.has_nulls()
             var result = List[Int64](capacity=n)
             var result_mask = List[Bool]()
             var has_any_null = False
             for i in range(n):
-                if has_mask and self._null_mask[i]:
+                if has_mask and self.is_null(i):
                     result.append(Int64(0))
                     result_mask.append(True)
                     has_any_null = True
@@ -6614,13 +6698,13 @@ struct Column(Copyable, ImplicitlyCopyable, Movable, Sized):
             )
         if len(self._f64_cache) > 0:
             var n = len(self._f64_cache)
-            var has_mask = self._null_mask.has_nulls()
+            var has_mask = self.has_nulls()
             var nan = Float64(0) / Float64(0)
             var result = List[Float64](capacity=n)
             var result_mask = List[Bool]()
             var has_any_null = False
             for i in range(n):
-                if has_mask and self._null_mask[i]:
+                if has_mask and self.is_null(i):
                     result.append(nan)
                     result_mask.append(True)
                     has_any_null = True
@@ -6633,7 +6717,7 @@ struct Column(Copyable, ImplicitlyCopyable, Movable, Sized):
             )
         if len(self._bool_cache) > 0:
             return self.copy()
-        var visitor = _AbsVisitor(self._null_mask, self.dtype.name)
+        var visitor = _AbsVisitor(self.null_mask_copy(), self.dtype.name)
         self._visit_raises(visitor)
         if visitor.is_identity:
             return self.copy()
@@ -6658,14 +6742,14 @@ struct Column(Copyable, ImplicitlyCopyable, Movable, Sized):
             return self.copy()
         if len(self._f64_cache) > 0:
             var n = len(self._f64_cache)
-            var has_mask = self._null_mask.has_nulls()
+            var has_mask = self.has_nulls()
             var nan = Float64(0) / Float64(0)
             var scale = Float64(10) ** Float64(decimals)
             var result = List[Float64](capacity=n)
             var result_mask = List[Bool]()
             var has_any_null = False
             for i in range(n):
-                if has_mask and self._null_mask[i]:
+                if has_mask and self.is_null(i):
                     result.append(nan)
                     result_mask.append(True)
                     has_any_null = True
@@ -6689,7 +6773,9 @@ struct Column(Copyable, ImplicitlyCopyable, Movable, Sized):
             return self._build_result_col(
                 ColumnData(result^), result_mask^, has_any_null
             )
-        var visitor = _RoundVisitor(self._null_mask, decimals, self.dtype.name)
+        var visitor = _RoundVisitor(
+            self.null_mask_copy(), decimals, self.dtype.name
+        )
         self._visit_raises(visitor)
         if visitor.is_identity:
             return self.copy()
@@ -6712,7 +6798,7 @@ struct Column(Copyable, ImplicitlyCopyable, Movable, Sized):
         # Int64 columns use the legacy visitor to preserve Int64 output.
         if len(self._f64_cache) > 0 and self.dtype != int64:
             var n = len(self._f64_cache)
-            var has_mask = self._null_mask.has_nulls()
+            var has_mask = self.has_nulls()
             var has_lo = lower.__bool__()
             var has_hi = upper.__bool__()
             var lo = Float64(0)
@@ -6726,7 +6812,7 @@ struct Column(Copyable, ImplicitlyCopyable, Movable, Sized):
             var result_mask = List[Bool]()
             var has_any_null = False
             for i in range(n):
-                if has_mask and self._null_mask[i]:
+                if has_mask and self.is_null(i):
                     result_data.append(nan)
                     result_mask.append(True)
                     has_any_null = True
@@ -6742,7 +6828,7 @@ struct Column(Copyable, ImplicitlyCopyable, Movable, Sized):
                 ColumnData(result_data^), result_mask^, has_any_null
             )
         var visitor = _ClipVisitor(
-            self._null_mask, lower, upper, self.dtype.name
+            self.null_mask_copy(), lower, upper, self.dtype.name
         )
         self._visit_raises(visitor)
         return self._build_result_col(
@@ -6759,13 +6845,13 @@ struct Column(Copyable, ImplicitlyCopyable, Movable, Sized):
         Call as ``col._apply[my_fn]()``.
         """
         var data = self._to_float64_list()
-        var has_mask = self._null_mask.has_nulls()
+        var has_mask = self.has_nulls()
         var result = List[Float64]()
         var result_mask = List[Bool]()
         var has_any_null = False
         var nan = Float64(0) / Float64(0)
         for i in range(len(data)):
-            if has_mask and self._null_mask[i]:
+            if has_mask and self.is_null(i):
                 result.append(nan)
                 result_mask.append(True)
                 has_any_null = True
@@ -6808,18 +6894,18 @@ struct Column(Copyable, ImplicitlyCopyable, Movable, Sized):
 
     def _isin_kernel[
         T: Comparable & Copyable & Movable
-    ](self, d: List[T], values: List[T]) -> Column:
+    ](self, d: List[T], values: List[T]) raises -> Column:
         """Shared kernel for all _isin_* methods.
 
         Builds a Bool Column: True where element is in ``values``.
         Nulls propagate as null.
         """
-        var has_mask = self._null_mask.has_nulls()
+        var has_mask = self.has_nulls()
         var result = List[Bool]()
         var result_mask = List[Bool]()
         var has_any_null = False
         for i in range(len(d)):
-            if has_mask and self._null_mask[i]:
+            if has_mask and self.is_null(i):
                 result.append(False)
                 result_mask.append(True)
                 has_any_null = True
@@ -6884,7 +6970,7 @@ struct Column(Copyable, ImplicitlyCopyable, Movable, Sized):
         which performs scalar-type coercion internally.  Raises for object
         dtype columns.  Nulls propagate as null.
         """
-        var visitor = _IsInVisitor(self._null_mask, scalars)
+        var visitor = _IsInVisitor(self.null_mask_copy(), scalars)
         self._visit_raises(visitor)
         return self._build_result_col(
             visitor.col_data.copy(),
@@ -6899,12 +6985,12 @@ struct Column(Copyable, ImplicitlyCopyable, Movable, Sized):
         Raises for String/Object columns (via _to_float64_list).
         """
         var data = self._to_float64_list()
-        var has_mask = self._null_mask.has_nulls()
+        var has_mask = self.has_nulls()
         var result = List[Bool]()
         var result_mask = List[Bool]()
         var has_any_null = False
         for i in range(len(data)):
-            if has_mask and self._null_mask[i]:
+            if has_mask and self.is_null(i):
                 result.append(False)
                 result_mask.append(True)
                 has_any_null = True
@@ -6937,9 +7023,9 @@ struct Column(Copyable, ImplicitlyCopyable, Movable, Sized):
             )
         var keep_on_true = mode == 1
         var visitor = _WhereMaskVisitor(
-            self._null_mask,
+            self.null_mask_copy(),
             cond._data[List[Bool]].copy(),
-            cond._null_mask,
+            cond.null_mask_copy(),
             keep_on_true,
             other,
         )
@@ -6979,7 +7065,7 @@ struct Column(Copyable, ImplicitlyCopyable, Movable, Sized):
                 + ")"
             )
         var visitor = _CombineFirstVisitor(
-            self._null_mask, other._data, other._null_mask
+            self.null_mask_copy(), other._data, other.null_mask_copy()
         )
         self._visit_raises(visitor)
         return self._build_result_col(
@@ -6995,7 +7081,7 @@ struct Column(Copyable, ImplicitlyCopyable, Movable, Sized):
         membership checks, giving O(n) overall complexity.
         Raises for Object dtype.
         """
-        var visitor = _UniqueVisitor(self._null_mask)
+        var visitor = _UniqueVisitor(self.null_mask_copy())
         self._visit_raises(visitor)
         return self._build_result_col(
             visitor.col_data.copy(),
@@ -7014,7 +7100,7 @@ struct Column(Copyable, ImplicitlyCopyable, Movable, Sized):
         Raises for unsupported source/target dtype combinations.
         """
         var visitor = _AstypeVisitor(
-            self._null_mask,
+            self.null_mask_copy(),
             target_dtype.is_integer(),
             target_dtype.is_float(),
             target_dtype == bool_,
@@ -7053,7 +7139,7 @@ struct Column(Copyable, ImplicitlyCopyable, Movable, Sized):
         an Index (List[String]) ColumnIndex; all other types fall back to
         List[PythonObject].
         """
-        var visitor = _ToColumnIndexVisitor(self._null_mask)
+        var visitor = _ToColumnIndexVisitor(self.null_mask_copy())
         self._visit_raises(visitor)
         return visitor.result.copy()
 
@@ -7067,7 +7153,7 @@ struct Column(Copyable, ImplicitlyCopyable, Movable, Sized):
         """
         var py_list = Python.evaluate("[]")
         var py_none = Python.evaluate("None")
-        var visitor = _ToPandasVisitor(py_list, py_none, self._null_mask)
+        var visitor = _ToPandasVisitor(py_list, py_none, self.null_mask_copy())
         self._visit_raises(visitor)
         var n = Int(py_list.__len__())
         var result = List[PythonObject]()
@@ -7085,7 +7171,9 @@ struct Column(Copyable, ImplicitlyCopyable, Movable, Sized):
                                 is provided.
         Existing null mask entries are propagated for taken rows.
         """
-        var visitor = _ReindexRowsVisitor(indices, fill_value, self._null_mask)
+        var visitor = _ReindexRowsVisitor(
+            indices, fill_value, self.null_mask_copy()
+        )
         self._visit_raises(visitor)
         return self._build_result_col(
             visitor.col_data.copy(),
@@ -7151,7 +7239,7 @@ struct Column(Copyable, ImplicitlyCopyable, Movable, Sized):
         preserve Int64 output).
         """
         var n = len(self._f64_cache)
-        var has_mask = self._null_mask.has_nulls()
+        var has_mask = self.has_nulls()
         var propagate_nan = False
         var nan = Float64(0) / Float64(0)
         var running: Float64
@@ -7164,7 +7252,7 @@ struct Column(Copyable, ImplicitlyCopyable, Movable, Sized):
         var result_mask = List[Bool]()
         var has_any_null = False
         for i in range(n):
-            var is_null = has_mask and self._null_mask[i]
+            var is_null = has_mask and self.is_null(i)
             if is_null:
                 if not skipna:
                     propagate_nan = True
@@ -7210,7 +7298,7 @@ struct Column(Copyable, ImplicitlyCopyable, Movable, Sized):
         # Int64 columns use the legacy visitor to preserve Int64 output.
         if len(self._f64_cache) > 0 and self.dtype != int64:
             return self._cumop_f64_cache(skipna, 1)
-        var visitor = _CumSumVisitor(skipna, self._null_mask)
+        var visitor = _CumSumVisitor(skipna, self.null_mask_copy())
         self._visit_raises(visitor)
         return self._build_result_col(
             visitor.col_data.copy(),
@@ -7229,7 +7317,7 @@ struct Column(Copyable, ImplicitlyCopyable, Movable, Sized):
         """
         if len(self._f64_cache) > 0 and self.dtype != int64:
             return self._cumop_f64_cache(skipna, 2)
-        var visitor = _CumProdVisitor(skipna, self._null_mask)
+        var visitor = _CumProdVisitor(skipna, self.null_mask_copy())
         self._visit_raises(visitor)
         return self._build_result_col(
             visitor.col_data.copy(),
@@ -7248,7 +7336,7 @@ struct Column(Copyable, ImplicitlyCopyable, Movable, Sized):
         """
         if len(self._f64_cache) > 0 and self.dtype != int64:
             return self._cumop_f64_cache(skipna, 3)
-        var visitor = _CumMinVisitor(skipna, self._null_mask)
+        var visitor = _CumMinVisitor(skipna, self.null_mask_copy())
         self._visit_raises(visitor)
         return self._build_result_col(
             visitor.col_data.copy(),
@@ -7267,7 +7355,7 @@ struct Column(Copyable, ImplicitlyCopyable, Movable, Sized):
         """
         if len(self._f64_cache) > 0 and self.dtype != int64:
             return self._cumop_f64_cache(skipna, 4)
-        var visitor = _CumMaxVisitor(skipna, self._null_mask)
+        var visitor = _CumMaxVisitor(skipna, self.null_mask_copy())
         self._visit_raises(visitor)
         return self._build_result_col(
             visitor.col_data.copy(),
@@ -7392,9 +7480,8 @@ struct Column(Copyable, ImplicitlyCopyable, Movable, Sized):
                 else:
                     data.append(Int64(Int(py=py_list[i])))
             var col = Column(name, ColumnData(data^), bison_dtype, bison_idx^)
-            col._null_mask = null_mask.copy()
+            col.set_null_mask(null_mask.copy())
             col._index_name = idx_name
-            col._try_activate_storage()
             return col^
         elif bison_dtype == float64:
             var data = List[Float64]()
@@ -7411,9 +7498,8 @@ struct Column(Copyable, ImplicitlyCopyable, Movable, Sized):
                     var bits = Int64(Int(py=packed[0]))
                     data.append(bitcast[DType.float64](bits))
             var col = Column(name, ColumnData(data^), bison_dtype, bison_idx^)
-            col._null_mask = null_mask.copy()
+            col.set_null_mask(null_mask.copy())
             col._index_name = idx_name
-            col._try_activate_storage()
             return col^
         elif bison_dtype == bool_:
             var data = List[Bool]()
@@ -7423,9 +7509,8 @@ struct Column(Copyable, ImplicitlyCopyable, Movable, Sized):
                 else:
                     data.append(Bool(py_list[i].__bool__()))
             var col = Column(name, ColumnData(data^), bison_dtype, bison_idx^)
-            col._null_mask = null_mask.copy()
+            col.set_null_mask(null_mask.copy())
             col._index_name = idx_name
-            col._try_activate_storage()
             return col^
         elif dtype_str == "string":
             var data = List[String]()
@@ -7436,9 +7521,8 @@ struct Column(Copyable, ImplicitlyCopyable, Movable, Sized):
                     data.append(String(py_list[i]))
             # #644: string-backed columns carry string_ dtype.
             var col = Column(name, ColumnData(data^), string_, bison_idx^)
-            col._null_mask = null_mask.copy()
+            col.set_null_mask(null_mask.copy())
             col._index_name = idx_name
-            col._try_activate_storage()
             return col^
         else:
             # Promote pure-string object columns to List[String] so that
@@ -7465,23 +7549,20 @@ struct Column(Copyable, ImplicitlyCopyable, Movable, Sized):
                     var col = Column(
                         name, ColumnData(str_data^), string_, bison_idx^
                     )
-                    col._null_mask = null_mask^
+                    col.set_null_mask(null_mask^)
                     col._index_name = idx_name
-                    col._try_activate_storage()
                     return col^
             var data = List[PythonObject]()
             for i in range(n):
                 data.append(py_list[i])
             var col = Column(name, ColumnData(data^), bison_dtype, bison_idx^)
-            col._null_mask = null_mask^
             col._index_name = idx_name
-            # Object-arm columns: re-populate the LegacyObjectData arm
-            # with the post-assignment null mask so downstream readers
-            # see a coherent view.
+            # Object-arm columns: populate the LegacyObjectData arm
+            # with the null mask so downstream readers see a coherent view.
             col._storage = ColumnStorage(
                 LegacyObjectData(
                     col._data[List[PythonObject]].copy(),
-                    col._null_mask.copy(),
+                    null_mask^,
                 )
             )
             return col^
@@ -7511,7 +7592,7 @@ struct Column(Copyable, ImplicitlyCopyable, Movable, Sized):
         The underlying storage uses the canonical Mojo type for *dtype*
         (Int64 for integer families, Float64 for float families, Bool for
         bool, PythonObject for everything else).  Every element is marked
-        null via ``_null_mask``.
+        null via ``set_null_mask``.
         """
         var c: Column
         if dtype.is_integer():
@@ -7542,7 +7623,7 @@ struct Column(Copyable, ImplicitlyCopyable, Movable, Sized):
             for _ in range(n):
                 data.append(py_none)
             c = Column(name, ColumnData(data^), dtype, index^)
-        c._null_mask = NullMask.all_null(n)
+        c.set_null_mask(NullMask.all_null(n))
         return c^
 
     @staticmethod
@@ -7565,7 +7646,7 @@ struct Column(Copyable, ImplicitlyCopyable, Movable, Sized):
         var pd = Python.import_module("pandas")
         var py_list = Python.evaluate("[]")
         var py_none = Python.evaluate("None")
-        var visitor = _ToPandasVisitor(py_list, py_none, self._null_mask)
+        var visitor = _ToPandasVisitor(py_list, py_none, self.null_mask_copy())
         self._visit_raises(visitor)
         # Detect integer columns that contain nulls and promote to the
         # corresponding pandas nullable integer dtype (e.g. "Int64") so that
@@ -7579,8 +7660,8 @@ struct Column(Copyable, ImplicitlyCopyable, Movable, Sized):
             dtype_name = "object"
         if self.dtype.is_integer():
             var has_nulls = False
-            for i in range(len(self._null_mask)):
-                if self._null_mask[i]:
+            for i in range(len(self)):
+                if self.is_null(i):
                     has_nulls = True
                     break
             if has_nulls:
@@ -7667,8 +7748,7 @@ def _col_cell_pyobj(col: Column, row: Int) raises -> PythonObject:
 
     Null cells (masked entries) are returned as Python ``None``.
     """
-    var has_mask = col._null_mask.has_nulls()
-    if has_mask and row < len(col._null_mask) and col._null_mask[row]:
+    if col.has_nulls() and row < len(col) and col.is_null(row):
         return Python.evaluate("None")
     # Fast path: read from typed caches when populated.
     if len(col._int64_cache) > 0:
@@ -7691,7 +7771,7 @@ def _scalar_from_col(col: Column, row: Int) raises -> DFScalar:
     ``List[PythonObject]`` cells are stringified since ``DFScalar`` has no
     ``PythonObject`` arm.
     """
-    if col._null_mask.has_nulls() and col._null_mask[row]:
+    if col.has_nulls() and col.is_null(row):
         return DFScalar.null()
     # Fast path: read from typed caches when populated.
     if len(col._int64_cache) > 0:
@@ -7712,8 +7792,7 @@ def _col_cell_str(col: Column, row: Int) raises -> String:
 
     Null cells (masked entries) are returned as an empty string.
     """
-    var has_mask = col._null_mask.has_nulls()
-    if has_mask and row < len(col._null_mask) and col._null_mask[row]:
+    if col.has_nulls() and row < len(col) and col.is_null(row):
         return String("")
     # Fast path: read from typed caches when populated.
     if len(col._int64_cache) > 0:

--- a/bison/io/csv.mojo
+++ b/bison/io/csv.mojo
@@ -69,8 +69,7 @@ def _infer_and_build_column(
                 null_mask.append_valid()
         var col = Column(name, data^, bool_)
         if null_mask.has_nulls():
-            col._null_mask = null_mask^
-        col._try_activate_storage()
+            col.set_null_mask(null_mask^)
         return col^
 
     # ------------------------------------------------------------------
@@ -98,8 +97,7 @@ def _infer_and_build_column(
                 null_mask.append_valid()
         var col = Column(name, data^, int64)
         if null_mask.has_nulls():
-            col._null_mask = null_mask^
-        col._try_activate_storage()
+            col.set_null_mask(null_mask^)
         return col^
 
     # ------------------------------------------------------------------
@@ -127,8 +125,7 @@ def _infer_and_build_column(
                 null_mask.append_valid()
         var col = Column(name, data^, float64)
         if null_mask.has_nulls():
-            col._null_mask = null_mask^
-        col._try_activate_storage()
+            col.set_null_mask(null_mask^)
         return col^
 
     # ------------------------------------------------------------------
@@ -145,7 +142,7 @@ def _infer_and_build_column(
             null_mask.append_valid()
     var col = Column(name, data^, string_)
     if null_mask.has_nulls():
-        col._null_mask = null_mask^
+        col.set_null_mask(null_mask^)
     col._try_activate_storage()
     return col^
 

--- a/bison/io/json.mojo
+++ b/bison/io/json.mojo
@@ -74,8 +74,7 @@ def _json_build_column(
                 null_mask.append_valid()
         var col = Column(name, data^, bool_)
         if null_mask.has_nulls():
-            col._null_mask = null_mask^
-        col._try_activate_storage()
+            col.set_null_mask(null_mask^)
         return col^
 
     elif dtype_str == "int64":
@@ -91,8 +90,7 @@ def _json_build_column(
                 null_mask.append_valid()
         var col = Column(name, data^, int64)
         if null_mask.has_nulls():
-            col._null_mask = null_mask^
-        col._try_activate_storage()
+            col.set_null_mask(null_mask^)
         return col^
 
     elif dtype_str == "float64":
@@ -108,8 +106,7 @@ def _json_build_column(
                 null_mask.append_valid()
         var col = Column(name, data^, float64)
         if null_mask.has_nulls():
-            col._null_mask = null_mask^
-        col._try_activate_storage()
+            col.set_null_mask(null_mask^)
         return col^
 
     else:  # "string"
@@ -125,8 +122,7 @@ def _json_build_column(
                 null_mask.append_valid()
         var col = Column(name, data^, string_)
         if null_mask.has_nulls():
-            col._null_mask = null_mask^
-        col._try_activate_storage()
+            col.set_null_mask(null_mask^)
         return col^
 
 

--- a/bison/reshape/_concat.mojo
+++ b/bison/reshape/_concat.mojo
@@ -62,7 +62,7 @@ def _promote_piece_to_object(
         for k in range(len(src)):
             out.append(py_str(src[k]))
     elif piece.is_object():
-        ref src = piece._obj_data()
+        ref src = piece._storage_legacy().data
         for k in range(len(src)):
             out.append(src[k])
     else:
@@ -81,11 +81,11 @@ def _append_piece_mask(
 ) raises:
     if not need_mask:
         return
-    var has_m = piece._null_mask.has_nulls()
+    var has_m = piece.has_nulls()
     var n = len(piece)
     for k in range(n):
         if has_m:
-            mask.append(piece._null_mask[k])
+            mask.append(piece.is_null(k))
         else:
             mask.append_valid()
 
@@ -104,24 +104,21 @@ def _null_col(
         for _ in range(n):
             data.append(Int64(0))
         var col = Column(name, data^, dtype)
-        col._null_mask = NullMask.all_null(n)
-        col._try_activate_storage()
+        col.set_null_mask(NullMask.all_null(n))
         return col^
     elif dtype == float64:
         var data = List[Float64]()
         for _ in range(n):
             data.append(Float64(0))
         var col = Column(name, data^, dtype)
-        col._null_mask = NullMask.all_null(n)
-        col._try_activate_storage()
+        col.set_null_mask(NullMask.all_null(n))
         return col^
     elif dtype == bool_:
         var data = List[Bool]()
         for _ in range(n):
             data.append(False)
         var col = Column(name, data^, dtype)
-        col._null_mask = NullMask.all_null(n)
-        col._try_activate_storage()
+        col.set_null_mask(NullMask.all_null(n))
         return col^
     elif dtype == string_:
         # #644: preserve the string_ ⟺ List[String] invariant for all-null
@@ -130,16 +127,14 @@ def _null_col(
         for _ in range(n):
             data.append(String(""))
         var col = Column(name, data^, string_)
-        col._null_mask = NullMask.all_null(n)
-        col._try_activate_storage()
+        col.set_null_mask(NullMask.all_null(n))
         return col^
     else:
         var data = List[PythonObject]()
         for _ in range(n):
             data.append(Python.evaluate("None"))
         var col = Column(name, data^, object_)
-        col._null_mask = NullMask.all_null(n)
-        col._try_activate_storage()
+        col.set_null_mask(NullMask.all_null(n))
         return col^
 
 
@@ -270,7 +265,7 @@ def _vstack(pieces: List[Column]) raises -> Column:
     # Detect whether any piece has a null mask.
     var need_mask = False
     for i in range(len(pieces)):
-        if pieces[i]._null_mask.has_nulls():
+        if pieces[i].has_nulls():
             need_mask = True
 
     # Check if all pieces share the same typed arm (no promotion needed).
@@ -286,8 +281,7 @@ def _vstack(pieces: List[Column]) raises -> Column:
             _append_piece_mask(mask, pieces[i], need_mask)
         var col = Column(col_name, data^, target_dtype)
         if need_mask:
-            col._null_mask = mask^
-        col._try_activate_storage()
+            col.set_null_mask(mask^)
         return col^
     elif common and common.value() == float64:
         var data = List[Float64]()
@@ -299,8 +293,7 @@ def _vstack(pieces: List[Column]) raises -> Column:
             _append_piece_mask(mask, pieces[i], need_mask)
         var col = Column(col_name, data^, target_dtype)
         if need_mask:
-            col._null_mask = mask^
-        col._try_activate_storage()
+            col.set_null_mask(mask^)
         return col^
     elif common and common.value() == bool_:
         var data = List[Bool]()
@@ -312,8 +305,7 @@ def _vstack(pieces: List[Column]) raises -> Column:
             _append_piece_mask(mask, pieces[i], need_mask)
         var col = Column(col_name, data^, target_dtype)
         if need_mask:
-            col._null_mask = mask^
-        col._try_activate_storage()
+            col.set_null_mask(mask^)
         return col^
     elif common and common.value() == string_:
         # #644: All pieces hold List[String]; keep the string arm intact.
@@ -326,8 +318,7 @@ def _vstack(pieces: List[Column]) raises -> Column:
             _append_piece_mask(mask, pieces[i], need_mask)
         var col = Column(col_name, data^, target_dtype)
         if need_mask:
-            col._null_mask = mask^
-        col._try_activate_storage()
+            col.set_null_mask(mask^)
         return col^
     elif target_dtype == float64:
         # Numeric promotion: pieces are a mix of float64, int64, and/or bool_.
@@ -338,8 +329,7 @@ def _vstack(pieces: List[Column]) raises -> Column:
             _append_piece_mask(mask, pieces[i], need_mask)
         var col = Column(col_name, data^, float64)
         if need_mask:
-            col._null_mask = mask^
-        col._try_activate_storage()
+            col.set_null_mask(mask^)
         return col^
     elif target_dtype == int64:
         # Numeric promotion: pieces are a mix of int64 and bool_.
@@ -350,8 +340,7 @@ def _vstack(pieces: List[Column]) raises -> Column:
             _append_piece_mask(mask, pieces[i], need_mask)
         var col = Column(col_name, data^, int64)
         if need_mask:
-            col._null_mask = mask^
-        col._try_activate_storage()
+            col.set_null_mask(mask^)
         return col^
     else:
         # Same non-numeric dtype backed by List[PythonObject] (e.g. datetime64_ns),
@@ -366,8 +355,7 @@ def _vstack(pieces: List[Column]) raises -> Column:
             _append_piece_mask(mask, pieces[i], need_mask)
         var col = Column(col_name, data^, target_dtype)
         if need_mask:
-            col._null_mask = mask^
-        col._try_activate_storage()
+            col.set_null_mask(mask^)
         return col^
 
 

--- a/tests/test_arrow.mojo
+++ b/tests/test_arrow.mojo
@@ -30,7 +30,7 @@ def test_int64_round_trip_no_nulls() raises:
     assert_equal(col2._data[List[Int64]][0], Int64(1))
     assert_equal(col2._data[List[Int64]][1], Int64(2))
     assert_equal(col2._data[List[Int64]][2], Int64(3))
-    assert_equal(len(col2._null_mask), 0)
+    assert_false(col2.has_nulls())
 
 
 def test_float64_round_trip_no_nulls() raises:
@@ -45,7 +45,7 @@ def test_float64_round_trip_no_nulls() raises:
     assert_equal(len(col2), 3)
     assert_equal(col2._data[List[Float64]][0], Float64(4.0))
     assert_equal(col2._data[List[Float64]][2], Float64(6.0))
-    assert_equal(len(col2._null_mask), 0)
+    assert_false(col2.has_nulls())
 
 
 def test_bool_round_trip_no_nulls() raises:
@@ -61,7 +61,7 @@ def test_bool_round_trip_no_nulls() raises:
     assert_true(col2._data[List[Bool]][0])
     assert_false(col2._data[List[Bool]][1])
     assert_true(col2._data[List[Bool]][2])
-    assert_equal(len(col2._null_mask), 0)
+    assert_false(col2.has_nulls())
 
 
 def test_string_round_trip_no_nulls() raises:
@@ -77,7 +77,7 @@ def test_string_round_trip_no_nulls() raises:
     assert_equal(col2._data[List[String]][0], "x")
     assert_equal(col2._data[List[String]][1], "y")
     assert_equal(col2._data[List[String]][2], "z")
-    assert_equal(len(col2._null_mask), 0)
+    assert_false(col2.has_nulls())
 
 
 def test_null_mask_preserved_int64() raises:
@@ -87,16 +87,17 @@ def test_null_mask_preserved_int64() raises:
     data.append(42)
     data.append(0)
     var col = Column("x", ColumnData(data^), int64)
-    col._null_mask = NullMask()
-    col._null_mask.append(True)
-    col._null_mask.append(False)
-    col._null_mask.append(True)
+    var mask = NullMask()
+    mask.append(True)
+    mask.append(False)
+    mask.append(True)
+    col.set_null_mask(mask^)
     var arr = column_to_marrow_array(col)
     var col2 = marrow_array_to_column(arr^, "x")
-    assert_equal(len(col2._null_mask), 3)
-    assert_true(col2._null_mask[0])
-    assert_false(col2._null_mask[1])
-    assert_true(col2._null_mask[2])
+    assert_true(col2.has_nulls())
+    assert_true(col2.is_null(0))
+    assert_false(col2.is_null(1))
+    assert_true(col2.is_null(2))
     assert_equal(col2._data[List[Int64]][1], Int64(42))
 
 
@@ -107,16 +108,17 @@ def test_null_mask_preserved_string() raises:
     data.append("")
     data.append("world")
     var col = Column("s", ColumnData(data^), string_)
-    col._null_mask = NullMask()
-    col._null_mask.append(False)
-    col._null_mask.append(True)
-    col._null_mask.append(False)
+    var mask = NullMask()
+    mask.append(False)
+    mask.append(True)
+    mask.append(False)
+    col.set_null_mask(mask^)
     var arr = column_to_marrow_array(col)
     var col2 = marrow_array_to_column(arr^, "s")
-    assert_equal(len(col2._null_mask), 3)
-    assert_false(col2._null_mask[0])
-    assert_true(col2._null_mask[1])
-    assert_false(col2._null_mask[2])
+    assert_true(col2.has_nulls())
+    assert_false(col2.is_null(0))
+    assert_true(col2.is_null(1))
+    assert_false(col2.is_null(2))
     assert_equal(col2._data[List[String]][0], "hello")
     assert_equal(col2._data[List[String]][2], "world")
 
@@ -166,20 +168,22 @@ def test_dataframe_round_trip_with_nulls() raises:
     d_a.append(0)
     d_a.append(30)
     var col_a = Column("a", ColumnData(d_a^), int64)
-    col_a._null_mask = NullMask()
-    col_a._null_mask.append(False)
-    col_a._null_mask.append(True)
-    col_a._null_mask.append(False)
+    var mask_a = NullMask()
+    mask_a.append(False)
+    mask_a.append(True)
+    mask_a.append(False)
+    col_a.set_null_mask(mask_a^)
 
     var d_b = List[String]()
     d_b.append("hi")
     d_b.append("bye")
     d_b.append("")
     var col_b = Column("b", ColumnData(d_b^), string_)
-    col_b._null_mask = NullMask()
-    col_b._null_mask.append(False)
-    col_b._null_mask.append(False)
-    col_b._null_mask.append(True)
+    var mask_b = NullMask()
+    mask_b.append(False)
+    mask_b.append(False)
+    mask_b.append(True)
+    col_b.set_null_mask(mask_b^)
 
     var cols = List[Column]()
     cols.append(col_a^)
@@ -189,15 +193,15 @@ def test_dataframe_round_trip_with_nulls() raises:
     var rb = dataframe_to_record_batch(df)
     var df2 = record_batch_to_dataframe(rb^)
 
-    assert_equal(len(df2._cols[0]._null_mask), 3)
-    assert_false(df2._cols[0]._null_mask[0])
-    assert_true(df2._cols[0]._null_mask[1])
-    assert_false(df2._cols[0]._null_mask[2])
+    assert_true(df2._cols[0].has_nulls())
+    assert_false(df2._cols[0].is_null(0))
+    assert_true(df2._cols[0].is_null(1))
+    assert_false(df2._cols[0].is_null(2))
 
-    assert_equal(len(df2._cols[1]._null_mask), 3)
-    assert_false(df2._cols[1]._null_mask[0])
-    assert_false(df2._cols[1]._null_mask[1])
-    assert_true(df2._cols[1]._null_mask[2])
+    assert_true(df2._cols[1].has_nulls())
+    assert_false(df2._cols[1].is_null(0))
+    assert_false(df2._cols[1].is_null(1))
+    assert_true(df2._cols[1].is_null(2))
 
 
 def test_python_object_column_raises() raises:
@@ -249,7 +253,7 @@ def test_storage_active_bool_no_nulls() raises:
 
 
 def test_storage_active_with_null_mask_finalized() raises:
-    """Phase 6c: after col._null_mask assignment, _try_activate_storage()
+    """Phase 6c: after set_null_mask(), _try_activate_storage()
     re-rebuilds _storage so the marrow bitmap reflects the current mask.
     """
     var data = List[Int64]()
@@ -261,7 +265,7 @@ def test_storage_active_with_null_mask_finalized() raises:
     mask.append_valid()
     mask.append_null()
     mask.append_valid()
-    col._null_mask = mask^
+    col.set_null_mask(mask^)
     col._try_activate_storage()
     # has_nulls() should now read True via the marrow bitmap path.
     assert_true(col.has_nulls())

--- a/tests/test_expr.mojo
+++ b/tests/test_expr.mojo
@@ -1,6 +1,6 @@
 """Tests for bison.expr: tokenizer, AST, parser, and evaluator."""
 from std.python import Python
-from std.testing import assert_true, assert_equal, TestSuite
+from std.testing import assert_true, assert_false, assert_equal, TestSuite
 from bison import DataFrame, Series
 from bison.expr import (
     parse,
@@ -606,11 +606,11 @@ def test_eval_null_and() raises:
     var pd = Python.import_module("pandas")
     var df = DataFrame(pd.DataFrame(Python.evaluate("{'a': [1.0, None, 3.0]}")))
     var mask = eval_expr(parse("a > 1 and a < 5"), df)
-    assert_true(len(mask._col._null_mask) > 0)
-    assert_true(not mask._col._null_mask[0])
+    assert_true(mask._col.has_nulls())
+    assert_false(mask._col.is_null(0))
     assert_true(not mask._col._data[List[Bool]][0])
-    assert_true(mask._col._null_mask[1])
-    assert_true(not mask._col._null_mask[2])
+    assert_true(mask._col.is_null(1))
+    assert_false(mask._col.is_null(2))
     assert_true(mask._col._data[List[Bool]][2])
 
 
@@ -622,11 +622,11 @@ def test_eval_null_or() raises:
     var pd = Python.import_module("pandas")
     var df = DataFrame(pd.DataFrame(Python.evaluate("{'a': [1.0, None, 6.0]}")))
     var mask = eval_expr(parse("a < 2 or a > 5"), df)
-    assert_true(len(mask._col._null_mask) > 0)
-    assert_true(not mask._col._null_mask[0])
+    assert_true(mask._col.has_nulls())
+    assert_false(mask._col.is_null(0))
     assert_true(mask._col._data[List[Bool]][0])
-    assert_true(mask._col._null_mask[1])
-    assert_true(not mask._col._null_mask[2])
+    assert_true(mask._col.is_null(1))
+    assert_false(mask._col.is_null(2))
     assert_true(mask._col._data[List[Bool]][2])
 
 
@@ -1632,17 +1632,17 @@ def test_conformance_eval_nulls_simple() raises:
     var bs_mask = bs_df.eval("a > 1")
 
     # Null positions must carry the null flag.
-    assert_true(len(bs_mask._col._null_mask) > 0)
-    assert_true(bs_mask._col._null_mask[1])
-    assert_true(bs_mask._col._null_mask[3])
+    assert_true(bs_mask._col.has_nulls())
+    assert_true(bs_mask._col.is_null(1))
+    assert_true(bs_mask._col.is_null(3))
 
     # Non-null positions must agree with pandas boolean operations.
     var pd_bools = (pd_df["a"] > 1)
-    assert_true(not bs_mask._col._null_mask[0])
+    assert_false(bs_mask._col.is_null(0))
     assert_true(not bs_mask._col._data[List[Bool]][0])
-    assert_true(not bs_mask._col._null_mask[2])
+    assert_false(bs_mask._col.is_null(2))
     assert_true(bs_mask._col._data[List[Bool]][2])
-    assert_true(not bs_mask._col._null_mask[4])
+    assert_false(bs_mask._col.is_null(4))
     assert_true(bs_mask._col._data[List[Bool]][4])
 
     # query() must exclude null rows; count must match pandas oracle.

--- a/tests/test_interop.mojo
+++ b/tests/test_interop.mojo
@@ -148,7 +148,7 @@ def test_float64_bitcast_roundtrip() raises:
 def test_int_column_with_nulls_to_pandas() raises:
     """Integer Column with null entries must round-trip through to_pandas() without raising.
 
-    When a Column has integer dtype and any _null_mask entries are True,
+    When a Column has integer dtype and any null mask entries are True,
     to_pandas() must use the pandas nullable integer dtype (e.g. "Int64")
     so that None values are accepted.  The resulting pandas Series must
     expose pd.isna() == True at the null positions and the correct integer
@@ -163,7 +163,7 @@ def test_int_column_with_nulls_to_pandas() raises:
     )
     var col = Column.from_pandas(pd_s, "with_nulls")
     # The column must have a null mask with True at index 1.
-    assert_true(col._null_mask[1], "null mask should be True at index 1")
+    assert_true(col.is_null(1), "null mask should be True at index 1")
     # Round-trip back to pandas must not raise.
     var back = col.to_pandas()
     # Non-null values must be preserved.
@@ -174,10 +174,10 @@ def test_int_column_with_nulls_to_pandas() raises:
 
 
 def test_int_column_direct_null_mask_to_pandas() raises:
-    """Column constructed directly with an int64 arm and a _null_mask must not raise on to_pandas().
+    """Column constructed directly with an int64 arm and a null mask must not raise on to_pandas().
 
     This covers the code path where a caller builds a Column manually
-    (e.g. from_dict or direct Column(...)) and sets _null_mask instead of
+    (e.g. from_dict or direct Column(...)) and sets a null mask instead of
     going through from_records.
     """
     var pd = Python.import_module("pandas")
@@ -190,7 +190,7 @@ def test_int_column_direct_null_mask_to_pandas() raises:
     mask.append_valid()
     mask.append_null()
     mask.append_valid()
-    col._null_mask = mask^
+    col.set_null_mask(mask^)
     # Must not raise even though dtype is int64 and mask has True entries.
     var back = col.to_pandas()
     assert_equal(Int(py=back[0]), 10)
@@ -217,7 +217,7 @@ def test_obj_column_with_null_mask_to_pandas() raises:
     mask.append_valid()
     mask.append_null()
     mask.append_valid()
-    col._null_mask = mask^
+    col.set_null_mask(mask^)
     var back = col.to_pandas()
     assert_equal(String(py=back[0]), "apple")
     assert_true(Bool(py=pd.isna(back[1])), "masked position must be NaN, not the stored value")
@@ -276,9 +276,9 @@ def test_string_promotion_with_nulls() raises:
     assert_equal(col.dtype.name, "string")
     assert_equal(col.__len__(), 3)
     # Null mask: position 1 should be null
-    assert_true(not col._null_mask[0], "position 0 should not be null")
-    assert_true(col._null_mask[1], "position 1 should be null")
-    assert_true(not col._null_mask[2], "position 2 should not be null")
+    assert_true(col.is_valid(0), "position 0 should not be null")
+    assert_true(col.is_null(1), "position 1 should be null")
+    assert_true(col.is_valid(2), "position 2 should not be null")
 
 
 def test_string_promotion_roundtrip() raises:

--- a/tests/test_io.mojo
+++ b/tests/test_io.mojo
@@ -1,6 +1,6 @@
 """Tests for DataFrame IO (read and write methods)."""
 from std.python import Python, PythonObject
-from std.testing import assert_equal, assert_true, TestSuite
+from std.testing import assert_equal, assert_true, assert_false, TestSuite
 from bison import (
     read_csv,
     read_parquet,
@@ -127,9 +127,9 @@ def test_read_csv_bool_with_nulls() raises:
     var df = read_csv(path)
     var col = df["flag"]._col
     assert_true(col.dtype == bool_)
-    assert_true(not col._null_mask[0])
-    assert_true(col._null_mask[1])
-    assert_true(not col._null_mask[2])
+    assert_false(col.is_null(0))
+    assert_true(col.is_null(1))
+    assert_false(col.is_null(2))
 
 
 def test_to_csv_returns_string() raises:
@@ -451,20 +451,22 @@ def test_parquet_roundtrip_with_nulls() raises:
     d_a.append(0)
     d_a.append(30)
     var col_a = Column("a", ColumnData(d_a^), int64)
-    col_a._null_mask = NullMask()
-    col_a._null_mask.append(False)
-    col_a._null_mask.append(True)
-    col_a._null_mask.append(False)
+    var mask_a = NullMask()
+    mask_a.append(False)
+    mask_a.append(True)
+    mask_a.append(False)
+    col_a.set_null_mask(mask_a^)
 
     var d_b = List[String]()
     d_b.append("hi")
     d_b.append("")
     d_b.append("bye")
     var col_b = Column("b", ColumnData(d_b^), string_)
-    col_b._null_mask = NullMask()
-    col_b._null_mask.append(False)
-    col_b._null_mask.append(True)
-    col_b._null_mask.append(False)
+    var mask_b = NullMask()
+    mask_b.append(False)
+    mask_b.append(True)
+    mask_b.append(False)
+    col_b.set_null_mask(mask_b^)
 
     var cols = List[Column]()
     cols.append(col_a^)
@@ -484,12 +486,12 @@ def test_parquet_roundtrip_with_nulls() raises:
     assert_equal(df2._cols[1]._data[List[String]][2], "bye")
 
     # Null masks preserved.
-    assert_true(not df2._cols[0]._null_mask[0])
-    assert_true(df2._cols[0]._null_mask[1])
-    assert_true(not df2._cols[0]._null_mask[2])
-    assert_true(not df2._cols[1]._null_mask[0])
-    assert_true(df2._cols[1]._null_mask[1])
-    assert_true(not df2._cols[1]._null_mask[2])
+    assert_false(df2._cols[0].is_null(0))
+    assert_true(df2._cols[0].is_null(1))
+    assert_false(df2._cols[0].is_null(2))
+    assert_false(df2._cols[1].is_null(0))
+    assert_true(df2._cols[1].is_null(1))
+    assert_false(df2._cols[1].is_null(2))
 
 
 
@@ -597,20 +599,22 @@ def test_ipc_roundtrip_with_nulls() raises:
     d_a.append(0.0)
     d_a.append(30.0)
     var col_a = Column("a", ColumnData(d_a^), float64)
-    col_a._null_mask = NullMask()
-    col_a._null_mask.append(False)
-    col_a._null_mask.append(True)
-    col_a._null_mask.append(False)
+    var mask_a = NullMask()
+    mask_a.append(False)
+    mask_a.append(True)
+    mask_a.append(False)
+    col_a.set_null_mask(mask_a^)
 
     var d_b = List[String]()
     d_b.append("hi")
     d_b.append("")
     d_b.append("bye")
     var col_b = Column("b", ColumnData(d_b^), string_)
-    col_b._null_mask = NullMask()
-    col_b._null_mask.append(False)
-    col_b._null_mask.append(True)
-    col_b._null_mask.append(False)
+    var mask_b = NullMask()
+    mask_b.append(False)
+    mask_b.append(True)
+    mask_b.append(False)
+    col_b.set_null_mask(mask_b^)
 
     var cols = List[Column]()
     cols.append(col_a^)
@@ -631,12 +635,12 @@ def test_ipc_roundtrip_with_nulls() raises:
     assert_equal(df2._cols[1]._data[List[String]][2], "bye")
 
     # Null masks preserved.
-    assert_true(not df2._cols[0]._null_mask[0])
-    assert_true(df2._cols[0]._null_mask[1])
-    assert_true(not df2._cols[0]._null_mask[2])
-    assert_true(not df2._cols[1]._null_mask[0])
-    assert_true(df2._cols[1]._null_mask[1])
-    assert_true(not df2._cols[1]._null_mask[2])
+    assert_false(df2._cols[0].is_null(0))
+    assert_true(df2._cols[0].is_null(1))
+    assert_false(df2._cols[0].is_null(2))
+    assert_false(df2._cols[1].is_null(0))
+    assert_true(df2._cols[1].is_null(1))
+    assert_false(df2._cols[1].is_null(2))
 
 
 def test_to_ipc_writes_file() raises:

--- a/tests/test_series_math.mojo
+++ b/tests/test_series_math.mojo
@@ -563,7 +563,7 @@ def test_bool_and() raises:
     assert_true(d[1] == False)
     assert_true(d[2] == False)
     assert_true(d[3] == False)
-    assert_true(len(result._col._null_mask) == 0)
+    assert_false(result._col.has_nulls())
 
 
 def test_bool_and_dunder() raises:
@@ -588,7 +588,7 @@ def test_bool_or() raises:
     assert_true(d[1] == True)
     assert_true(d[2] == True)
     assert_true(d[3] == False)
-    assert_true(len(result._col._null_mask) == 0)
+    assert_false(result._col.has_nulls())
 
 
 def test_bool_xor() raises:
@@ -602,7 +602,7 @@ def test_bool_xor() raises:
     assert_true(d[1] == True)
     assert_true(d[2] == True)
     assert_true(d[3] == False)
-    assert_true(len(result._col._null_mask) == 0)
+    assert_false(result._col.has_nulls())
 
 
 def test_bool_invert() raises:
@@ -615,7 +615,7 @@ def test_bool_invert() raises:
     assert_true(d[1] == True)
     assert_true(d[2] == False)
     assert_true(d[3] == True)
-    assert_true(len(result._col._null_mask) == 0)
+    assert_false(result._col.has_nulls())
 
 
 def test_bool_and_kleene_nulls() raises:
@@ -627,13 +627,13 @@ def test_bool_and_kleene_nulls() raises:
     var s2 = Series(pd.Series(Python.evaluate("[None, None, None]"), dtype="object").astype("boolean"))
     var result = s1.and_(s2)
     # False AND Null → False (non-null)
-    assert_true(len(result._col._null_mask) > 0)
-    assert_true(result._col._null_mask[0] == False)
+    assert_true(result._col.has_nulls())
+    assert_false(result._col.is_null(0))
     assert_true(result._col._data[List[Bool]][0] == False)
     # True AND Null → Null
-    assert_true(result._col._null_mask[1] == True)
+    assert_true(result._col.is_null(1))
     # Null AND Null → Null
-    assert_true(result._col._null_mask[2] == True)
+    assert_true(result._col.is_null(2))
 
 
 def test_bool_or_kleene_nulls() raises:
@@ -645,13 +645,13 @@ def test_bool_or_kleene_nulls() raises:
     var s2 = Series(pd.Series(Python.evaluate("[None, None, None]"), dtype="object").astype("boolean"))
     var result = s1.or_(s2)
     # True OR Null → True (non-null)
-    assert_true(len(result._col._null_mask) > 0)
-    assert_true(result._col._null_mask[0] == False)
+    assert_true(result._col.has_nulls())
+    assert_false(result._col.is_null(0))
     assert_true(result._col._data[List[Bool]][0] == True)
     # False OR Null → Null
-    assert_true(result._col._null_mask[1] == True)
+    assert_true(result._col.is_null(1))
     # Null OR Null → Null
-    assert_true(result._col._null_mask[2] == True)
+    assert_true(result._col.is_null(2))
 
 
 def test_bool_invert_null() raises:
@@ -659,11 +659,11 @@ def test_bool_invert_null() raises:
     var pd = Python.import_module("pandas")
     var s = Series(pd.Series(Python.evaluate("[True, None, False]"), dtype="object").astype("boolean"))
     var result = s.invert()
-    assert_true(len(result._col._null_mask) > 0)
-    assert_true(result._col._null_mask[0] == False)
+    assert_true(result._col.has_nulls())
+    assert_false(result._col.is_null(0))
     assert_true(result._col._data[List[Bool]][0] == False)
-    assert_true(result._col._null_mask[1] == True)
-    assert_true(result._col._null_mask[2] == False)
+    assert_true(result._col.is_null(1))
+    assert_false(result._col.is_null(2))
     assert_true(result._col._data[List[Bool]][2] == True)
 
 


### PR DESCRIPTION
## Summary

- **Delete `Column._null_mask: NullMask` field** — null tracking now lives entirely in `_storage` (AnyArray validity bitmap or LegacyObjectData.null_mask)
- **Add 4 new Column helpers**: `null_mask_copy()`, `set_null_mask()`, `clear_null_mask()`, `set_valid_at()` that dispatch on the active `_storage` arm
- **Migrate ~550 `_null_mask` references** across 13 files to use the new helpers or existing `is_null()`/`is_valid()`/`has_nulls()` methods
- **Delete `_obj_data()` method** — 3 callers now use `_storage_legacy().data` directly

## Details

Phase 6c part 2a of the dual-backend Column storage migration (#619). Follow-up to #647 (part 1, landed in #655).

The `_null_mask` field was fully redundant — `_storage` (always populated post-#647) already carries null information in the Arrow validity bitmap (AnyArray) or bundled NullMask (LegacyObjectData). All read sites already dispatched through `_storage` via `is_null()`/`has_nulls()`. The field existed only because ~550 write/read sites still referenced it directly.

### Migration patterns applied

| Pattern | Count | Replacement |
|---------|-------|-------------|
| `col._null_mask.has_nulls()` | ~90 | `col.has_nulls()` |
| `col._null_mask[i]` / `.is_null(i)` | ~80 | `col.is_null(i)` |
| `col._null_mask.is_valid(i)` | ~30 | `col.is_valid(i)` |
| `col._null_mask = mask^` | ~70 | `col.set_null_mask(mask^)` |
| `col._null_mask.copy()` (visitor args) | ~40 | `col.null_mask_copy()` |
| `col._null_mask.set_valid(r)` | 5 | `col.set_valid_at(r)` |

### Files changed

- `bison/column.mojo` — bulk of deletions + new helpers
- `bison/_frame.mojo` — Series/DataFrame ops, join, pivot, groupby
- `bison/arrow.mojo` — Arrow conversion layer
- `bison/reshape/_concat.mojo` — concat/vstack
- `bison/io/csv.mojo`, `bison/io/json.mojo` — I/O construction
- `bison/accessors/str_accessor.mojo`, `dt_accessor.mojo` — result column writes
- 5 test files

### Remaining work

`_data: ColumnData` field deletion is tracked in a follow-up issue. The `ColumnData` alias stays for now (42 visitor structs depend on it, blocked on #642).

## Test plan

- [x] `pixi run check` — zero warnings
- [x] `pixi run lint` — all pre-commit hooks pass
- [x] `pixi run test` — all 21 test suites pass (0 failures)
- [x] Grep confirms no `Column._null_mask` field references remain outside of comments

Refs: #619, #642, #647, #656

https://claude.ai/code/session_01FHD8Bmrog6wUkLuwhhDAvU