### PR TITLE
perf: optimize Column.copy() to eliminate redundant allocations

### DIFF
--- a/bison/column.mojo
+++ b/bison/column.mojo
@@ -5346,14 +5346,18 @@ struct Column(Copyable, ImplicitlyCopyable, Movable, Sized):
     # ------------------------------------------------------------------
 
     def copy(self) -> Column:
-        """Return an independent copy of this Column."""
-        var visitor = _CopyDataVisitor()
-        self._visit(visitor)
-        var idx = self._index.copy()
-        var col = Column(self.name, visitor^.result.copy(), self.dtype, idx^)
+        """Return an independent copy of this Column.
+
+        Copies storage and typed caches directly — avoids the round-trip
+        through ``_CopyDataVisitor`` + constructor that would redundantly
+        rebuild caches and marrow storage only to overwrite them.
+        """
+        var col = Column()
+        col.name = self.name
+        col.dtype = self.dtype
+        col._index = self._index.copy()
         col._index_names = self._index_names.copy()
         col._index_name = self._index_name
-        # Copy storage backend and typed caches (always populated post-#647).
         col._storage = self._storage.copy()
         col._f64_cache = self._f64_cache.copy()
         col._int64_cache = self._int64_cache.copy()


### PR DESCRIPTION
## Summary

- **`Column.copy()` was doing ~6 heap allocations** per copy for numeric columns (visit caches → build ColumnData → copy ColumnData into constructor → constructor rebuilds caches + marrow → immediately overwrite both with copies of the originals). Steps 1–4 were pure waste.
- **Fix**: bypass the constructor entirely and copy fields directly, reducing to ~2 allocations (cache + storage).
- This makes `df["a"].sum()` on 100K rows **~9x faster** (0.65ms → 0.07ms), now **~1.3x faster than pandas**.

## Benchmarks (100K float64 rows, 200 iterations)

| Metric | Before | After |
|--------|--------|-------|
| Column extraction `df["a"]` | 0.593 ms | 0.029 ms |
| Sum computation `.sum()` | 0.007 ms | 0.007 ms |
| Combined `df["a"].sum()` | 0.646 ms | 0.071 ms |
| vs pandas ratio | 6.95x slower | **1.3x faster** |

The bottleneck was **91% column extraction overhead**, not the sum kernel (which was already 13x faster than pandas via marrow SIMD).

## Test plan

- [x] All 921 tests pass across 21 test files (`pixi run test`)
- [x] Pre-commit hooks pass (`mojo format`, `mojo package --Werror`)
- [x] Profiling script confirms extraction dropped from 0.59ms to 0.03ms

https://claude.ai/code/session_019DU5Vh5m9jRF89joRPZ8YV