### PR TITLE
perf: eliminate _f64_list() copy in scalar cmp and fuse two-predicate AND/OR

### DIFF
--- a/bison/column.mojo
+++ b/bison/column.mojo
@@ -2740,6 +2740,212 @@ comptime _BOOL_XOR = 2
 
 
 # ------------------------------------------------------------------
+# Fused scalar-comparison kernels (used by expr/_eval.mojo)
+# ------------------------------------------------------------------
+
+
+def _col_is_numeric_anyarray(col: Column) -> Bool:
+    """Return True if *col* has numeric/bool AnyArray storage (fuse-eligible).
+    """
+    return col._storage.isa[AnyArray]() and (
+        col.is_int() or col.is_float() or col.is_bool()
+    )
+
+
+def _str_op_to_cmp_int(op: String) raises -> Int:
+    """Convert an operator string to a _CMP_* integer constant."""
+    if op == "<":
+        return _CMP_LT
+    elif op == "<=":
+        return _CMP_LE
+    elif op == ">":
+        return _CMP_GT
+    elif op == ">=":
+        return _CMP_GE
+    elif op == "==":
+        return _CMP_EQ
+    elif op == "!=":
+        return _CMP_NE
+    raise Error("unknown comparison operator: '" + op + "'")
+
+
+def _cmp_f64_op(elem: Float64, op: Int, scalar: Float64) -> Bool:
+    """Apply a runtime _CMP_* op between a Float64 element and scalar."""
+    if op == _CMP_LT:
+        return elem < scalar
+    elif op == _CMP_LE:
+        return elem <= scalar
+    elif op == _CMP_GT:
+        return elem > scalar
+    elif op == _CMP_GE:
+        return elem >= scalar
+    elif op == _CMP_EQ:
+        return elem == scalar
+    else:
+        return elem != scalar
+
+
+def _fused_cmp_and_scalar(
+    col_a: Column,
+    op_a: Int,
+    scalar_a: Float64,
+    col_b: Column,
+    op_b: Int,
+    scalar_b: Float64,
+) raises -> Column:
+    """Evaluate ``(col_a op_a scalar_a) AND (col_b op_b scalar_b)`` in one pass.
+
+    ``op_a`` / ``op_b`` are ``_CMP_*`` integer constants.  Both columns must
+    have numeric / bool ``AnyArray`` storage (the caller is responsible for
+    verifying this before calling).  Kleene three-valued null semantics are
+    preserved: ``null AND False → False``, ``null AND True → null``.
+
+    Returns a boolean Column.
+    """
+    var n = len(col_a)
+    var result = List[Bool](capacity=n)
+    var result_mask = List[Bool]()
+    var a_has_nulls = col_a.has_nulls()
+    var b_has_nulls = col_b.has_nulls()
+    var has_any_null = False
+
+    ref a_arr = col_a._storage[AnyArray]
+    ref b_arr = col_b._storage[AnyArray]
+    var a_dt = a_arr.dtype()
+    var b_dt = b_arr.dtype()
+
+    # Hot path: both columns are float64 with no nulls (most common case).
+    if (
+        a_dt == _m_float64
+        and b_dt == _m_float64
+        and not a_has_nulls
+        and not b_has_nulls
+    ):
+        ref a = a_arr.as_float64()
+        ref b = b_arr.as_float64()
+        for i in range(n):
+            result.append(
+                _cmp_f64_op(rebind[Float64](a.unsafe_get(i)), op_a, scalar_a)
+                and _cmp_f64_op(
+                    rebind[Float64](b.unsafe_get(i)), op_b, scalar_b
+                )
+            )
+        return col_a._build_result_col(ColumnData(result^), result_mask^, False)
+
+    # General path: any numeric dtype, handles nulls with Kleene AND semantics.
+    # result_mask must be the same length as result so we always append to it.
+    var a_f64 = col_a._f64_list()
+    var b_f64 = col_b._f64_list()
+    for i in range(n):
+        var a_null = a_has_nulls and col_a.is_null(i)
+        var b_null = b_has_nulls and col_b.is_null(i)
+        if not a_null and not b_null:
+            result.append(
+                _cmp_f64_op(a_f64[i], op_a, scalar_a)
+                and _cmp_f64_op(b_f64[i], op_b, scalar_b)
+            )
+            result_mask.append(False)
+        elif a_null:
+            # null AND b: False absorbs null; True → null
+            if not b_null and not _cmp_f64_op(b_f64[i], op_b, scalar_b):
+                result.append(False)
+                result_mask.append(False)
+            else:
+                result.append(False)
+                result_mask.append(True)
+                has_any_null = True
+        else:
+            # a AND null: False absorbs null; True → null
+            if not _cmp_f64_op(a_f64[i], op_a, scalar_a):
+                result.append(False)
+                result_mask.append(False)
+            else:
+                result.append(False)
+                result_mask.append(True)
+                has_any_null = True
+    return col_a._build_result_col(
+        ColumnData(result^), result_mask^, has_any_null
+    )
+
+
+def _fused_cmp_or_scalar(
+    col_a: Column,
+    op_a: Int,
+    scalar_a: Float64,
+    col_b: Column,
+    op_b: Int,
+    scalar_b: Float64,
+) raises -> Column:
+    """Evaluate ``(col_a op_a scalar_a) OR (col_b op_b scalar_b)`` in one pass.
+
+    Like ``_fused_cmp_and_scalar`` but uses Kleene OR semantics:
+    ``null OR True → True``, ``null OR False → null``.
+    """
+    var n = len(col_a)
+    var result = List[Bool](capacity=n)
+    var result_mask = List[Bool]()
+    var a_has_nulls = col_a.has_nulls()
+    var b_has_nulls = col_b.has_nulls()
+    var has_any_null = False
+
+    ref a_arr = col_a._storage[AnyArray]
+    ref b_arr = col_b._storage[AnyArray]
+    var a_dt = a_arr.dtype()
+    var b_dt = b_arr.dtype()
+
+    # Hot path: both columns are float64 with no nulls.
+    if (
+        a_dt == _m_float64
+        and b_dt == _m_float64
+        and not a_has_nulls
+        and not b_has_nulls
+    ):
+        ref a = a_arr.as_float64()
+        ref b = b_arr.as_float64()
+        for i in range(n):
+            result.append(
+                _cmp_f64_op(rebind[Float64](a.unsafe_get(i)), op_a, scalar_a)
+                or _cmp_f64_op(rebind[Float64](b.unsafe_get(i)), op_b, scalar_b)
+            )
+        return col_a._build_result_col(ColumnData(result^), result_mask^, False)
+
+    # General path: any numeric dtype, handles nulls with Kleene OR semantics.
+    # result_mask must be the same length as result so we always append to it.
+    var a_f64 = col_a._f64_list()
+    var b_f64 = col_b._f64_list()
+    for i in range(n):
+        var a_null = a_has_nulls and col_a.is_null(i)
+        var b_null = b_has_nulls and col_b.is_null(i)
+        if not a_null and not b_null:
+            result.append(
+                _cmp_f64_op(a_f64[i], op_a, scalar_a)
+                or _cmp_f64_op(b_f64[i], op_b, scalar_b)
+            )
+            result_mask.append(False)
+        elif a_null:
+            # null OR b: True absorbs null; False → null
+            if not b_null and _cmp_f64_op(b_f64[i], op_b, scalar_b):
+                result.append(True)
+                result_mask.append(False)
+            else:
+                result.append(False)
+                result_mask.append(True)
+                has_any_null = True
+        else:
+            # a OR null: True absorbs null; False → null
+            if _cmp_f64_op(a_f64[i], op_a, scalar_a):
+                result.append(True)
+                result_mask.append(False)
+            else:
+                result.append(False)
+                result_mask.append(True)
+                has_any_null = True
+    return col_a._build_result_col(
+        ColumnData(result^), result_mask^, has_any_null
+    )
+
+
+# ------------------------------------------------------------------
 # Comparison visitor — dispatches on self's ColumnData arm and stores
 # the RHS column's data to handle the Bool-Bool fast path internally.
 # ------------------------------------------------------------------
@@ -6480,36 +6686,90 @@ struct Column(Copyable, ImplicitlyCopyable, Movable, Sized):
         ``op`` is a compile-time constant (``_CMP_*``) that selects the
         operation.  Null propagation: null elements produce a null result.
         """
-        # Storage-aware fast path using Float64 list extracted from storage.
+        # Storage-aware fast path: dispatch once on dtype, then loop reading
+        # directly from the AnyArray without an intermediate List[Float64] copy.
         if self._storage.isa[AnyArray]() and (
             self.is_int() or self.is_float() or self.is_bool()
         ):
-            var data = self._f64_list()
-            var n = len(data)
+            ref arr = self._storage[AnyArray]
+            var dt = arr.dtype()
+            var n = arr.length()
             var result = List[Bool](capacity=n)
             var result_mask = List[Bool]()
             var has_any_null = self.has_nulls()
-            for i in range(n):
-                if has_any_null and self.is_null(i):
-                    result.append(False)
-                    result_mask.append(True)
-                else:
-                    var v: Bool
-                    comptime if op == _CMP_EQ:
-                        v = data[i] == scalar
-                    elif op == _CMP_NE:
-                        v = data[i] != scalar
-                    elif op == _CMP_LT:
-                        v = data[i] < scalar
-                    elif op == _CMP_LE:
-                        v = data[i] <= scalar
-                    elif op == _CMP_GT:
-                        v = data[i] > scalar
+            if dt == _m_float64:
+                ref a = arr.as_float64()
+                for i in range(n):
+                    if has_any_null and self.is_null(i):
+                        result.append(False)
+                        result_mask.append(True)
                     else:
-                        v = data[i] >= scalar
-                    result.append(v)
-                    if has_any_null:
-                        result_mask.append(False)
+                        var elem = rebind[Float64](a.unsafe_get(i))
+                        var v: Bool
+                        comptime if op == _CMP_EQ:
+                            v = elem == scalar
+                        elif op == _CMP_NE:
+                            v = elem != scalar
+                        elif op == _CMP_LT:
+                            v = elem < scalar
+                        elif op == _CMP_LE:
+                            v = elem <= scalar
+                        elif op == _CMP_GT:
+                            v = elem > scalar
+                        else:
+                            v = elem >= scalar
+                        result.append(v)
+                        if has_any_null:
+                            result_mask.append(False)
+            elif dt == _m_int64:
+                ref a = arr.as_int64()
+                for i in range(n):
+                    if has_any_null and self.is_null(i):
+                        result.append(False)
+                        result_mask.append(True)
+                    else:
+                        var elem = Float64(rebind[Int64](a.unsafe_get(i)))
+                        var v: Bool
+                        comptime if op == _CMP_EQ:
+                            v = elem == scalar
+                        elif op == _CMP_NE:
+                            v = elem != scalar
+                        elif op == _CMP_LT:
+                            v = elem < scalar
+                        elif op == _CMP_LE:
+                            v = elem <= scalar
+                        elif op == _CMP_GT:
+                            v = elem > scalar
+                        else:
+                            v = elem >= scalar
+                        result.append(v)
+                        if has_any_null:
+                            result_mask.append(False)
+            else:
+                ref a = arr.as_bool()
+                var view = a.values()
+                for i in range(n):
+                    if has_any_null and self.is_null(i):
+                        result.append(False)
+                        result_mask.append(True)
+                    else:
+                        var elem = 1.0 if view.test(a.offset + i) else 0.0
+                        var v: Bool
+                        comptime if op == _CMP_EQ:
+                            v = elem == scalar
+                        elif op == _CMP_NE:
+                            v = elem != scalar
+                        elif op == _CMP_LT:
+                            v = elem < scalar
+                        elif op == _CMP_LE:
+                            v = elem <= scalar
+                        elif op == _CMP_GT:
+                            v = elem > scalar
+                        else:
+                            v = elem >= scalar
+                        result.append(v)
+                        if has_any_null:
+                            result_mask.append(False)
             return self._build_result_col(
                 ColumnData(result^), result_mask^, has_any_null
             )

--- a/bison/expr/_eval.mojo
+++ b/bison/expr/_eval.mojo
@@ -30,6 +30,13 @@ from ._ast import (
 )
 from ..series import Series
 from ..dataframe import DataFrame
+from ..column import (
+    Column,
+    _col_is_numeric_anyarray,
+    _fused_cmp_and_scalar,
+    _fused_cmp_or_scalar,
+    _str_op_to_cmp_int,
+)
 
 
 # ------------------------------------------------------------------
@@ -235,6 +242,73 @@ def _eval_compare(
 # ------------------------------------------------------------------
 
 
+struct _FuseCmpInfo(Copyable, Movable):
+    """Result of attempting to extract a fusible scalar comparison.
+
+    *eligible* is False when the node cannot participate in a fused kernel
+    (e.g. string/null scalar, col-vs-col, or non-numeric AnyArray storage).
+    When *eligible* is True, *col_name*, *op_int*, and *scalar* are valid.
+    """
+
+    var eligible: Bool
+    var col_name: String
+    var op_int: Int
+    var scalar: Float64
+
+    def __init__(out self):
+        self.eligible = False
+        self.col_name = String("")
+        self.op_int = 0
+        self.scalar = Float64(0.0)
+
+
+def _try_extract_fuse_cmp(
+    cmp_node_idx: Int, parsed: ParsedExpr
+) raises -> _FuseCmpInfo:
+    """Attempt to extract (col_name, op_int, scalar) from an NK_COMPARE node.
+
+    Sets *eligible = True* only when the comparison is (identifier op numeric),
+    which covers NK_FLOAT / NK_INT / NK_BOOL scalar right-hand sides.  String
+    and null literals are excluded.  Column-vs-column comparisons are excluded.
+    AnyArray eligibility is checked separately in ``_eval_node`` after column
+    resolution.
+    """
+    var info = _FuseCmpInfo()
+    var cmp_node = parsed.node_at(cmp_node_idx)
+    var lhs = parsed.node_at(cmp_node.left)
+    var rhs = parsed.node_at(cmp_node.right)
+
+    # Normalise to (identifier, op, scalar_node) form.
+    var col_name: String
+    var op_str: String
+    var scalar_node: ASTNode
+    if lhs.kind == NK_IDENT and rhs.kind != NK_IDENT:
+        col_name = lhs.value
+        op_str = cmp_node.value
+        scalar_node = rhs
+    elif rhs.kind == NK_IDENT and lhs.kind != NK_IDENT:
+        col_name = rhs.value
+        op_str = _flip_op(cmp_node.value)
+        scalar_node = lhs
+    else:
+        return info^  # col vs col, or no identifier — not fusible
+
+    # Only numeric literals are eligible (not strings or None).
+    if scalar_node.kind == NK_FLOAT:
+        info.scalar = atof(scalar_node.value)
+    elif scalar_node.kind == NK_INT:
+        info.scalar = Float64(Int(scalar_node.value))
+    elif scalar_node.kind == NK_BOOL:
+        info.scalar = 1.0 if scalar_node.value == "True" else 0.0
+    else:
+        return info^  # string / None scalar — fall back to generic path
+
+    info.col_name = col_name
+    info.op_int = _str_op_to_cmp_int(op_str)
+    info.eligible = True
+    return info^
+
+
 def _eval_node(
     node_idx: Int, parsed: ParsedExpr, df: DataFrame
 ) raises -> Series:
@@ -248,10 +322,56 @@ def _eval_node(
     elif node.kind == NK_NOT:
         return _eval_node(node.left, parsed, df).__invert__()
     elif node.kind == NK_AND:
+        # Fast path: fuse (col_a op scalar_a) AND (col_b op scalar_b).
+        if (
+            parsed.node_at(node.left).kind == NK_COMPARE
+            and parsed.node_at(node.right).kind == NK_COMPARE
+        ):
+            var a_info = _try_extract_fuse_cmp(node.left, parsed)
+            var b_info = _try_extract_fuse_cmp(node.right, parsed)
+            if a_info.eligible and b_info.eligible:
+                var a_col = _resolve_ident(a_info.col_name, df)._col
+                var b_col = _resolve_ident(b_info.col_name, df)._col
+                if _col_is_numeric_anyarray(a_col) and _col_is_numeric_anyarray(
+                    b_col
+                ):
+                    return Series(
+                        _fused_cmp_and_scalar(
+                            a_col,
+                            a_info.op_int,
+                            a_info.scalar,
+                            b_col,
+                            b_info.op_int,
+                            b_info.scalar,
+                        )
+                    )
         var left_result = _eval_node(node.left, parsed, df)
         var right_result = _eval_node(node.right, parsed, df)
         return left_result.__and__(right_result)
     elif node.kind == NK_OR:
+        # Fast path: fuse (col_a op scalar_a) OR (col_b op scalar_b).
+        if (
+            parsed.node_at(node.left).kind == NK_COMPARE
+            and parsed.node_at(node.right).kind == NK_COMPARE
+        ):
+            var a_info = _try_extract_fuse_cmp(node.left, parsed)
+            var b_info = _try_extract_fuse_cmp(node.right, parsed)
+            if a_info.eligible and b_info.eligible:
+                var a_col = _resolve_ident(a_info.col_name, df)._col
+                var b_col = _resolve_ident(b_info.col_name, df)._col
+                if _col_is_numeric_anyarray(a_col) and _col_is_numeric_anyarray(
+                    b_col
+                ):
+                    return Series(
+                        _fused_cmp_or_scalar(
+                            a_col,
+                            a_info.op_int,
+                            a_info.scalar,
+                            b_col,
+                            b_info.op_int,
+                            b_info.scalar,
+                        )
+                    )
         var left_result = _eval_node(node.left, parsed, df)
         var right_result = _eval_node(node.right, parsed, df)
         return left_result.__or__(right_result)


### PR DESCRIPTION
## Summary

Two targeted optimisations to the `query_and` / `query_or` hot path on numeric columns, addressing the 19.94× bison-vs-pandas gap identified during benchmarking.

### Improvement 1 — eliminate `_f64_list()` copy in `_cmp_scalar_op`

`_cmp_scalar_op` previously called `_f64_list()` which copies the **entire** AnyArray into a fresh `List[Float64]` (800 KB for 100 K `float64` rows) before the comparison loop. The new implementation dispatches **once** on the AnyArray dtype (`_m_float64`, `_m_int64`, `_m_bool_`) and reads each element via `unsafe_get()` inside a tight loop, removing the intermediate allocation entirely.

This affects every scalar comparison (`>`, `<`, `>=`, `<=`, `==`, `!=`) on a numeric column — a prerequisite for `query_simple`, `query_and`, `query_or`, and `eval_expr`.

### Improvement 2 — fused AND/OR predicate kernel

`_eval_node(NK_AND)` and `_eval_node(NK_OR)` now detect when both child nodes are simple `(column op numeric_scalar)` comparisons and dispatch to new `_fused_cmp_and_scalar` / `_fused_cmp_or_scalar` kernels in `column.mojo`.

These kernels evaluate **both predicates in a single pass** over the two source columns:

- **Hot path** (both columns are `float64`, no nulls — covers the benchmark): one tight loop, no allocations beyond the final `List[Bool]` result.
- **General path** (int/bool dtypes, nulls present): falls back to `_f64_list()` but still combines both predicates in one loop, avoiding two intermediate boolean `Series` + two extra `_bool_list()` copies + one `_bool_op` loop.

Kleene three-valued null semantics (`null AND False → False`, `null OR True → True`) are preserved and covered by existing tests.

The fused path is bypassed for non-eligible expressions (string/None scalars, col-vs-col, non-numeric AnyArray storage), which fall through to the existing generic path.

## What was avoided per `query_and` call (100 K float64 rows, no nulls)

| Step | Before | After |
|---|---|---|
| Eval `a > 0.5` | `_f64_list()` copy (800 KB) + bool result (100 KB) + marrow round-trip | eliminated — done inside fused loop |
| Eval `b < 0.3` | same | eliminated |
| `__and__` | `_bool_list()` × 2 + AND loop + marrow round-trip | eliminated |
| **Net** | ~3 MB allocations, ~1.7 M element ops | 1 allocation (result `List[Bool]`), 1 loop pass |

## Test plan

- [x] All 22 test files pass (`pixi run test` — 22 passed, 0 failed)
- [x] Zero warnings (`pixi run check` passes with `--Werror`)
- [x] `test_eval_null_and` and `test_eval_null_or` exercise Kleene null semantics through the new fused path
- [x] `test_conformance_query_nulls_and` and `test_conformance_query_nulls_or` verify null row exclusion matches pandas

https://claude.ai/code/session_01KqCDBE2eu3WbxL6DpNDzyZ