### PR TITLE
fix: replace bare except: blocks in IO modules with descriptive errors

### DIFF
--- a/bison/io/csv.mojo
+++ b/bison/io/csv.mojo
@@ -81,6 +81,8 @@ def _infer_and_build_column(
         try:
             _ = atol(raw[i])
         except:
+            # atol() raises for non-integer strings; expected during dtype
+            # inference — not an error.
             all_int = False
             break
 
@@ -109,6 +111,8 @@ def _infer_and_build_column(
         try:
             _ = atof(raw[i])
         except:
+            # atof() raises for non-numeric strings; expected during dtype
+            # inference — not an error.
             all_float = False
             break
 
@@ -227,7 +231,10 @@ def read_csv(
         try:
             data_start += Int(py=skiprows.value())
         except:
-            pass  # unsupported form — ignore
+            raise Error(
+                "read_csv: 'skiprows' must be an integer, got: "
+                + String(skiprows.value())
+            )
 
     # ------------------------------------------------------------------
     # Determine the effective row limit.
@@ -241,7 +248,10 @@ def read_csv(
             if nr < max_rows:
                 max_rows = nr
         except:
-            pass
+            raise Error(
+                "read_csv: 'nrows' must be a non-negative integer, got: "
+                + String(nrows.value())
+            )
 
     # ------------------------------------------------------------------
     # Build the NA-value set (defaults + user-supplied extras).
@@ -262,7 +272,7 @@ def read_csv(
             for i in range(nvlen):
                 na_set.append(String(nv[i]))
         except:
-            # Single value rather than a list.
+            # Single scalar value rather than a list — add it directly.
             na_set.append(String(na_values.value()))
 
     # ------------------------------------------------------------------
@@ -285,12 +295,20 @@ def read_csv(
                             out_col_names.append(col_names[j])
                             break
                 except:
-                    var ci = Int(py=uc[i])
-                    if ci >= 0 and ci < ncols:
-                        col_indices.append(ci)
-                        out_col_names.append(col_names[ci])
-        except:
-            pass
+                    # Not a string — fall back to integer index.
+                    try:
+                        var ci = Int(py=uc[i])
+                        if ci >= 0 and ci < ncols:
+                            col_indices.append(ci)
+                            out_col_names.append(col_names[ci])
+                    except:
+                        raise Error(
+                            "read_csv: invalid usecols element at position "
+                            + String(i)
+                            + ": expected a column name or integer index"
+                        )
+        except e:
+            raise e^
 
     if len(col_indices) == 0:
         # No usecols filter (or it resolved to nothing) — use all columns.

--- a/bison/io/json.mojo
+++ b/bison/io/json.mojo
@@ -149,11 +149,10 @@ def _json_records_to_df(
         var key = col_names[ci]
         var py_vals = Python.evaluate("[]")
         for ri in range(n):
+            # Records may have inconsistent keys (sparse JSON); .get()
+            # returns None for missing keys instead of raising.
             var row = records[ri]
-            try:
-                py_vals.append(row[key])
-            except:
-                py_vals.append(Python.evaluate("None"))
+            py_vals.append(row.get(key))
         var col = _json_build_column(key, py_vals, n)
         cols.append(col^)
 
@@ -218,14 +217,16 @@ def read_json(
         if parsed_type == "list":
             eff_orient = "records"
         else:
-            # dict — probe for split-format keys.
+            # dict — probe for split-format keys ("columns" + "data").
+            # KeyError is expected when the dict uses a different orient;
+            # this is intentional format detection, not an error.
             var has_split = False
             try:
                 _ = parsed["columns"]
                 _ = parsed["data"]
                 has_split = True
             except:
-                pass
+                pass  # Not split format — keys absent.
             if has_split:
                 eff_orient = "split"
             else:
@@ -274,11 +275,10 @@ def read_json(
             var key = col_names[ci]
             var py_vals = Python.evaluate("[]")
             for ri in range(nrows):
+                # Row dicts may lack some column keys (sparse data);
+                # .get() returns None for missing keys.
                 var idx_key = index_keys[ri]
-                try:
-                    py_vals.append(parsed[idx_key][key])
-                except:
-                    py_vals.append(Python.evaluate("None"))
+                py_vals.append(parsed[idx_key].get(key))
             var col = _json_build_column(key, py_vals, nrows)
             cols.append(col^)
         return DataFrame(cols^)
@@ -325,10 +325,9 @@ def read_json(
             var col_dict = parsed[col_name]
             var py_vals = Python.evaluate("[]")
             for ri in range(nrows):
-                try:
-                    py_vals.append(col_dict[idx_keys[ri]])
-                except:
-                    py_vals.append(Python.evaluate("None"))
+                # Column dicts may lack some index keys (sparse data);
+                # .get() returns None for missing keys.
+                py_vals.append(col_dict.get(idx_keys[ri]))
             var col = _json_build_column(col_name, py_vals, nrows)
             cols.append(col^)
         return DataFrame(cols^)

--- a/bison/io/parquet.mojo
+++ b/bison/io/parquet.mojo
@@ -96,5 +96,12 @@ def read_parquet(
 
         return df^
     except:
-        # Unsupported Arrow types (e.g. nested, decimal) → pandas fallback.
+        # marrow does not handle all Arrow types (nested structs, decimals,
+        # maps, etc.).  Fall back to pandas which supports the full spec.
+        # Emit a warning so the fallback is visible during debugging (#682).
+        var warnings = Python.import_module("warnings")
+        warnings.warn(
+            "read_parquet: native marrow reader failed; falling back to"
+            " pandas. Pass engine='pyarrow' to skip the native path."
+        )
         return _read_parquet_pandas(path, engine, columns, filters)


### PR DESCRIPTION
## Summary

- **csv.mojo**: Raise descriptive errors for invalid `skiprows`, `nrows`, and `usecols` parameters instead of silently ignoring them; add explanatory comments to intentional type-inference try/except blocks (`atol`/`atof` probing); wrap inner `usecols` int-fallback in its own try/except with a positional error message
- **json.mojo**: Replace try/except dict key access with `.get()` for sparse JSON records (3 sites), eliminating bare except blocks entirely; add comment to the split-format probing block explaining intentional key detection
- **parquet.mojo**: Emit `warnings.warn()` when the native marrow reader fails and falls back to pandas, so the fallback is visible during debugging instead of silently swallowed

12 bare `except:` blocks across the IO modules silently swallowed parse errors. When data loading failed (malformed CSV values, invalid parameter types, bad JSON keys), users got no error information — the code silently fell through to a default path. This made debugging data-loading issues very difficult.

## Test plan

- [x] `pixi run test` — all 21 test files pass (0 failures)
- [x] `pixi run check` — zero warnings with `--Werror`
- [x] All pre-commit hooks pass (trim whitespace, no bare raise, mojo format, mojo build --Werror)
- [ ] Verify `read_csv` raises on invalid `skiprows` (e.g., `skiprows="abc"`)
- [ ] Verify `read_csv` raises on invalid `usecols` element types
- [ ] Verify `read_parquet` emits a warning when marrow fallback triggers

Closes #682

https://claude.ai/code/session_014ZJsei7ijKG8r1JWqm59fc