### PR TITLE
bench: gut query/eval bodies instead of skipping whole files

### DIFF
--- a/benchmarks/bench_core.mojo
+++ b/benchmarks/bench_core.mojo
@@ -199,147 +199,21 @@ def main() raises:
         )
 
     # ------------------------------------------------------------------
-    # query_simple  (native single-condition filter via df.query)
+    # query_simple, query_and, query_or, eval_expr, query_size_1k,
+    # query_size_10k  (native df.query / df.eval pipeline)
     #
-    # Uses the native parse+eval+mask pipeline; no pandas round-trip.
-    # Comparison baseline uses boolean-index pandas (not pd.query) so
-    # both sides use the cheapest available path.
+    # Disabled: calling df.query/df.eval from this file currently triggers
+    # a 10+ minute mojo compile (see #708). The benchmarks are emitted as
+    # skipped so the dashboard keeps the series column and starts graphing
+    # again as soon as upstream mojo is fixed and the full bodies are
+    # restored.
     # ------------------------------------------------------------------
-    skipped = False
-    try:
-        var t0 = perf_counter_ns()
-        for _ in range(MED_ITERS):
-            _ = df.query("a > 0.5")
-        bison_ms = _elapsed_ms(t0, MED_ITERS)
-    except e:
-        if "not implemented" in String(e):
-            skipped = True
-        else:
-            raise e^
-    pandas_ms = _time_pandas("pd_df[pd_df['a'] > 0.5]", g, MED_ITERS)
-    if skipped:
-        results.append(BenchResult.skipped_result("query_simple"))
-    else:
-        results.append(
-            BenchResult("query_simple", bison_ms, pandas_ms, MED_ITERS)
-        )
-
-    # ------------------------------------------------------------------
-    # query_and  (native two-condition AND filter via df.query)
-    #
-    # Both logical connectives and comparisons are evaluated natively
-    # without a pandas round-trip.  Pandas baseline uses boolean-index
-    # form which avoids pd.eval overhead.
-    # ------------------------------------------------------------------
-    skipped = False
-    try:
-        var t0 = perf_counter_ns()
-        for _ in range(MED_ITERS):
-            _ = df.query("a > 0.5 and b < 0.3")
-        bison_ms = _elapsed_ms(t0, MED_ITERS)
-    except e:
-        if "not implemented" in String(e):
-            skipped = True
-        else:
-            raise e^
-    pandas_ms = _time_pandas(
-        "pd_df[(pd_df['a'] > 0.5) & (pd_df['b'] < 0.3)]", g, MED_ITERS
-    )
-    if skipped:
-        results.append(BenchResult.skipped_result("query_and"))
-    else:
-        results.append(BenchResult("query_and", bison_ms, pandas_ms, MED_ITERS))
-
-    # ------------------------------------------------------------------
-    # query_or  (native two-condition OR filter via df.query)
-    # ------------------------------------------------------------------
-    skipped = False
-    try:
-        var t0 = perf_counter_ns()
-        for _ in range(MED_ITERS):
-            _ = df.query("a > 0.8 or b > 0.8")
-        bison_ms = _elapsed_ms(t0, MED_ITERS)
-    except e:
-        if "not implemented" in String(e):
-            skipped = True
-        else:
-            raise e^
-    pandas_ms = _time_pandas(
-        "pd_df[(pd_df['a'] > 0.8) | (pd_df['b'] > 0.8)]", g, MED_ITERS
-    )
-    if skipped:
-        results.append(BenchResult.skipped_result("query_or"))
-    else:
-        results.append(BenchResult("query_or", bison_ms, pandas_ms, MED_ITERS))
-
-    # ------------------------------------------------------------------
-    # eval_expr  (native df.eval returning a boolean Series)
-    #
-    # df.eval("a > 0.5") runs the same parse+eval pipeline as df.query
-    # but returns the raw boolean mask instead of filtering rows.
-    # ------------------------------------------------------------------
-    skipped = False
-    try:
-        var t0 = perf_counter_ns()
-        for _ in range(MED_ITERS):
-            _ = df.eval("a > 0.5")
-        bison_ms = _elapsed_ms(t0, MED_ITERS)
-    except e:
-        if "not implemented" in String(e):
-            skipped = True
-        else:
-            raise e^
-    pandas_ms = _time_pandas("pd_df['a'] > 0.5", g, MED_ITERS)
-    if skipped:
-        results.append(BenchResult.skipped_result("eval_expr"))
-    else:
-        results.append(BenchResult("eval_expr", bison_ms, pandas_ms, MED_ITERS))
-
-    # ------------------------------------------------------------------
-    # query_size_1k / query_size_10k
-    #
-    # Size sweep for the simple single-condition filter at 1 K and 10 K
-    # rows.  Together with query_simple (100 K rows above) these three
-    # data points make the native-path overhead trend visible across
-    # representative sizes.
-    # ------------------------------------------------------------------
-    skipped = False
-    try:
-        var t0 = perf_counter_ns()
-        for _ in range(MED_ITERS):
-            _ = df_1k.query("a > 0.5")
-        bison_ms = _elapsed_ms(t0, MED_ITERS)
-    except e:
-        if "not implemented" in String(e):
-            skipped = True
-        else:
-            raise e^
-    pandas_ms = _time_pandas("pd_df_1k[pd_df_1k['a'] > 0.5]", g, MED_ITERS)
-    if skipped:
-        results.append(BenchResult.skipped_result("query_size_1k"))
-    else:
-        results.append(
-            BenchResult("query_size_1k", bison_ms, pandas_ms, MED_ITERS)
-        )
-
-    skipped = False
-    try:
-        var t0 = perf_counter_ns()
-        for _ in range(MED_ITERS):
-            _ = df_10k.query("a > 0.5")
-        bison_ms = _elapsed_ms(t0, MED_ITERS)
-    except e:
-        if "not implemented" in String(e):
-            skipped = True
-        else:
-            raise e^
-    pandas_ms = _time_pandas("pd_df_10k[pd_df_10k['a'] > 0.5]", g, MED_ITERS)
-    if skipped:
-        results.append(BenchResult.skipped_result("query_size_10k"))
-    else:
-        results.append(
-            BenchResult("query_size_10k", bison_ms, pandas_ms, MED_ITERS)
-        )
+    results.append(BenchResult.skipped_result("query_simple"))
+    results.append(BenchResult.skipped_result("query_and"))
+    results.append(BenchResult.skipped_result("query_or"))
+    results.append(BenchResult.skipped_result("eval_expr"))
+    results.append(BenchResult.skipped_result("query_size_1k"))
+    results.append(BenchResult.skipped_result("query_size_10k"))
 
     # ------------------------------------------------------------------
     # iloc_row  (single integer-position row access via df.iloc())

--- a/benchmarks/bench_profile.mojo
+++ b/benchmarks/bench_profile.mojo
@@ -91,13 +91,15 @@ def _profile_merge(df: DataFrame, df2: DataFrame, iters: Int) raises:
 
 
 def _profile_query(df: DataFrame, iters: Int) raises:
-    """Profile DataFrame.query with a compound expression."""
-    print("  query (a > 0.5 and b < 0.3) ...", end="")
-    var t0 = perf_counter_ns()
-    for _ in range(iters):
-        _ = df.query("a > 0.5 and b < 0.3")
-    var ms = _elapsed_ms(t0, iters)
-    print(" ", ms, "ms/call")
+    """Profile DataFrame.query with a compound expression.
+
+    Disabled body: calling `df.query` from this file currently triggers a
+    10+ minute mojo compile (see #708). Restore the inner loop once
+    upstream mojo is fixed.
+    """
+    print("  query (a > 0.5 and b < 0.3) ... [skipped — #708]")
+    _ = df
+    _ = iters
 
 
 def _profile_csv(df: DataFrame, iters: Int) raises:

--- a/scripts/check_compile.sh
+++ b/scripts/check_compile.sh
@@ -45,25 +45,9 @@ fi
 
 # Collect entry-point files: benchmarks only.
 # Tests are validated by the test runner (run_tests.sh).
-#
-# Benchmarks that call DataFrame.query/eval (bench_core, bench_profile) are
-# excluded: the query expression plumbing hits a known mojo-nightly compile
-# slowness (10+ minutes per file) that makes this parallel check unusable.
-# The query/eval code path is already exercised by tests/test_expr.mojo in
-# the regular test suite, and the benchmarks themselves are exercised by
-# scripts/run_benchmarks.sh when the dashboard is updated.
-SKIP=( "bench_core.mojo" "bench_profile.mojo" )
 FILES=()
 for f in "$REPO_ROOT"/benchmarks/bench_*.mojo; do
-    [ -f "$f" ] || continue
-    skip=0
-    for s in "${SKIP[@]}"; do
-        if [ "$(basename "$f")" = "$s" ]; then
-            skip=1
-            break
-        fi
-    done
-    [ "$skip" -eq 0 ] && FILES+=("$f")
+    [ -f "$f" ] && FILES+=("$f")
 done
 
 echo "Compile-checking ${#FILES[@]} files ..."

--- a/scripts/run_benchmarks.sh
+++ b/scripts/run_benchmarks.sh
@@ -59,11 +59,17 @@ blob_dir, commit, timestamp, ref, out_file = sys.argv[1:]
 all_results = []
 for path in sorted(glob.glob(os.path.join(blob_dir, "*.json"))):
     with open(path) as f:
-        try:
-            data = json.load(f)
-            all_results.extend(data.get("results", []))
-        except json.JSONDecodeError:
-            print(f"WARNING: could not parse {path}", file=sys.stderr)
+        # Benchmarks may emit `# ...` comment lines alongside the JSON
+        # envelope (e.g. bench_builder prints the optimizer-escape sink
+        # value). Strip them so the remainder parses as JSON.
+        raw = "".join(
+            line for line in f if not line.lstrip().startswith("#")
+        )
+    try:
+        data = json.loads(raw)
+        all_results.extend(data.get("results", []))
+    except json.JSONDecodeError:
+        print(f"WARNING: could not parse {path}", file=sys.stderr)
 
 envelope = {
     "commit": commit,


### PR DESCRIPTION
## Summary

Instead of skipping the whole `bench_core` and `bench_profile` entry points (which would lose sort/groupby/merge/csv/iloc/apply/etc coverage), replace just the `df.query` / `df.eval` loops with `BenchResult.skipped_result(...)` entries. These were the only calls triggering the 10+ minute mojo-nightly compile tracked in #708. The rest of the benchmarks run unchanged.

- `bench_core.mojo`: `query_simple`, `query_and`, `query_or`, `eval_expr`, `query_size_1k`, `query_size_10k` → emitted as skipped.
- `bench_profile.mojo`: `_profile_query` body stubbed; no longer calls `df.query`.
- `scripts/check_compile.sh`: removed the whole-file skip for bench_core/bench_profile added in #707 — both compile in seconds again.
- `scripts/run_benchmarks.sh`: strip `# ...` comment lines when merging per-bench JSON output. `bench_builder` prints `# sink = ...` to keep the optimizer from eliding its loops, which previously caused the merge step to silently drop its entries.

Skipped entries keep their slot on the dashboard so they resume graphing as soon as the bodies are restored.

## Test plan

- [x] `pixi run check-compile` — all 3 files OK, ~46 s total
- [x] `pixi run bench` — all 3 files run, ~80 s wall clock; 29 result entries, 11 skipped (6 query/eval + 5 profile_*), 18 active
- [ ] Benchmarks workflow goes green on next push to main

Closes #708 for the workaround scope; the underlying compiler slowness remains tracked there.

https://claude.ai/code/session_01XHsQekhc2tev9osqB4Sphk