### PR TITLE
feat: add profiling infrastructure and compile-check CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,5 +41,8 @@ jobs:
       - name: Generate version file
         run: pixi run gen-version
 
+      - name: Compile-check all entry points
+        run: pixi run check-compile
+
       - name: Run tests
         run: pixi run test

--- a/.gitignore
+++ b/.gitignore
@@ -9,4 +9,5 @@ SESSION.md
 dist/
 .test-pass-count
 results/
+profile_results/
 docs/data.json

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -46,6 +46,7 @@ pixi run gen-version    # write bison/_version.mojo from pixi.toml
 pixi run test           # regenerates version then runs all tests
 pixi run fmt            # mojo format bison/
 pixi run check          # mojo package bison/ --Werror (no warnings allowed)
+pixi run check-compile  # compile-check all test and benchmark entry points
 pixi run lint           # pre-commit run --all-files
 pixi run bench          # run benchmarks (depends on gen-version)
 pixi run profile        # profile operations with samply (see docs/profiling.md)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -48,6 +48,7 @@ pixi run fmt            # mojo format bison/
 pixi run check          # mojo package bison/ --Werror (no warnings allowed)
 pixi run lint           # pre-commit run --all-files
 pixi run bench          # run benchmarks (depends on gen-version)
+pixi run profile        # profile operations with samply (see docs/profiling.md)
 pixi run gen-report     # merge benchmark results into docs/data.json
 ```
 
@@ -206,6 +207,18 @@ Helper utilities live in `tests/_helpers.mojo`: `assert_frame_equal`, `assert_se
 `benchmarks/bench_core.mojo` measures bison vs pandas across aggregation, groupby, indexing, and I/O operations. `benchmarks/_bench_utils.mojo` provides `time_fn()` (wraps Python timeit) and `BenchResult` (outputs JSON with ratio = bison_ms / pandas_ms).
 
 Iteration counts: `FAST_ITERS=100`, `MED_ITERS=20`, `SLOW_ITERS=3`, `IO_ITERS=5`. Results are stored in `results/<commit>.json`; the latest is symlinked as `results/latest.json`. `scripts/generate_report.py` merges history into `docs/data.json` (capped at 200 runs).
+
+### Profiling
+
+`benchmarks/bench_profile.mojo` runs operations in isolation for external profilers. Compiled with `-g --debug-info-language C` for debug symbols readable by standard Linux tools.
+
+```bash
+pixi run profile sort           # samply flamegraph for sort_values
+pixi run profile merge          # samply flamegraph for merge
+pixi run profile --callgrind    # use callgrind instead (may fail with AVX-512)
+```
+
+Output goes to `profile_results/` (gitignored). View samply results: `samply load profile_results/sort.samply.json`. See `docs/profiling.md` for full documentation.
 
 ## CI / GitHub Actions
 

--- a/benchmarks/bench_profile.mojo
+++ b/benchmarks/bench_profile.mojo
@@ -1,0 +1,182 @@
+"""Profiling benchmark: runs bison operations in isolation for external profilers.
+
+Designed to be compiled with debug symbols and run under callgrind or samply
+so that function-level and line-level cost attribution is captured by the
+profiling tool — no custom instrumentation needed.
+
+Each operation runs enough iterations to accumulate ~1-2 seconds of runtime,
+giving sampling profilers good coverage.
+
+Environment variables:
+    BISON_PROFILE_OP  Which operation to profile.  One of:
+                      sort, groupby, merge, query, csv, all (default: all)
+
+Usage (via pixi):
+    pixi run profile              # samply, all operations
+    pixi run profile sort         # samply, just sort_values
+    pixi run profile merge --callgrind  # callgrind for merge
+
+Manual usage:
+    mojo build -I .bison-cache -I . benchmarks/bench_profile.mojo \\
+        -g --debug-info-language C -o /tmp/bison_profile
+    BISON_PROFILE_OP=sort samply record /tmp/bison_profile
+"""
+
+from benchmarks._bench_utils import BenchResult, print_json
+from bison import DataFrame, read_csv
+from std.os import getenv
+from std.python import Python
+from std.time import perf_counter_ns
+
+# ---------------------------------------------------------------------------
+# Iteration counts — tuned so each operation accumulates ~1-2 s total,
+# giving profilers enough samples for stable attribution.
+# ---------------------------------------------------------------------------
+
+comptime SORT_ITERS = 30
+comptime GROUPBY_ITERS = 50
+comptime MERGE_ITERS = 30
+comptime QUERY_ITERS = 100
+comptime CSV_ITERS = 10
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _elapsed_ms(t0: UInt, iters: Int) -> Float64:
+    return Float64(perf_counter_ns() - t0) / Float64(iters) / 1_000_000.0
+
+
+# ---------------------------------------------------------------------------
+# Profile functions — tight loops that keep the target operation hot.
+# ---------------------------------------------------------------------------
+
+
+def _profile_sort(df: DataFrame, iters: Int) raises:
+    """Profile DataFrame.sort_values (single key, ascending)."""
+    print("  sort_values ...", end="")
+    var by = List[String]()
+    by.append("a")
+    var t0 = perf_counter_ns()
+    for _ in range(iters):
+        _ = df.sort_values(by)
+    var ms = _elapsed_ms(t0, iters)
+    print(" ", ms, "ms/call")
+
+
+def _profile_groupby(df: DataFrame, iters: Int) raises:
+    """Profile DataFrame.groupby().sum() (single key)."""
+    print("  groupby_sum ...", end="")
+    var t0 = perf_counter_ns()
+    for _ in range(iters):
+        var by = List[String]()
+        by.append("key")
+        _ = df.groupby(by).sum()
+    var ms = _elapsed_ms(t0, iters)
+    print(" ", ms, "ms/call")
+
+
+def _profile_merge(df: DataFrame, df2: DataFrame, iters: Int) raises:
+    """Profile DataFrame.merge (inner join on integer key)."""
+    print("  merge ...", end="")
+    var t0 = perf_counter_ns()
+    for _ in range(iters):
+        var on_keys = List[String]()
+        on_keys.append("id")
+        _ = df.merge(df2, on=on_keys^)
+    var ms = _elapsed_ms(t0, iters)
+    print(" ", ms, "ms/call")
+
+
+def _profile_query(df: DataFrame, iters: Int) raises:
+    """Profile DataFrame.query with a compound expression."""
+    print("  query (a > 0.5 and b < 0.3) ...", end="")
+    var t0 = perf_counter_ns()
+    for _ in range(iters):
+        _ = df.query("a > 0.5 and b < 0.3")
+    var ms = _elapsed_ms(t0, iters)
+    print(" ", ms, "ms/call")
+
+
+def _profile_csv(df: DataFrame, iters: Int) raises:
+    """Profile CSV round-trip (to_csv + read_csv)."""
+    print("  csv_roundtrip ...", end="")
+    var tmp = "/tmp/_bison_profile_csv.csv"
+    var t0 = perf_counter_ns()
+    for _ in range(iters):
+        _ = df.to_csv(tmp)
+        _ = read_csv(tmp)
+    var ms = _elapsed_ms(t0, iters)
+    print(" ", ms, "ms/call")
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+
+def main() raises:
+    var op = getenv("BISON_PROFILE_OP", "")
+
+    # When invoked by run_benchmarks.sh without BISON_PROFILE_OP, emit
+    # skip-JSON so the runner doesn't choke on unexpected output.
+    if len(op) == 0:
+        var results = List[BenchResult]()
+        results.append(BenchResult.skipped_result("profile_sort"))
+        results.append(BenchResult.skipped_result("profile_groupby"))
+        results.append(BenchResult.skipped_result("profile_merge"))
+        results.append(BenchResult.skipped_result("profile_query"))
+        results.append(BenchResult.skipped_result("profile_csv"))
+        print_json(results)
+        return
+
+    # ------------------------------------------------------------------
+    # Build fixtures (same schema as bench_core.mojo).
+    # ------------------------------------------------------------------
+    var _make_fixtures = Python.evaluate(
+        "lambda n: ("
+        "    lambda np, pd, keys: ("
+        "        pd.DataFrame({"
+        "            'key': np.random.default_rng(7).choice(keys, n),"
+        "            'a':   np.random.default_rng(42).random(n),"
+        "            'b':   np.random.default_rng(123).random(n),"
+        "            'c':   np.random.default_rng(42).integers(0, 1000, n),"
+        "            'id':  np.arange(n, dtype='int64'),"
+        "        }),"
+        "        pd.DataFrame({"
+        "            'id':  np.arange(n // 10, dtype='int64'),"
+        "            'val': np.random.default_rng(999).random(n // 10),"
+        "        }),"
+        "    )"
+        ")("
+        "    __import__('numpy'),"
+        "    __import__('pandas'),"
+        "    ['k0','k1','k2','k3','k4','k5','k6','k7','k8','k9'],"
+        ")"
+    )
+    var _fixtures = _make_fixtures(100_000)
+    var pd_df = _fixtures[0]
+    var pd_df2 = _fixtures[1]
+
+    var df = DataFrame.from_pandas(pd_df)
+    var df2 = DataFrame.from_pandas(pd_df2)
+
+    print("bison profiling benchmark")
+    print("  operation:", op)
+    print("  rows:      100,000")
+    print("")
+
+    if op == "sort" or op == "all":
+        _profile_sort(df, SORT_ITERS)
+    if op == "groupby" or op == "all":
+        _profile_groupby(df, GROUPBY_ITERS)
+    if op == "merge" or op == "all":
+        _profile_merge(df, df2, MERGE_ITERS)
+    if op == "query" or op == "all":
+        _profile_query(df, QUERY_ITERS)
+    if op == "csv" or op == "all":
+        _profile_csv(df, CSV_ITERS)
+
+    print("")
+    print("done — use callgrind_annotate or samply to inspect the profile data")

--- a/docs/profiling.md
+++ b/docs/profiling.md
@@ -1,0 +1,246 @@
+# Profiling bison
+
+This guide explains how to profile bison operations to identify where runtime
+is spent during optimization sessions.
+
+## Overview
+
+Bison uses external profiling tools (samply, callgrind) rather than custom
+instrumentation. Mojo compiles to native code, so standard Linux profiling
+tools work when the binary is compiled with debug symbols. This gives
+function-level and line-level cost attribution automatically.
+
+## Prerequisites
+
+Install samply (the default profiling tool):
+
+```bash
+cargo install samply
+```
+
+Ensure perf events are accessible:
+
+```bash
+# Check current level (needs to be <= 1)
+cat /proc/sys/kernel/perf_event_paranoid
+
+# If it shows 2 or higher, lower it:
+echo 1 | sudo tee /proc/sys/kernel/perf_event_paranoid
+```
+
+## Quick start
+
+```bash
+# Profile all benchmark operations (samply, default)
+pixi run profile
+
+# Profile a single operation
+pixi run profile sort
+
+# Profile with callgrind instead
+pixi run profile merge --callgrind
+```
+
+## Available operations
+
+| Name | Operation | Description |
+|------|-----------|-------------|
+| `sort` | `DataFrame.sort_values` | Single-key ascending sort on 100K rows |
+| `groupby` | `DataFrame.groupby().sum()` | Single-key groupby + sum aggregation |
+| `merge` | `DataFrame.merge` | Inner join on integer key (100K x 10K rows) |
+| `query` | `DataFrame.query` | Compound boolean expression filter |
+| `csv` | `to_csv` + `read_csv` | CSV round-trip on 100K rows |
+| `all` | All of the above | Runs sequentially (default) |
+
+## Profiling tools
+
+### samply (default)
+
+[samply](https://github.com/mstange/samply) is a sampling profiler that
+produces interactive flamegraphs viewable in
+[Firefox Profiler](https://profiler.firefox.com). It runs at near-native
+speed and captures real wall-clock timing.
+
+```bash
+pixi run profile sort
+```
+
+This produces `profile_results/sort.samply.json`. View the flamegraph:
+
+```bash
+samply load profile_results/sort.samply.json
+```
+
+This opens Firefox Profiler in your browser with an interactive flamegraph.
+You can zoom into call stacks, filter by function name, and see
+time-weighted call trees.
+
+### callgrind (alternative)
+
+[Callgrind](https://valgrind.org/docs/manual/cl-manual.html) is a
+call-graph profiler built on valgrind. It counts instruction execution at
+the function and line level, giving deterministic cost attribution that
+does not vary between runs.
+
+```bash
+pixi run profile sort --callgrind
+```
+
+This produces `profile_results/callgrind.out.sort` and prints a summary.
+
+To explore the results:
+
+```bash
+# Text-based exploration
+callgrind_annotate --auto=yes profile_results/callgrind.out.sort | less
+
+# GUI viewer (if kcachegrind is installed)
+kcachegrind profile_results/callgrind.out.sort
+```
+
+**Callgrind output explained:**
+
+- **Ir** (instruction reads) is the primary cost metric. Higher Ir = more time.
+- Functions are listed in descending Ir order. Look for bison functions
+  like `sort_perm`, `take`, `_row_key_str`, `_groupby_indices`.
+- Line-level annotation shows which specific lines within a function are
+  most expensive.
+
+**Caveats:** Callgrind runs code under a CPU emulator (~20-50x slower than
+native). It may crash on Mojo binaries that use AVX-512 instructions
+(valgrind 3.22 does not support all EVEX-encoded instructions). If you
+encounter `SIGILL` errors, use samply instead.
+
+### When to use which tool
+
+| | samply | callgrind |
+|---|--------|-----------|
+| **Speed** | Near-native | ~20-50x slower |
+| **Accuracy** | Statistical (sampling) | Deterministic (instruction count) |
+| **Output** | Interactive flamegraph | Text + kcachegrind |
+| **Best for** | High-level overview, call trees | Line-level hotspot analysis |
+| **AVX-512** | Works | May crash |
+| **Install** | `cargo install samply` | `apt install valgrind` |
+
+## How it works
+
+The `pixi run profile` command:
+
+1. Packages `bison/` into `bison.mojopkg` (cached)
+2. Compiles `benchmarks/bench_profile.mojo` with debug symbols:
+   ```bash
+   mojo build -g --debug-info-language C -o /tmp/bison_profile ...
+   ```
+3. Runs the compiled binary under the selected profiler
+4. Saves results to `profile_results/`
+
+The compiler flags:
+- `-g` adds full debug info (function names + line numbers in profile output)
+- `--debug-info-language C` makes symbols readable by standard Linux tools
+  (samply, callgrind, perf) that don't understand Mojo debug format natively
+
+## Manual profiling
+
+For more control, you can compile and profile manually:
+
+```bash
+# 1. Build the bison package
+pixi run build-marrow
+pixi run gen-version
+mojo package bison/ -o .bison-cache/bison.mojopkg
+
+# 2. Compile with debug symbols
+mojo build -I .bison-cache -I . benchmarks/bench_profile.mojo \
+    -g --debug-info-language C \
+    -o /tmp/bison_profile
+
+# 3a. Profile with samply
+BISON_PROFILE_OP=sort samply record /tmp/bison_profile
+
+# 3b. Or profile with perf (if installed)
+BISON_PROFILE_OP=sort perf record -g /tmp/bison_profile
+perf report
+
+# 3c. Or profile with callgrind
+BISON_PROFILE_OP=sort valgrind --tool=callgrind \
+    --callgrind-out-file=my_profile.out /tmp/bison_profile
+callgrind_annotate --auto=yes my_profile.out
+```
+
+## Interpreting results
+
+### Reading a samply flamegraph
+
+In Firefox Profiler:
+
+- **Flame chart** (default view): Each row is a stack frame. Width = time
+  spent. Wider bars = more time. Click to zoom in.
+- **Call tree** tab: Shows hierarchical breakdown of where time is spent.
+  Sort by "Self" to find the functions that do the most actual work (vs
+  just calling other functions).
+- **Search**: Type a function name (e.g. `sort_perm`) to highlight it
+  across the flame chart.
+
+### Common hot functions
+
+| Function | Called by | What it does |
+|----------|-----------|--------------|
+| `sort_perm` | `sort_values` | Merge-sort to produce permutation array |
+| `take` | `sort_values`, `groupby` | Reorder column data by index array |
+| `_row_key_str` | `merge`, `groupby` | Serialize row values to string key |
+| `_groupby_indices` | `groupby` | Build key-to-row-index mapping |
+| `_eval_expr` | `query` | Evaluate parsed expression against DataFrame |
+| `take_with_nulls` | `merge` | Reorder with null insertion for outer joins |
+| `_merge_sort_perm_comparable` | `sort_perm` | The actual sort kernel |
+| `_try_activate_storage` | `Column` construction | Sync marrow backend |
+
+### Example analysis workflow
+
+1. Run `pixi run profile sort` and open the flamegraph
+2. Look at the call tree: is most time in `sort_perm` (sorting) or `take`
+   (copying)?
+3. If `sort_perm` dominates, the sort algorithm itself is the bottleneck
+4. If `take` dominates, column copying is the bottleneck — consider
+   in-place permutation or batch `take`
+5. Drill into `sort_perm` to see if the merge-sort kernel
+   (`_merge_sort_perm_comparable`) is the hotspot, or if it's the
+   permutation composition loop
+
+## Adding new profiling targets
+
+To profile a new operation, add a function to `benchmarks/bench_profile.mojo`:
+
+```mojo
+def _profile_my_op(df: DataFrame, iters: Int) raises:
+    """Profile description."""
+    print("  my_op ...", end="")
+    var t0 = perf_counter_ns()
+    for _ in range(iters):
+        _ = df.my_op(...)
+    var ms = _elapsed_ms(t0, iters)
+    print(" ", ms, "ms/call")
+```
+
+Then add the dispatch in `main()`:
+
+```mojo
+if op == "my_op" or op == "all":
+    _profile_my_op(df, MY_OP_ITERS)
+```
+
+Choose an iteration count that gives ~1-2 seconds total runtime for good
+profiler coverage.
+
+## Fixture details
+
+The profiling benchmark uses the same 100K-row fixture as `bench_core.mojo`:
+
+| Column | Type | Description |
+|--------|------|-------------|
+| `key` | string | 10 unique values (`k0`...`k9`) |
+| `a` | float64 | Random uniform [0, 1) |
+| `b` | float64 | Random uniform [0, 1) |
+| `c` | int64 | Random integers [0, 1000) |
+| `id` | int64 | Unique sequential (0 to N-1) |
+
+A secondary 10K-row fixture is used for merge (right side).

--- a/pixi.toml
+++ b/pixi.toml
@@ -24,6 +24,7 @@ build-marrow  = "mojo package vendor/marrow/marrow -o .pixi/envs/default/lib/moj
 test          = { cmd = "bash scripts/run_tests.sh", depends-on = ["gen-version", "build-marrow"] }
 fmt           = "mojo format bison/"
 check         = { cmd = "mojo package bison/ --Werror -o /tmp/bison.mojopkg", depends-on = ["build-marrow"] }
+check-compile = { cmd = "bash scripts/check_compile.sh", depends-on = ["gen-version", "build-marrow"] }
 lint          = "pre-commit run --all-files"
 bench         = { cmd = "bash scripts/run_benchmarks.sh", depends-on = ["gen-version", "build-marrow"] }
 profile       = { cmd = "bash scripts/run_profile.sh", depends-on = ["gen-version", "build-marrow"] }

--- a/pixi.toml
+++ b/pixi.toml
@@ -26,6 +26,7 @@ fmt           = "mojo format bison/"
 check         = { cmd = "mojo package bison/ --Werror -o /tmp/bison.mojopkg", depends-on = ["build-marrow"] }
 lint          = "pre-commit run --all-files"
 bench         = { cmd = "bash scripts/run_benchmarks.sh", depends-on = ["gen-version", "build-marrow"] }
+profile       = { cmd = "bash scripts/run_profile.sh", depends-on = ["gen-version", "build-marrow"] }
 gen-report    = "python scripts/generate_report.py"
 
 [environments]

--- a/scripts/check_compile.sh
+++ b/scripts/check_compile.sh
@@ -1,0 +1,126 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# ---------------------------------------------------------------------------
+# check_compile.sh — verify that all Mojo files with entry points compile.
+#
+# Catches import errors, type errors, and syntax issues in test and benchmark
+# files that `mojo package bison/ --Werror` (the pre-commit check) does not
+# cover, since those files live outside the bison package.
+#
+# Uses `mojo build` to compile each file.  Linker-only failures (missing
+# system libraries) are reported as warnings rather than errors, since those
+# are environment-specific and not source-level bugs.
+#
+# Files are compiled in parallel for speed.
+#
+# Usage:
+#   pixi run check-compile
+# ---------------------------------------------------------------------------
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+CACHE_DIR="$REPO_ROOT/.bison-cache"
+PKG_FILE="$CACHE_DIR/bison.mojopkg"
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+mkdir -p "$CACHE_DIR"
+
+# Build bison.mojopkg if needed.
+if [ ! -f "$PKG_FILE" ] || \
+   find "$REPO_ROOT/bison" -name "*.mojo" -newer "$PKG_FILE" -print -quit | grep -q .; then
+    echo "Packaging bison/ -> $PKG_FILE ..."
+    TMP_PKG="$TMP_DIR/bison.mojopkg"
+    mojo package "$REPO_ROOT/bison" -o "$TMP_PKG"
+    mv "$TMP_PKG" "$PKG_FILE"
+else
+    echo "Package up to date: bison.mojopkg"
+fi
+
+# Collect all entry-point files: tests and benchmarks.
+FILES=()
+for f in "$REPO_ROOT"/tests/test_*.mojo "$REPO_ROOT"/benchmarks/bench_*.mojo; do
+    [ -f "$f" ] && FILES+=("$f")
+done
+
+echo "Compile-checking ${#FILES[@]} files ..."
+echo ""
+
+BIN_DIR="$TMP_DIR/bin"
+RESULT_DIR="$TMP_DIR/results"
+LOG_DIR="$TMP_DIR/logs"
+mkdir -p "$BIN_DIR" "$RESULT_DIR" "$LOG_DIR"
+
+# Compile in parallel.
+MAX_JOBS=$(( $(nproc) - 1 ))
+[ "$MAX_JOBS" -lt 1 ] && MAX_JOBS=1
+
+pids=()
+running=0
+
+for f in "${FILES[@]}"; do
+    name="$(basename "$f" .mojo)"
+    result_file="$RESULT_DIR/$name"
+    log_file="$LOG_DIR/$name.log"
+    (
+        if mojo build -I "$CACHE_DIR" -I "$REPO_ROOT" "$f" -o "$BIN_DIR/$name" >"$log_file" 2>&1; then
+            echo "pass" > "$result_file"
+        elif grep -q "failed to link executable" "$log_file"; then
+            # Linker-only failure (e.g. missing libm on some systems).
+            # The source compiled — the link step failed due to the environment.
+            echo "link" > "$result_file"
+        else
+            echo "fail" > "$result_file"
+        fi
+    ) &
+    pids+=($!)
+    running=$(( running + 1 ))
+
+    if [ "$running" -ge "$MAX_JOBS" ]; then
+        wait "${pids[$(( ${#pids[@]} - running ))]}" || true
+        running=$(( running - 1 ))
+    fi
+done
+
+# Wait for all compile jobs to finish.
+for pid in "${pids[@]}"; do
+    wait "$pid" || true
+done
+
+# Collect results.
+PASS=0
+FAIL=0
+LINK=0
+ERRORS=()
+
+for f in "${FILES[@]}"; do
+    name="$(basename "$f" .mojo)"
+    result_file="$RESULT_DIR/$name"
+    result="$(cat "$result_file" 2>/dev/null || echo fail)"
+    if [ "$result" = "pass" ]; then
+        echo "  OK   $(basename "$f")"
+        PASS=$((PASS + 1))
+    elif [ "$result" = "link" ]; then
+        echo "  WARN $(basename "$f")  (link-only failure)"
+        LINK=$((LINK + 1))
+    else
+        echo "  FAIL $(basename "$f")"
+        FAIL=$((FAIL + 1))
+        ERRORS+=("$f")
+    fi
+done
+
+echo ""
+echo "Results: $PASS passed, $FAIL failed, $LINK link-only warnings"
+
+if [ ${#ERRORS[@]} -gt 0 ]; then
+    echo ""
+    echo "Failed to compile:"
+    for e in "${ERRORS[@]}"; do
+        echo "  $e"
+    done
+    echo ""
+    echo "Re-run individually for detailed error output:"
+    echo "  mojo build -I .bison-cache -I . <file>"
+    exit 1
+fi

--- a/scripts/run_profile.sh
+++ b/scripts/run_profile.sh
@@ -1,0 +1,179 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# ---------------------------------------------------------------------------
+# run_profile.sh — build bison with debug symbols and profile under
+# samply (default) or callgrind.
+#
+# Usage:
+#   pixi run profile                     # samply, all operations
+#   pixi run profile sort                # samply, just sort_values
+#   pixi run profile merge --callgrind   # callgrind for merge
+#   pixi run profile --help
+# ---------------------------------------------------------------------------
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+CACHE_DIR="$REPO_ROOT/.bison-cache"
+PKG_FILE="$CACHE_DIR/bison.mojopkg"
+PROFILE_DIR="$REPO_ROOT/profile_results"
+BENCH_SRC="$REPO_ROOT/benchmarks/bench_profile.mojo"
+BIN_OUT="/tmp/bison_profile_$$"
+
+trap 'rm -f "$BIN_OUT"' EXIT
+
+# ---------------------------------------------------------------------------
+# Parse arguments
+# ---------------------------------------------------------------------------
+OP="all"
+TOOL="samply"
+
+usage() {
+    cat <<EOF
+Usage: $(basename "$0") [OPERATION] [--samply | --callgrind]
+
+Profile bison benchmark operations using external profiling tools.
+
+Operations:
+  all       Profile all operations (default)
+  sort      DataFrame.sort_values (single key)
+  groupby   DataFrame.groupby().sum()
+  merge     DataFrame.merge (inner join)
+  query     DataFrame.query (compound expression)
+  csv       CSV round-trip (to_csv + read_csv)
+
+Tools:
+  --samply      Use samply sampling profiler (default)
+                Produces interactive flamegraphs via Firefox Profiler.
+                Install: cargo install samply
+  --callgrind   Use valgrind's callgrind for instruction-level profiling
+                Note: may fail if Mojo uses unsupported instructions (AVX-512)
+
+Examples:
+  pixi run profile                   # all ops, samply
+  pixi run profile sort              # just sort_values
+  pixi run profile merge --callgrind # merge with callgrind
+
+Output is written to profile_results/ in the repo root.
+EOF
+    exit 0
+}
+
+for arg in "$@"; do
+    case "$arg" in
+        --help|-h) usage ;;
+        --samply) TOOL="samply" ;;
+        --callgrind) TOOL="callgrind" ;;
+        sort|groupby|merge|query|csv|all) OP="$arg" ;;
+        *) echo "Unknown argument: $arg" >&2; usage ;;
+    esac
+done
+
+# ---------------------------------------------------------------------------
+# Validate tool availability
+# ---------------------------------------------------------------------------
+if [ "$TOOL" = "samply" ]; then
+    if ! command -v samply &>/dev/null; then
+        echo "Error: samply not found." >&2
+        echo "Install with: cargo install samply" >&2
+        echo "" >&2
+        echo "Alternatively, use --callgrind (may not work with AVX-512)." >&2
+        exit 1
+    fi
+    # samply needs perf_event_paranoid <= 1
+    PARANOID="$(cat /proc/sys/kernel/perf_event_paranoid 2>/dev/null || echo 0)"
+    if [ "$PARANOID" -gt 1 ]; then
+        echo "samply requires perf_event_paranoid <= 1 (currently $PARANOID)." >&2
+        echo "Run: echo 1 | sudo tee /proc/sys/kernel/perf_event_paranoid" >&2
+        exit 1
+    fi
+elif [ "$TOOL" = "callgrind" ]; then
+    if ! command -v valgrind &>/dev/null; then
+        echo "Error: valgrind not found. Install it or use --samply." >&2
+        exit 1
+    fi
+    echo "WARNING: callgrind may crash on Mojo binaries that use AVX-512."
+    echo "         Use --samply (the default) if you encounter issues."
+    echo ""
+fi
+
+# ---------------------------------------------------------------------------
+# Build bison.mojopkg (reuses cache from run_benchmarks.sh)
+# ---------------------------------------------------------------------------
+mkdir -p "$CACHE_DIR" "$PROFILE_DIR"
+
+needs_package_rebuild() {
+    [ ! -f "$PKG_FILE" ] && return 0
+    find "$REPO_ROOT/bison" -name "*.mojo" -newer "$PKG_FILE" -print -quit | grep -q . && return 0
+    return 1
+}
+
+if needs_package_rebuild; then
+    echo "Packaging bison/ -> $PKG_FILE ..."
+    TMP_PKG="$(mktemp -d)/bison.mojopkg"
+    mojo package "$REPO_ROOT/bison" -o "$TMP_PKG"
+    mv "$TMP_PKG" "$PKG_FILE"
+else
+    echo "Package up to date: bison.mojopkg"
+fi
+
+# ---------------------------------------------------------------------------
+# Compile bench_profile.mojo with debug symbols
+#
+# -g                       Full debug info (function names + line numbers)
+# --debug-info-language C  Makes symbols readable by samply/callgrind/perf
+# ---------------------------------------------------------------------------
+echo "Compiling bench_profile.mojo with debug symbols ..."
+mojo build \
+    -I "$CACHE_DIR" \
+    -I "$REPO_ROOT" \
+    "$BENCH_SRC" \
+    -g --debug-info-language C \
+    -o "$BIN_OUT"
+
+echo "Binary: $BIN_OUT"
+echo ""
+
+# ---------------------------------------------------------------------------
+# Run under profiler
+# ---------------------------------------------------------------------------
+if [ "$TOOL" = "samply" ]; then
+    OUTFILE="$PROFILE_DIR/${OP}.samply.json"
+    echo "Running under samply (op=$OP) ..."
+    echo "  Output: $OUTFILE"
+    echo ""
+
+    BISON_PROFILE_OP="$OP" samply record \
+        --save-only \
+        --output "$OUTFILE" \
+        "$BIN_OUT"
+
+    echo ""
+    echo "Profile saved: $OUTFILE"
+    echo ""
+    echo "To view the interactive flamegraph:"
+    echo "  samply load $OUTFILE"
+
+elif [ "$TOOL" = "callgrind" ]; then
+    OUTFILE="$PROFILE_DIR/callgrind.out.${OP}"
+    echo "Running under callgrind (op=$OP) ..."
+    echo "  Output: $OUTFILE"
+    echo ""
+
+    BISON_PROFILE_OP="$OP" valgrind \
+        --tool=callgrind \
+        --callgrind-out-file="$OUTFILE" \
+        "$BIN_OUT" 2>&1
+
+    echo ""
+    echo "=== Callgrind Summary ==="
+    echo ""
+    callgrind_annotate --auto=yes --inclusive=yes "$OUTFILE" \
+        | head -80
+    echo ""
+    echo "Full output: $OUTFILE"
+    echo "View details: callgrind_annotate --auto=yes $OUTFILE | less"
+    echo "GUI viewer:   kcachegrind $OUTFILE  (if installed)"
+fi
+
+echo ""
+echo "Profile complete."


### PR DESCRIPTION
## Summary

- Add `pixi run profile` to run bison benchmarks under [samply](https://github.com/mstange/samply) (or callgrind) with debug symbols, producing interactive flamegraphs for identifying hot paths during optimization sessions
- Add `pixi run check-compile` and a CI step that verifies all test and benchmark entry points compile, catching breakage that `mojo package bison/ --Werror` misses (since it only checks the bison package, not standalone files)

## Profiling infrastructure

**New files:**
- `benchmarks/bench_profile.mojo` — runs 5 key operations (sort, groupby, merge, query, csv) in tight loops for profiler sampling. Controlled by `BISON_PROFILE_OP` env var. Emits skip-JSON when unset so `run_benchmarks.sh` handles it gracefully in CI.
- `scripts/run_profile.sh` — compiles with `mojo build -g --debug-info-language C`, then runs under samply (default) or callgrind. Same debug-symbol approach as marrow's `vendor/marrow/scripts/profile.py`.
- `docs/profiling.md` — full guide: tool setup, usage, interpreting flamegraphs, common hot functions, adding new targets.

**Usage:**
```bash
pixi run profile sort           # flamegraph for sort_values
pixi run profile groupby        # flamegraph for groupby_sum
pixi run profile all            # all 5 operations
samply load profile_results/sort.samply.json  # view interactively
```

Samply is the default over callgrind because valgrind 3.22 crashes on Mojo's AVX-512 instructions (EVEX-encoded ops that VEX doesn't support).

## Compile-check CI

**New files:**
- `scripts/check_compile.sh` — runs `mojo build` on all `tests/test_*.mojo` and `benchmarks/bench_*.mojo` in parallel. Linker-only failures are reported as warnings (environment-specific), real compilation errors fail the build.
- `.github/workflows/ci.yml` — new "Compile-check all entry points" step before tests

**Pre-existing issues found by the new check:**
- `bench_builder.mojo` — type error: `PrimitiveBuilder[bool_]` incompatible with current marrow API (see follow-up issue)
- `test_functional.mojo` / `test_series_transforms.mojo` — linker-only failures with `libm` under `mojo build` (work fine with `mojo run`)

## Test plan

- [x] `pixi run profile sort` — compiles with debug symbols, runs under samply, saves profile JSON
- [x] `pixi run profile all` — profiles all 5 operations successfully
- [x] `pixi run bench` — still works (bench_profile.mojo emits skip-JSON)
- [x] `pixi run check` — no new warnings in bison package
- [x] `pixi run check-compile` — compiles all 24 entry points (21 pass, 1 pre-existing fail, 2 link-only warnings)
- [x] Pre-commit hooks all pass

https://claude.ai/code/session_016GgFqL1Wr6LnU6tcbru68d