### PR TITLE
perf: int64 fast path in DataFrame.merge (~1.9x speedup)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ dist/
 results/
 profile_results/
 docs/data.json
+.worktrees/

--- a/bison/_frame.mojo
+++ b/bison/_frame.mojo
@@ -5025,34 +5025,59 @@ struct DataFrame(Copyable, Movable):
         for i in range(len(self._cols)):
             left_col_idx[self._cols[i].name.value()] = i
 
-        # Build right hash map: key_str → list of right row indices.
-        var right_map = Dict[String, List[Int]]()
+        # Build index lists (out_left, out_right) from the hash join.
+        # Fast path: single int64 key — avoids String allocation per row.
+        # Fallback: String-serialise each key for multi-column / non-int keys.
+        var n_left = self.shape()[0]
         var n_right = right.shape()[0]
-        for i in range(n_right):
-            var k = DataFrame._row_key_str(right, rkeys, i, right_col_idx)
-            if k not in right_map:
-                right_map[k] = List[Int]()
-            right_map[k].append(i)
-
-        # Match rows — build parallel index lists (-1 means null/unmatched side).
         var out_left = List[Int]()
         var out_right = List[Int]()
-        var n_left = self.shape()[0]
         var right_matched = List[Bool]()
         for _ in range(n_right):
             right_matched.append(False)
 
-        for i in range(n_left):
-            var k = DataFrame._row_key_str(self, lkeys, i, left_col_idx)
-            if k in right_map:
-                ref matches = right_map[k]
-                for m in range(len(matches)):
+        if (
+            len(lkeys) == 1
+            and self._cols[left_col_idx[lkeys[0]]].is_int()
+            and right._cols[right_col_idx[rkeys[0]]].is_int()
+        ):
+            var lkey_idx = left_col_idx[lkeys[0]]
+            var rkey_idx = right_col_idx[rkeys[0]]
+            var right_map = Dict[Int, List[Int]]()
+            for i in range(n_right):
+                var k = Int(right._cols[rkey_idx]._int64_cache[i])
+                if k not in right_map:
+                    right_map[k] = List[Int]()
+                right_map[k].append(i)
+            for i in range(n_left):
+                var k = Int(self._cols[lkey_idx]._int64_cache[i])
+                if k in right_map:
+                    ref matches = right_map[k]
+                    for m in range(len(matches)):
+                        out_left.append(i)
+                        out_right.append(matches[m])
+                        right_matched[matches[m]] = True
+                elif how == "left" or how == "outer":
                     out_left.append(i)
-                    out_right.append(matches[m])
-                    right_matched[matches[m]] = True
-            elif how == "left" or how == "outer":
-                out_left.append(i)
-                out_right.append(-1)
+                    out_right.append(-1)
+        else:
+            var right_map = Dict[String, List[Int]]()
+            for i in range(n_right):
+                var k = DataFrame._row_key_str(right, rkeys, i, right_col_idx)
+                if k not in right_map:
+                    right_map[k] = List[Int]()
+                right_map[k].append(i)
+            for i in range(n_left):
+                var k = DataFrame._row_key_str(self, lkeys, i, left_col_idx)
+                if k in right_map:
+                    ref matches = right_map[k]
+                    for m in range(len(matches)):
+                        out_left.append(i)
+                        out_right.append(matches[m])
+                        right_matched[matches[m]] = True
+                elif how == "left" or how == "outer":
+                    out_left.append(i)
+                    out_right.append(-1)
 
         if how == "right" or how == "outer":
             for j in range(n_right):

--- a/scripts/run_profile.sh
+++ b/scripts/run_profile.sh
@@ -149,6 +149,7 @@ mojo build \
     -I "$REPO_ROOT" \
     "$BENCH_SRC" \
     -g --debug-info-language C \
+    -Xlinker -lm \
     -o "$BIN_OUT"
 
 echo "Binary: $BIN_OUT"

--- a/tests/test_combining.mojo
+++ b/tests/test_combining.mojo
@@ -326,5 +326,94 @@ def test_merge_multikey_delimiter_no_false_match() raises:
     assert_equal(result.shape()[0], 0)
 
 
+def test_merge_inner_int64_key_all_values() raises:
+    """Verify all output column values for an int64 key join, not just counts."""
+    var pd = Python.import_module("pandas")
+    var left = DataFrame(
+        pd.DataFrame(
+            Python.evaluate("{'id': [10, 20, 30, 40], 'val': [1, 2, 3, 4]}")
+        )
+    )
+    var right = DataFrame(
+        pd.DataFrame(
+            Python.evaluate("{'id': [20, 30, 50], 'score': [200, 300, 500]}")
+        )
+    )
+    var on = List[String]()
+    on.append("id")
+    var result = left.merge(right, on=on^)
+    assert_equal(result.shape()[0], 2)
+    assert_equal(result.shape()[1], 3)
+    var id_col = result["id"]
+    assert_equal(id_col.iloc(0)[Int64], Int64(20))
+    assert_equal(id_col.iloc(1)[Int64], Int64(30))
+    var val_col = result["val"]
+    assert_equal(val_col.iloc(0)[Int64], Int64(2))
+    assert_equal(val_col.iloc(1)[Int64], Int64(3))
+    var score_col = result["score"]
+    assert_equal(score_col.iloc(0)[Int64], Int64(200))
+    assert_equal(score_col.iloc(1)[Int64], Int64(300))
+
+
+def test_merge_inner_int64_many_to_one() raises:
+    """One left int64 key matching multiple right rows (many-to-one)."""
+    var pd = Python.import_module("pandas")
+    var left = DataFrame(
+        pd.DataFrame(Python.evaluate("{'id': [1, 2], 'a': [10, 20]}"))
+    )
+    var right = DataFrame(
+        pd.DataFrame(
+            Python.evaluate("{'id': [1, 1, 2], 'b': [100, 101, 200]}")
+        )
+    )
+    var on = List[String]()
+    on.append("id")
+    var result = left.merge(right, on=on^)
+    assert_equal(result.shape()[0], 3)
+    var id_col = result["id"]
+    assert_equal(id_col.iloc(0)[Int64], Int64(1))
+    assert_equal(id_col.iloc(1)[Int64], Int64(1))
+    assert_equal(id_col.iloc(2)[Int64], Int64(2))
+    var b_col = result["b"]
+    assert_equal(b_col.iloc(0)[Int64], Int64(100))
+    assert_equal(b_col.iloc(1)[Int64], Int64(101))
+    assert_equal(b_col.iloc(2)[Int64], Int64(200))
+
+
+def test_merge_inner_int64_no_matches() raises:
+    """Inner join on int64 key with no overlapping keys produces empty result."""
+    var pd = Python.import_module("pandas")
+    var left = DataFrame(
+        pd.DataFrame(Python.evaluate("{'id': [1, 2, 3], 'a': [10, 20, 30]}"))
+    )
+    var right = DataFrame(
+        pd.DataFrame(Python.evaluate("{'id': [4, 5, 6], 'b': [40, 50, 60]}"))
+    )
+    var on = List[String]()
+    on.append("id")
+    var result = left.merge(right, on=on^)
+    assert_equal(result.shape()[0], 0)
+
+
+def test_merge_left_int64_key() raises:
+    """Left join on int64 key preserves unmatched left rows with null right values."""
+    var pd = Python.import_module("pandas")
+    var left = DataFrame(
+        pd.DataFrame(Python.evaluate("{'id': [1, 2, 3], 'a': [10, 20, 30]}"))
+    )
+    var right = DataFrame(
+        pd.DataFrame(Python.evaluate("{'id': [1, 3], 'b': [100, 300]}"))
+    )
+    var on = List[String]()
+    on.append("id")
+    var result = left.merge(right, how="left", on=on^)
+    # All 3 left rows, row 2 (id=2) gets null b
+    assert_equal(result.shape()[0], 3)
+    var id_col = result["id"]
+    assert_equal(id_col.iloc(0)[Int64], Int64(1))
+    assert_equal(id_col.iloc(1)[Int64], Int64(2))
+    assert_equal(id_col.iloc(2)[Int64], Int64(3))
+
+
 def main() raises:
     TestSuite.discover_tests[__functions_in_module()]().run()


### PR DESCRIPTION
## Summary

- Adds a typed fast path in `DataFrame.merge` for single-key int64 joins
- Avoids one heap-allocated `String` per row on both join sides (110K allocations for the benchmark fixture)
- Fixes `run_profile.sh`: AOT build now passes `-Xlinker -lm` to avoid a linker error on glibc 2.34+

## Root cause

`merge` called `_row_key_str` for every row on both sides, which for an `int64` key:
1. Dispatched through `_visit_raises` 
2. Called `String(Int(data[row]))` — heap-allocated a new String
3. Hashed the String bytes in `Dict[String, List[Int]]`

For a plain integer key, hashing `String("12345")` is strictly worse than hashing the raw `Int` value, with no semantic benefit.

## Fix

When `len(key_cols) == 1` and both key columns have `is_int() == True`, the build and probe phases now use `Dict[Int, List[Int]]` directly. All other join configurations (multi-key, float64, string, object) fall through unchanged to the existing string-serialisation path.

## Benchmark

Measured with `pixi run profile merge` (100K × 10K inner join on integer `id`):

| | ms/call |
|---|---|
| Before | 8.1 ms |
| After | 4.3 ms |
| Speedup | ~1.9× |

## Tests

4 new tests added to `tests/test_combining.mojo`:
- `test_merge_inner_int64_key_all_values` — value-level correctness for key, left, and right columns
- `test_merge_inner_int64_many_to_one` — one left key matching multiple right rows
- `test_merge_inner_int64_no_matches` — inner join with no overlapping keys
- `test_merge_left_int64_key` — left join null-row correctness

## Test plan

- [x] All 22 combining tests pass
- [x] Full test suite passes (31/31)
- [x] `pixi run check` passes (zero warnings)
- [x] Pre-commit hooks pass (format, build --Werror)