### PR TITLE
perf: eliminate marrow bool roundtrip and is_valid() overhead in query_and

### DIFF
--- a/benchmarks/bench_query_phases.mojo
+++ b/benchmarks/bench_query_phases.mojo
@@ -1,0 +1,158 @@
+"""Phase-level timing breakdown for query_and.
+
+Measures each sub-step of df.query("a > 0.5 and b < 0.3") independently
+to identify which phase accounts for the 17.4x pandas gap.
+
+Phases timed:
+  (A) parse only        — _parse_expr overhead
+  (B) eval only         — mask generation (compare + marrow wrap)
+  (C) filter only       — df[prebuilt_mask] (bool_list + indices + take×N)
+  (C1) filter, 1 col    — df_1col[mask] isolates fixed overhead in C
+  (C5) filter, 5 cols   — baseline
+  full query            — end-to-end, should ≈ B+C
+
+Usage:
+    mojo run benchmarks/bench_query_phases.mojo
+"""
+
+from bison import DataFrame, Series
+from bison.expr import parse, eval_expr
+from std.python import Python
+from std.time import perf_counter_ns
+
+comptime ITERS = 200
+comptime PARSE_ITERS = 10_000
+
+
+def _ms(t0: UInt, iters: Int) -> Float64:
+    return Float64(perf_counter_ns() - t0) / Float64(iters) / 1_000_000.0
+
+
+def main() raises:
+    # ------------------------------------------------------------------
+    # Build fixtures using Python.evaluate (same style as bench_core.mojo)
+    # ------------------------------------------------------------------
+    var _make5 = Python.evaluate(
+        "lambda n: __import__('pandas').DataFrame({    'key':"
+        " __import__('numpy').random.default_rng(7).choice(       "
+        " ['k0','k1','k2','k3','k4','k5','k6','k7','k8','k9'], n),    'a':  "
+        " __import__('numpy').random.default_rng(42).random(n),    'b':  "
+        " __import__('numpy').random.default_rng(123).random(n),    'c':  "
+        " __import__('numpy').random.default_rng(42).integers(0, 1000, n),   "
+        " 'id':  __import__('numpy').arange(n, dtype='int64'),})"
+    )
+    var _make1 = Python.evaluate(
+        "lambda n: __import__('pandas').DataFrame({"
+        "    'a': __import__('numpy').random.default_rng(42).random(n),"
+        "})"
+    )
+
+    var df5 = DataFrame.from_pandas(_make5(100_000))
+    var df1 = DataFrame.from_pandas(_make1(100_000))
+
+    print("query_and phase breakdown — 100k rows")
+    print("======================================")
+
+    # ------------------------------------------------------------------
+    # Full 5-col query (baseline)
+    # ------------------------------------------------------------------
+    var t0 = perf_counter_ns()
+    for _ in range(ITERS):
+        _ = df5.query("a > 0.5 and b < 0.3")
+    var full_ms = _ms(t0, ITERS)
+    print("full query (5 cols) :", full_ms, "ms/call")
+
+    # ------------------------------------------------------------------
+    # Phase A: parse only
+    # ------------------------------------------------------------------
+    t0 = perf_counter_ns()
+    for _ in range(PARSE_ITERS):
+        _ = parse("a > 0.5 and b < 0.3")
+    var parse_ms = _ms(t0, PARSE_ITERS)
+    print("A parse only        :", parse_ms, "ms/call")
+
+    # ------------------------------------------------------------------
+    # Phase B: eval only (mask generation — compare + marrow bool Column)
+    # Pre-parse once so parse overhead is excluded.
+    # ------------------------------------------------------------------
+    var parsed_and = parse("a > 0.5 and b < 0.3")
+    t0 = perf_counter_ns()
+    for _ in range(ITERS):
+        _ = eval_expr(parsed_and, df5)
+    var eval_ms = _ms(t0, ITERS)
+    print("B eval only         :", eval_ms, "ms/call")
+
+    # Single comparison — to verify AND fusion is 1-pass vs 2-pass
+    var parsed_single = parse("a > 0.5")
+    t0 = perf_counter_ns()
+    for _ in range(ITERS):
+        _ = eval_expr(parsed_single, df5)
+    var single_ms = _ms(t0, ITERS)
+    print("B single cmp        :", single_ms, "ms/call")
+    print(
+        "  AND/single ratio  :",
+        eval_ms / single_ms,
+        "x  (1.0=fused 1-pass, 2.0=not fused)",
+    )
+
+    # ------------------------------------------------------------------
+    # Phase C (5-col): filter only — df5[prebuilt_mask]
+    # ------------------------------------------------------------------
+    var mask5 = df5.eval("a > 0.5 and b < 0.3")
+    t0 = perf_counter_ns()
+    for _ in range(ITERS):
+        _ = df5[mask5]
+    var filter5_ms = _ms(t0, ITERS)
+    print("C filter (5 cols)   :", filter5_ms, "ms/call")
+
+    # ------------------------------------------------------------------
+    # Phase C1 (1-col): filter only — df1[prebuilt_mask_single]
+    # Isolates the fixed cost: bool_list() + indices build.
+    # Per-column take cost = (filter5_ms - filter1_ms) / 4
+    # ------------------------------------------------------------------
+    var mask1 = df1.eval("a > 0.5")
+    t0 = perf_counter_ns()
+    for _ in range(ITERS):
+        _ = df1[mask1]
+    var filter1_ms = _ms(t0, ITERS)
+    print("C1 filter (1 col)   :", filter1_ms, "ms/call")
+
+    var per_col_ms = (filter5_ms - filter1_ms) / 4.0
+    print("  per-col take cost :", per_col_ms, "ms  (=(C5-C1)/4)")
+    print(
+        "  fixed filter cost :",
+        filter1_ms - per_col_ms,
+        "ms  (bool_list+indices, est.)",
+    )
+
+    print("")
+    print("Summary (5-col query)")
+    print("  A parse:    ", parse_ms, "ms  (", 100.0 * parse_ms / full_ms, "%)")
+    print("  B eval:     ", eval_ms, "ms  (", 100.0 * eval_ms / full_ms, "%)")
+    print(
+        "  C filter:   ",
+        filter5_ms,
+        "ms  (",
+        100.0 * filter5_ms / full_ms,
+        "%)",
+    )
+    print(
+        "    fixed:    ",
+        filter1_ms - per_col_ms,
+        "ms  (",
+        100.0 * (filter1_ms - per_col_ms) / full_ms,
+        "%)",
+    )
+    print(
+        "    per-col:  ",
+        per_col_ms,
+        "ms x5 =",
+        per_col_ms * 5.0,
+        "ms  (",
+        100.0 * per_col_ms * 5.0 / full_ms,
+        "%)",
+    )
+    print("  total full: ", full_ms, "ms")
+    print("")
+    var npass = df5.query("a > 0.5 and b < 0.3").shape()[0]
+    print("Selectivity: ", npass, "of 100,000 rows pass the filter")

--- a/bison/_frame.mojo
+++ b/bison/_frame.mojo
@@ -38,7 +38,12 @@ from .column import (
 )
 from .accessors.str_accessor import StringMethods
 from .accessors.dt_accessor import DatetimeMethods
-from .expr import parse as _parse_expr, eval_expr as _eval_expr
+from .expr import (
+    parse as _parse_expr,
+    eval_expr as _eval_expr,
+    try_eval_fused_and_bool_list as _try_fused_and_bool_list,
+    FusedAndBoolListResult as _FusedAndBoolListResult,
+)
 from .arrow import column_to_marrow_array, marrow_array_to_column
 from marrow.arrays import AnyArray
 from marrow.builders import StringBuilder as _MarrowStringBuilder
@@ -1964,10 +1969,23 @@ struct DataFrame(Copyable, Movable):
             )
         var indices = List[Int]()
         if mask._col.is_bool():
-            var d = mask._col._bool_list()
-            for i in range(mask_len):
-                if mask._col.is_valid(i) and d[i]:
-                    indices.append(i)
+            if not mask._col.has_nulls() and mask._col._storage.isa[AnyArray]():
+                ref a = mask._col._storage[AnyArray].as_bool()
+                var view = a.values()
+                var off = a.offset
+                for i in range(mask_len):
+                    if view.test(off + i):
+                        indices.append(i)
+            else:
+                var d = mask._col._bool_list()
+                if not mask._col.has_nulls():
+                    for i in range(mask_len):
+                        if d[i]:
+                            indices.append(i)
+                else:
+                    for i in range(mask_len):
+                        if mask._col.is_valid(i) and d[i]:
+                            indices.append(i)
         else:
             raise Error(
                 "DataFrame.__getitem__: mask Series must have bool dtype"
@@ -3263,6 +3281,17 @@ struct DataFrame(Copyable, Movable):
 
     def query(self, expr: String) raises -> DataFrame:
         var parsed = _parse_expr(expr)
+        var fused = _try_fused_and_bool_list(parsed, self)
+        if fused.eligible:
+            ref d = fused.mask
+            var indices = List[Int]()
+            for i in range(len(d)):
+                if d[i]:
+                    indices.append(i)
+            var result_cols = List[Column]()
+            for i in range(len(self._cols)):
+                result_cols.append(self._cols[i].take(indices))
+            return DataFrame(result_cols^)
         var mask = _eval_expr(parsed, self)
         return self[mask]
 

--- a/bison/column.mojo
+++ b/bison/column.mojo
@@ -2868,6 +2868,32 @@ def _fused_cmp_and_scalar(
     )
 
 
+def _fused_cmp_and_bool_list(
+    col_a: Column,
+    op_a: Int,
+    scalar_a: Float64,
+    col_b: Column,
+    op_b: Int,
+    scalar_b: Float64,
+) raises -> List[Bool]:
+    """Fast path for (col_a op_a scalar_a) AND (col_b op_b scalar_b).
+
+    Both columns must be no-null float64 AnyArray. Caller is responsible for
+    verifying eligibility. Returns a ``List[Bool]`` directly — avoids the
+    marrow bitmap roundtrip when the caller only needs the raw bool values.
+    """
+    var n = len(col_a)
+    var result = List[Bool](capacity=n)
+    ref a = col_a._storage[AnyArray].as_float64()
+    ref b = col_b._storage[AnyArray].as_float64()
+    for i in range(n):
+        result.append(
+            _cmp_f64_op(rebind[Float64](a.unsafe_get(i)), op_a, scalar_a)
+            and _cmp_f64_op(rebind[Float64](b.unsafe_get(i)), op_b, scalar_b)
+        )
+    return result^
+
+
 def _fused_cmp_or_scalar(
     col_a: Column,
     op_a: Int,

--- a/bison/expr/__init__.mojo
+++ b/bison/expr/__init__.mojo
@@ -36,4 +36,8 @@ from ._ast import (
     NK_OR,
 )
 from ._parser import parse
-from ._eval import eval_expr
+from ._eval import (
+    eval_expr,
+    try_eval_fused_and_bool_list,
+    FusedAndBoolListResult,
+)

--- a/bison/expr/_eval.mojo
+++ b/bison/expr/_eval.mojo
@@ -34,6 +34,7 @@ from ..column import (
     Column,
     _col_is_numeric_anyarray,
     _fused_cmp_and_scalar,
+    _fused_cmp_and_bool_list,
     _fused_cmp_or_scalar,
     _str_op_to_cmp_int,
 )
@@ -394,3 +395,71 @@ def eval_expr(parsed: ParsedExpr, df: DataFrame) raises -> Series:
     precedence are handled by the parser.
     """
     return _eval_node(parsed.root, parsed, df)
+
+
+struct FusedAndBoolListResult(Movable):
+    """Result of ``try_eval_fused_and_bool_list``.
+
+    *eligible* is False when the expression is not a fusible no-null AND;
+    the caller should fall back to ``eval_expr`` in that case.
+    When *eligible* is True, *mask* holds the row-by-row bool values.
+    """
+
+    var eligible: Bool
+    var mask: List[Bool]
+
+    def __init__(out self):
+        self.eligible = False
+        self.mask = List[Bool]()
+
+    def __init__(out self, *, deinit take: Self):
+        self.eligible = take.eligible
+        self.mask = take.mask^
+
+
+def try_eval_fused_and_bool_list(
+    parsed: ParsedExpr, df: DataFrame
+) raises -> FusedAndBoolListResult:
+    """Try to evaluate a fused AND expression directly to ``List[Bool]``.
+
+    Returns an eligible result when the expression is a top-level AND of two
+    no-null float64 scalar comparisons — the common ``query_and`` hot path.
+    Returns non-eligible for all other expression shapes; the caller should
+    fall back to ``eval_expr``.
+
+    Skips the marrow bitmap roundtrip: the caller can iterate the returned
+    mask directly without creating or unpacking a bool Column.
+    """
+    var out = FusedAndBoolListResult()
+    var node = parsed.node_at(parsed.root)
+    if node.kind != NK_AND:
+        return out^
+    if (
+        parsed.node_at(node.left).kind != NK_COMPARE
+        or parsed.node_at(node.right).kind != NK_COMPARE
+    ):
+        return out^
+    var a_info = _try_extract_fuse_cmp(node.left, parsed)
+    var b_info = _try_extract_fuse_cmp(node.right, parsed)
+    if not a_info.eligible or not b_info.eligible:
+        return out^
+    var a_col = _resolve_ident(a_info.col_name, df)._col
+    var b_col = _resolve_ident(b_info.col_name, df)._col
+    if not _col_is_numeric_anyarray(a_col) or not _col_is_numeric_anyarray(
+        b_col
+    ):
+        return out^
+    if not a_col.is_float() or not b_col.is_float():
+        return out^
+    if a_col.has_nulls() or b_col.has_nulls():
+        return out^
+    out.eligible = True
+    out.mask = _fused_cmp_and_bool_list(
+        a_col,
+        a_info.op_int,
+        a_info.scalar,
+        b_col,
+        b_info.op_int,
+        b_info.scalar,
+    )
+    return out^


### PR DESCRIPTION
## Summary

- **6x improvement**: `query_and` drops from **17.40x** to **2.87x** vs pandas
- Three targeted fixes eliminate the two dominant hot-path costs identified by profiling

## Root cause (from phase profiling)

Phase breakdown before this PR (100k rows, `a > 0.5 and b < 0.3`):
- 84% of time in Phase C (filter): `_bool_list()` bitmap unpack + 100k `is_valid(i)` calls
- 13% in Phase B (eval): `_build_result_col` → `List[Bool]` → marrow bitmap build

## Changes

### Fix 1 — skip `is_valid(i)` for no-null masks (`_frame.mojo`)
Hoisted a single `has_nulls()` check before the filter loop. For comparison-result masks (which never have nulls), this eliminates 100k `Variant.isa[AnyArray]()` + `AnyArray.is_valid()` cross-package dispatch calls per query.

### Fix 2 — read Arrow bitmap directly in `__getitem__` (`_frame.mojo`)
When the mask Column has no nulls and uses `AnyArray` bool storage, iterate `as_bool().values().test(offset + i)` directly instead of calling `_bool_list()`. Eliminates the 100k-element `List[Bool]` allocation and the per-bit unpack loop.

### Fix 3 — bypass marrow roundtrip in `query()` fast path (`column.mojo`, `expr/_eval.mojo`)
For the common `query_and` shape — top-level AND of two no-null float64 scalar comparisons — a new `try_eval_fused_and_bool_list` function evaluates directly to `List[Bool]` via `_fused_cmp_and_bool_list`, skipping `_build_result_col` and the `List[Optional[Bool]]` → marrow bitmap conversion entirely. `query()` then iterates the list directly to build the index set.

## Benchmark results

| Benchmark | Before | After |
|-----------|--------|-------|
| `query_and` (100k rows) | 17.40x pandas | **2.87x pandas** |
| `query_simple` | — | 2.74x pandas |
| `query_or` | — | 2.59x pandas |

## Also included

`benchmarks/bench_query_phases.mojo` — phase-level timing breakdown (parse / eval / filter / per-column take) used to identify the bottlenecks.

## Test plan

- [x] `pixi run test` — 22 passed, 0 failed
- [x] `pixi run check` — no warnings
- [x] `pixi run bench` — verified ratio improvement