### PR TITLE
bench: build AOT binary before running benchmarks (fixes #710)

### DIFF
--- a/scripts/run_benchmarks.sh
+++ b/scripts/run_benchmarks.sh
@@ -38,9 +38,16 @@ WARN_COUNT=0
 
 for f in "$BENCH_DIR"/bench_*.mojo; do
     name="$(basename "$f" .mojo)"
+    BIN_OUT="$TMP_DIR/$name"
+    echo "Building $name ..."
+    if ! mojo build -I "$CACHE_DIR" -I "$REPO_ROOT" "$f" -Xlinker -lm -o "$BIN_OUT"; then
+        echo "  WARNING: $name failed to build — skipping"
+        WARN_COUNT=$((WARN_COUNT + 1))
+        continue
+    fi
     echo "Running $name ..."
     blob_file="$BLOB_DIR/$name.json"
-    if mojo run -I "$CACHE_DIR" -I "$REPO_ROOT" "$f" > "$blob_file"; then
+    if "$BIN_OUT" > "$blob_file"; then
         echo "  OK"
     else
         echo "  WARNING: $name exited with non-zero status — skipping"


### PR DESCRIPTION
## Summary

- Replaces `mojo run` with `mojo build` + direct binary execution in `run_benchmarks.sh`, eliminating JIT compilation and Python startup overhead from reported benchmark numbers
- Adds `-Xlinker -lm` to the build command to avoid a linker error on `fmaxf` when building AOT
- Aligns `run_benchmarks.sh` with the approach already used in `run_profile.sh`

Fixes #710.

## Test plan

- [ ] `pixi run bench` completes without error and writes `results/latest.json`
- [ ] Reported ms/call numbers are stable across repeated runs (no JIT noise)
- [ ] Build failures for individual bench files are caught and reported as warnings, not fatal errors

https://claude.ai/code/session_017oWiYkE3B8ciquGx1KVoJN