### PR TITLE
perf: replace O(n²) column name lookups and string concat with O(n) equivalents

### DIFF
--- a/bison/_frame.mojo
+++ b/bison/_frame.mojo
@@ -1030,14 +1030,14 @@ struct Series(Copyable, ImplicitlyCopyable, Movable):
         path : File path to write.  When empty (default) the CSV text is
                returned as a ``String``.
         """
-        var result = String()
         ref col = self._col
         var has_index = col._index_len() > 0
         var n = col.__len__()
+        var result = String(capacity=n * 32)
         for i in range(n):
             var key = col._index_label(i) if has_index else String(i)
             var val = _col_cell_str(col, i)
-            result += (
+            result.write(
                 _csv_quote_field(key, ",")
                 + ","
                 + _csv_quote_field(val, ",")

--- a/bison/index.mojo
+++ b/bison/index.mojo
@@ -30,16 +30,18 @@ struct Index(Copyable, Movable):
         return self._data.copy()
 
     def __repr__(self) -> String:
-        var s = String("Index([")
-        for i in range(len(self._data)):
+        var n = len(self._data)
+        var s = String(capacity=n * 16)
+        s.write("Index([")
+        for i in range(n):
             if i > 0:
-                s += ", "
-            s += "'" + self._data[i] + "'"
-        s += "]"
+                s.write(", ")
+            s.write("'" + self._data[i] + "'")
+        s.write("]")
         if self.name:
-            s += ", name='" + self.name + "'"
-        s += ")"
-        return s
+            s.write(", name='" + self.name + "'")
+        s.write(")")
+        return s^
 
     def get_loc(self, key: String) raises -> Int:
         for i in range(len(self._data)):

--- a/bison/reshape/_concat.mojo
+++ b/bison/reshape/_concat.mojo
@@ -1,5 +1,5 @@
 from std.python import Python, PythonObject
-from std.collections import Optional
+from std.collections import Optional, Dict, Set
 from ..dataframe import DataFrame, _sort_col_names
 from ..column import Column, NullMask
 from ..dtypes import BisonDtype, int64, float64, bool_, object_, string_
@@ -200,6 +200,26 @@ def _dtype_for(dfs: List[DataFrame], col_name: String) raises -> BisonDtype:
     return object_
 
 
+def _dtype_for_mapped(
+    dfs: List[DataFrame],
+    name_maps: List[Dict[String, Int]],
+    col_name: String,
+) raises -> BisonDtype:
+    """Like _dtype_for but uses pre-built name→index maps for O(1) lookups."""
+    var result: Optional[BisonDtype] = None
+    for i in range(len(dfs)):
+        if col_name in name_maps[i]:
+            var j = name_maps[i][col_name]
+            var dt = dfs[i]._cols[j].dtype
+            if result:
+                result = _promote_dtype(result.value(), dt)
+            else:
+                result = dt
+    if result:
+        return result.value()
+    return object_
+
+
 def _common_dtype(pieces: List[Column]) -> Optional[BisonDtype]:
     """Return the shared dtype if all pieces use the same typed data arm.
 
@@ -394,48 +414,51 @@ def _concat_axis0(
             for j in range(len(dfs[0]._cols)):
                 col_names.append(dfs[0]._cols[j].name.value())
             for i in range(1, len(dfs)):
+                var col_set = Set[String]()
+                for j in range(len(dfs[i]._cols)):
+                    col_set.add(dfs[i]._cols[j].name.value())
                 var keep = List[String]()
                 for k in range(len(col_names)):
-                    var found = False
-                    for j in range(len(dfs[i]._cols)):
-                        if dfs[i]._cols[j].name == col_names[k]:
-                            found = True
-                    if found:
+                    if col_names[k] in col_set:
                         keep.append(col_names[k])
                 col_names = keep^
     else:
         # Outer (default): union of all column names, first-seen order.
+        var seen = Set[String]()
         for i in range(len(dfs)):
             for j in range(len(dfs[i]._cols)):
                 var name = dfs[i]._cols[j].name.value()
-                var seen = False
-                for k in range(len(col_names)):
-                    if col_names[k] == name:
-                        seen = True
-                if not seen:
+                if name not in seen:
                     col_names.append(name)
+                    seen.add(name)
 
     if sort:
         col_names = _sort_col_names(col_names)
 
     # 2. For each output column, gather one piece from every DataFrame and stack.
+    # Pre-build name→column-index maps for O(1) lookups per DataFrame.
+    var name_maps = List[Dict[String, Int]]()
+    for i in range(len(dfs)):
+        var m = Dict[String, Int]()
+        for j in range(len(dfs[i]._cols)):
+            m[dfs[i]._cols[j].name.value()] = j
+        name_maps.append(m^)
+
     var result_cols = List[Column]()
     for c in range(len(col_names)):
         var col_name = col_names[c]
-        var dtype = _dtype_for(dfs, col_name)
+        var dtype = _dtype_for_mapped(dfs, name_maps, col_name)
         var pieces = List[Column]()
         for i in range(len(dfs)):
             var nrows = dfs[i].shape()[0]
-            var found = False
-            for j in range(len(dfs[i]._cols)):
-                if dfs[i]._cols[j].name == col_name:
-                    var piece = dfs[i]._cols[j].copy()
-                    # Cast to promoted dtype if this frame's column differs.
-                    if piece.dtype != dtype:
-                        piece = piece._astype(dtype)
-                    pieces.append(piece^)
-                    found = True
-            if not found:
+            if col_name in name_maps[i]:
+                var j = name_maps[i][col_name]
+                var piece = dfs[i]._cols[j].copy()
+                # Cast to promoted dtype if this frame's column differs.
+                if piece.dtype != dtype:
+                    piece = piece._astype(dtype)
+                pieces.append(piece^)
+            else:
                 pieces.append(_null_col(col_name, nrows, dtype))
         result_cols.append(_vstack(pieces))
 


### PR DESCRIPTION
Closes #684

## Summary

- **`_concat.mojo`**: replace triple-nested column name loops with `Set`/`Dict` lookups
  - Inner join intersection: build a `Set[String]` per DataFrame for O(1) membership test
  - Outer join union: track seen names with a `Set[String]` — eliminates O(seen) scan per name
  - Piece-finding loop: pre-build `name_maps: List[Dict[String, Int]]` once upfront; new `_dtype_for_mapped` uses them — step 2 drops from O(D×C²) to O(D×C)
- **`_frame.mojo`** — `Series.to_csv`: replace `result += (...)` in loop with `String(capacity=n*32)` + `write()` — avoids full-string copy on every row
- **`index.mojo`** — `Index.__repr__`: same `capacity` + `write()` pattern

## Test plan

- [x] `pixi run test` — 96/96 pass
- [x] `pixi run check` — zero warnings