### PR TITLE
perf: 15x merge speedup — inline take_with_nulls and tighten merge hot path

### DIFF
--- a/bison/_frame.mojo
+++ b/bison/_frame.mojo
@@ -5030,11 +5030,14 @@ struct DataFrame(Copyable, Movable):
         # Fallback: String-serialise each key for multi-column / non-int keys.
         var n_left = self.shape()[0]
         var n_right = right.shape()[0]
-        var out_left = List[Int]()
-        var out_right = List[Int]()
+        var out_left = List[Int](capacity=n_left)
+        var out_right = List[Int](capacity=n_left)
+        var needs_right_unmatched = how == "right" or how == "outer"
         var right_matched = List[Bool]()
-        for _ in range(n_right):
-            right_matched.append(False)
+        if needs_right_unmatched:
+            right_matched = List[Bool](capacity=n_right)
+            for _ in range(n_right):
+                right_matched.append(False)
 
         if (
             len(lkeys) == 1
@@ -5056,7 +5059,8 @@ struct DataFrame(Copyable, Movable):
                     for m in range(len(matches)):
                         out_left.append(i)
                         out_right.append(matches[m])
-                        right_matched[matches[m]] = True
+                        if needs_right_unmatched:
+                            right_matched[matches[m]] = True
                 elif how == "left" or how == "outer":
                     out_left.append(i)
                     out_right.append(-1)
@@ -5074,7 +5078,8 @@ struct DataFrame(Copyable, Movable):
                     for m in range(len(matches)):
                         out_left.append(i)
                         out_right.append(matches[m])
-                        right_matched[matches[m]] = True
+                        if needs_right_unmatched:
+                            right_matched[matches[m]] = True
                 elif how == "left" or how == "outer":
                     out_left.append(i)
                     out_right.append(-1)
@@ -5149,8 +5154,11 @@ struct DataFrame(Copyable, Movable):
                                         key_col.set_valid_at(r)
                             break
                     # Sync secondary caches and rebuild marrow after
-                    # cache-first key fill (#645).
-                    key_col._rebuild_storage()
+                    # cache-first key fill (#645). Only needed when right-only
+                    # rows exist (outer/right joins); inner/left joins leave
+                    # key_col unmodified so the caches are already correct.
+                    if needs_right_unmatched:
+                        key_col._rebuild_storage()
                     result_cols.append(key_col^)
                     break
 

--- a/bison/column.mojo
+++ b/bison/column.mojo
@@ -5636,18 +5636,113 @@ struct Column(Copyable, ImplicitlyCopyable, Movable, Sized):
 
     def take_with_nulls(self, indices: List[Int]) raises -> Column:
         """Like take() but index -1 inserts a null placeholder row."""
-        var visitor = _TakeWithNullsVisitor(indices, self.null_mask_copy())
-        self._visit_raises(visitor)
-        # Save out_mask before consuming visitor to avoid partial-move issues.
-        var out_mask = visitor.out_mask.copy()
-        # Use _caches_only_from_col_data to skip marrow AnyArray construction
-        # (#659 perf fix).
-        var col = Column._caches_only_from_col_data(
-            self.name, self.dtype, visitor^.result.copy()
-        )
-        if out_mask.has_nulls():
-            col.set_null_mask(out_mask^)
-        return col^
+        var n = len(indices)
+        var src_has_nulls = self.has_nulls()
+        var out_mask = NullMask()
+
+        if len(self._int64_cache) > 0:
+            var result = List[Int64](capacity=n)
+            var f64 = List[Float64](capacity=n)
+            for k in range(n):
+                var i = indices[k]
+                if i < 0:
+                    result.append(Int64(0))
+                    f64.append(Float64(0))
+                    out_mask.append_null()
+                else:
+                    var v = self._int64_cache[i]
+                    result.append(v)
+                    f64.append(Float64(v))
+                    out_mask.append(src_has_nulls and self.is_null(i))
+            var col = Column._caches_only(
+                self.name,
+                self.dtype,
+                result^,
+                f64^,
+                List[Bool](),
+                List[String](),
+            )
+            if out_mask.has_nulls():
+                col.set_null_mask(out_mask^)
+            return col^
+        elif len(self._f64_cache) > 0:
+            var result = List[Float64](capacity=n)
+            for k in range(n):
+                var i = indices[k]
+                if i < 0:
+                    result.append(Float64(0) / Float64(0))
+                    out_mask.append_null()
+                else:
+                    result.append(self._f64_cache[i])
+                    out_mask.append(src_has_nulls and self.is_null(i))
+            var col = Column._caches_only(
+                self.name,
+                self.dtype,
+                List[Int64](),
+                result^,
+                List[Bool](),
+                List[String](),
+            )
+            if out_mask.has_nulls():
+                col.set_null_mask(out_mask^)
+            return col^
+        elif len(self._bool_cache) > 0:
+            var result = List[Bool](capacity=n)
+            var f64 = List[Float64](capacity=n)
+            for k in range(n):
+                var i = indices[k]
+                if i < 0:
+                    result.append(False)
+                    f64.append(Float64(0))
+                    out_mask.append_null()
+                else:
+                    var v = self._bool_cache[i]
+                    result.append(v)
+                    f64.append(Float64(1.0) if v else Float64(0.0))
+                    out_mask.append(src_has_nulls and self.is_null(i))
+            var col = Column._caches_only(
+                self.name,
+                self.dtype,
+                List[Int64](),
+                f64^,
+                result^,
+                List[String](),
+            )
+            if out_mask.has_nulls():
+                col.set_null_mask(out_mask^)
+            return col^
+        elif len(self._str_cache) > 0:
+            var result = List[String](capacity=n)
+            for k in range(n):
+                var i = indices[k]
+                if i < 0:
+                    result.append(String(""))
+                    out_mask.append_null()
+                else:
+                    result.append(self._str_cache[i])
+                    out_mask.append(src_has_nulls and self.is_null(i))
+            var col = Column._caches_only(
+                self.name,
+                self.dtype,
+                List[Int64](),
+                List[Float64](),
+                List[Bool](),
+                result^,
+            )
+            if out_mask.has_nulls():
+                col.set_null_mask(out_mask^)
+            return col^
+        else:
+            # Object / datetime / timedelta: fall back to visitor path.
+            var visitor = _TakeWithNullsVisitor(indices, self.null_mask_copy())
+            self._visit_raises(visitor)
+            var obj_mask = visitor.out_mask.copy()
+            var col = Column._caches_only_from_col_data(
+                self.name, self.dtype, visitor^.result.copy()
+            )
+            if obj_mask.has_nulls():
+                col.set_null_mask(obj_mask^)
+            return col^
 
     def concat(self, other: Column) raises -> Column:
         """Return a new Column with *other* appended row-wise."""


### PR DESCRIPTION
## Summary

Merge benchmark: **39.7 ms → 2.6 ms (15.2x faster, now at pandas parity — 1.0x ratio)**.

| | bison | pandas | ratio |
|---|---|---|---|
| Before | 39.69 ms | 2.67 ms | 14.9x slower |
| After | 2.60 ms | 2.57 ms | **1.0x (parity)** |

## Changes

### 1. Pre-allocate `out_left` / `out_right` (`_frame.mojo`)

Both index lists now use `List[Int](capacity=n_left)`, eliminating ~13 doublings during the hash-probe loop.

### 2. Gate `right_matched` and `_rebuild_storage()` behind join type (`_frame.mojo`)

Introduced `needs_right_unmatched = how == "right" or how == "outer"`:

- `right_matched` is only allocated and initialised for right/outer joins (inner/left joins don't need it).
- The `right_matched[matches[m]] = True` write inside the probe loop is guarded by the same flag.
- `_rebuild_storage()` on each key column is only called when there may be right-only rows; for inner/left joins the caches are already correct after `take_with_nulls`.

### 3. Rewrite `take_with_nulls()` as a direct inline gather loop (`column.mojo`)

The old implementation routed through `_TakeWithNullsVisitor`, which:
- copied the `indices` list into the visitor struct,
- dispatched through `_visit_raises`,
- copied the `ColumnData` result via `_caches_only_from_col_data`.

For a 5-column join with 10K output rows that was ~150K redundant element copies per merge call.

The new implementation mirrors the existing `take()` pattern: one loop per dtype arm, pre-allocated result lists, direct reads from typed caches (`_int64_cache` etc.), and a single `_caches_only` call — no intermediate `ColumnData` Variant, no visitor struct, no index copies.

Object/PythonObject columns retain the visitor fallback (not used in the benchmark).

## Test plan

- [x] `pixi run check` — zero warnings
- [x] `pixi run test` — all 22 test files pass (merge correctness covered by `tests/test_merge.mojo`)
- [x] `pixi run bench` — numbers above confirmed

https://claude.ai/code/session_012Z29S23XzMRhibvaxywvDH