### PR TITLE
perf: eliminate null-check and bounds-check overhead in sort kernel (−17.5%)

### DIFF
--- a/bison/column.mojo
+++ b/bison/column.mojo
@@ -4131,6 +4131,13 @@ def _merge_sort_perm_comparable[
     var has_mask = len(null_mask) > 0
     var scratch = List[Int](capacity=n)
     scratch.resize(n, 0)
+    # Raw pointers into perm, scratch, and data let the inner loop skip
+    # per-access bounds checks.  All index arithmetic below keeps every
+    # access within [0, n) by construction (lo, li, ri, k, hi are
+    # derived from the merge-sort invariants).
+    var pp = perm.unsafe_ptr()
+    var sp = scratch.unsafe_ptr()
+    var dp = data.unsafe_ptr()
     var width = 1
     while width < n:
         var lo = 0
@@ -4145,8 +4152,8 @@ def _merge_sort_perm_comparable[
             var li = lo
             var ri = mid_idx
             while li < mid_idx and ri < hi:
-                var lv = perm[li]
-                var rv = perm[ri]
+                var lv = pp[li]
+                var rv = pp[ri]
                 var lnull = has_mask and null_mask[lv]
                 var rnull = has_mask and null_mask[rv]
                 var take_right: Bool
@@ -4157,26 +4164,26 @@ def _merge_sort_perm_comparable[
                 elif rnull:
                     take_right = not na_last
                 elif ascending:
-                    take_right = data[rv] < data[lv]
+                    take_right = dp[rv] < dp[lv]
                 else:
-                    take_right = data[rv] > data[lv]
+                    take_right = dp[rv] > dp[lv]
                 if take_right:
-                    scratch[k] = rv
+                    sp[k] = rv
                     ri += 1
                 else:
-                    scratch[k] = lv
+                    sp[k] = lv
                     li += 1
                 k += 1
             while li < mid_idx:
-                scratch[k] = perm[li]
+                sp[k] = pp[li]
                 li += 1
                 k += 1
             while ri < hi:
-                scratch[k] = perm[ri]
+                sp[k] = pp[ri]
                 ri += 1
                 k += 1
             for j in range(lo, hi):
-                perm[j] = scratch[j]
+                pp[j] = sp[j]
             lo += 2 * width
         width *= 2
 
@@ -5001,6 +5008,8 @@ struct Column(Copyable, ImplicitlyCopyable, Movable, Sized):
         """
         if self._storage.isa[AnyArray]():
             ref arr = self._storage[AnyArray]
+            if arr.null_count() == 0:
+                return NullMask()
             var n = len(self)
             var mask = NullMask()
             for i in range(n):

--- a/tests/test_arrow.mojo
+++ b/tests/test_arrow.mojo
@@ -291,6 +291,23 @@ def test_fast_path_anyarray_backed_with_nulls() raises:
     assert_equal(col3._str_list()[2], "c")
 
 
+def test_null_mask_copy_no_nulls_returns_empty() raises:
+    """AnyArray-backed column with no nulls: null_mask_copy returns an empty NullMask.
+
+    The sort kernel uses `len(null_mask) > 0` to decide whether to enter the
+    null-check branch on every comparison.  For a no-null column the mask must
+    be empty so the kernel uses the fast path with no null overhead.
+    """
+    var data = List[Float64]()
+    data.append(3.0)
+    data.append(1.0)
+    data.append(2.0)
+    var col = Column("a", data^, float64)
+    var col2 = marrow_array_to_column(column_to_marrow_array(col), "a")
+    var mask = col2.null_mask_copy()
+    assert_equal(len(mask), 0)
+
+
 def main() raises:
     test_int64_round_trip_no_nulls()
     test_float64_round_trip_no_nulls()
@@ -306,4 +323,5 @@ def main() raises:
     test_storage_active_bool_no_nulls()
     test_fast_path_anyarray_backed_int64()
     test_fast_path_anyarray_backed_with_nulls()
+    test_null_mask_copy_no_nulls_returns_empty()
     print("test_arrow: all tests passed")


### PR DESCRIPTION
## Summary

- `null_mask_copy()`: early-return empty `NullMask` when `AnyArray.null_count() == 0`, eliminating ~4.6% of sort cycles wasted on null-branch evaluation in the merge kernel for no-null columns
- `_merge_sort_perm_comparable`: switch `perm`, `scratch`, and `data` inner-loop accesses to `unsafe_ptr`, eliminating ~4.0% of sort cycles wasted on `check_bounds` inside a loop with proven in-bounds invariants

**Measured improvement: 22.5 ms → 18.6 ms/call on 100K rows, single float64 key (−17.5%)**

## Root causes (from perf profiling)

**Fix 1 — `null_mask_copy` always lied about having nulls for AnyArray columns.**
The function previously iterated every row and built an n-element `NullMask` even when `arr.null_count() == 0`. This made `has_mask = True` in `_merge_sort_perm_comparable`, forcing `null_mask[lv]` and `null_mask[rv]` to be evaluated on every one of the ~1.7 M merge comparisons for a no-null 100K-row column. `Column.has_nulls()` already used `null_count()` correctly; `null_mask_copy()` just needed one early-exit guard.

**Fix 2 — `List::__getitem__` bounds checks inside the hot merge loop.**
`perm[li]`, `data[rv]`, `scratch[k]`, etc. all went through `check_bounds` despite the merge-sort loop invariants (`lo ≤ li < mid_idx ≤ ri < hi ≤ n`) guaranteeing every access is in range. Switching to `unsafe_ptr` reads/writes eliminates the checks entirely.

## Test plan

- [ ] New test `test_null_mask_copy_no_nulls_returns_empty` in `tests/test_arrow.mojo` verifies Fix 1 directly (was failing before, passes after)
- [ ] All 21 test files pass (`pixi run test`)
- [ ] `pixi run check` passes (zero warnings)
- [ ] Re-profiled: 18.6 ms/call vs 22.5 ms/call baseline

## Follow-up

Issues #732 and #733 track the next opportunities: skipping the intermediate `take()` on the sort-key column (identity-perm fast path and a full indirect sort kernel).