### PR TITLE
fix(column): grow NullMask bitmap on valid append beyond capacity

### DIFF
--- a/bison/column.mojo
+++ b/bison/column.mojo
@@ -4672,14 +4672,11 @@ struct NullMask(Copyable, Movable, Sized):
             self._builder.unsafe_set(self._length - 1)
             self._has_nulls = True
         elif self._has_nulls:
-            # Already allocated — must explicitly write a 0 bit so a
-            # previously-set bit at this index doesn't leak through after
-            # a resize.  ``resize`` zero-fills new bytes so growing alone
-            # is safe; this only matters when ``_length`` was reduced and
-            # is now growing back into reused capacity, but we keep the
-            # branch defensive.
-            if self._length <= self._capacity:
-                self._builder.unsafe_clear(self._length - 1)
+            # Grow the bitmap if needed before writing the valid bit.
+            # Without this, appending valid entries beyond the current
+            # capacity leaves uninitialized bits that read back as null.
+            self._ensure_capacity(self._length)
+            self._builder.unsafe_clear(self._length - 1)
 
     def append_null(mut self) raises:
         """Append a null marker to the mask."""

--- a/docs/superpowers/specs/2026-04-24-nullmask-bitmap-overflow-design.md
+++ b/docs/superpowers/specs/2026-04-24-nullmask-bitmap-overflow-design.md
@@ -1,0 +1,96 @@
+# NullMask bitmap overflow fix — design spec
+
+**Issue:** #756
+**Branch:** `fix/756-nullmask-bitmap-overflow`
+**Date:** 2026-04-24
+
+## Problem
+
+`NullMask.append` in `column.mojo` (~line 4667) has a capacity bug. When
+appending a valid (`False`) entry while `_has_nulls=True`, the bitmap is not
+grown if `_length > _capacity`. The `elif self._has_nulls` branch guards
+`unsafe_clear` behind `if self._length <= self._capacity`, silently skipping
+the write when capacity is exhausted. New bits beyond the old capacity are
+left uninitialized and may be read as null by `null_mask_copy()`.
+
+`null_mask_copy()` (~line 5284) rebuilds a fresh `NullMask` by iterating the
+Arrow validity bitmap and calling `append_valid` / `append_null`, so it
+inherits the bug. The underlying Column's `NullMask` (built via
+`NullMask.from_list`) is correct; only the copy used by `_ToPandasVisitor`
+is wrong.
+
+Concrete symptom: `Series.rolling(200).min().to_pandas()` on 1000 elements
+returns false `NaN` at index ~519 and beyond because the null mask copy
+overflows its 64-bit initial allocation.
+
+## Fix
+
+**File:** `bison/column.mojo`, `NullMask.append` (~line 4674)
+
+Replace:
+
+```mojo
+elif self._has_nulls:
+    if self._length <= self._capacity:
+        self._builder.unsafe_clear(self._length - 1)
+```
+
+With:
+
+```mojo
+elif self._has_nulls:
+    self._ensure_capacity(self._length)
+    self._builder.unsafe_clear(self._length - 1)
+```
+
+The `if self._length <= self._capacity` guard is removed. `_ensure_capacity`
+already handles the no-op case (returns early when `min_bits <= _capacity`)
+and grows the bitmap when needed — which is exactly what was missing.
+
+The no-nulls fast path (`_has_nulls == False`) is unaffected; no allocation
+happens when there are no nulls.
+
+## Tests (TDD — write failing tests first)
+
+### 1. Unit test — `tests/test_missing.mojo`
+
+Directly exercises `NullMask.append` across a capacity boundary:
+
+```mojo
+def test_null_mask_append_valid_grows_capacity() raises:
+    # One null activates _has_nulls and allocates 64 bits.
+    # 300 subsequent valid appends must force capacity growth and
+    # write clean 0-bits — not leave uninitialized bits as null.
+    var mask = NullMask()
+    mask.append_null()               # index 0 — null
+    for i in range(300):
+        mask.append_valid()          # indices 1–300 — valid
+    assert_true(mask.is_null(0))
+    for i in range(1, 301):
+        assert_true(mask.is_valid(i))
+```
+
+This test fails before the fix and passes after.
+
+### 2. Integration test — `tests/test_window.mojo`
+
+Exact repro from the issue:
+
+```mojo
+def test_series_rolling_large_window_no_false_nan() raises:
+    var pd = Python.import_module("pandas")
+    var vals = Python.evaluate("[float(i % 17) for i in range(1000)]")
+    var pd_s = pd.Series(vals, name="x")
+    var s = Series(pd_s, "x")
+    var result = s.rolling(200).min().to_pandas()
+    var expected = pd_s.rolling(200).min()
+    _assert_series_close(result, expected)
+```
+
+This test fails before the fix (false NaN at index ~519) and passes after.
+
+## Scope
+
+- **1 file changed:** `bison/column.mojo` (~2 lines)
+- **2 test additions:** `tests/test_missing.mojo`, `tests/test_window.mojo`
+- No API changes, no new imports, no behaviour changes outside the buggy branch

--- a/tests/test_missing.mojo
+++ b/tests/test_missing.mojo
@@ -249,10 +249,6 @@ def test_series_fillna_works() raises:
 # NullMask.append capacity growth
 # ------------------------------------------------------------------
 
-# ------------------------------------------------------------------
-# NullMask.append capacity growth
-# ------------------------------------------------------------------
-
 def test_null_mask_append_valid_grows_capacity() raises:
     """NullMask must maintain _length <= _capacity after valid appends.
 

--- a/tests/test_missing.mojo
+++ b/tests/test_missing.mojo
@@ -1,7 +1,7 @@
 """Tests for DataFrame missing-data handling."""
 from std.python import Python, PythonObject
 from std.testing import assert_true, assert_equal, TestSuite
-from bison import DataFrame, Series, DFScalar
+from bison import DataFrame, Series, DFScalar, NullMask
 
 
 # ------------------------------------------------------------------
@@ -243,6 +243,32 @@ def test_series_fillna_works() raises:
     var s = Series(pd.Series(Python.evaluate("[1.0, None, 2.0]")))
     var filled = s.fillna(DFScalar(Float64(0.0)))
     assert_true(filled.size() == 3)
+
+
+# ------------------------------------------------------------------
+# NullMask.append capacity growth
+# ------------------------------------------------------------------
+
+# ------------------------------------------------------------------
+# NullMask.append capacity growth
+# ------------------------------------------------------------------
+
+def test_null_mask_append_valid_grows_capacity() raises:
+    """NullMask must maintain _length <= _capacity after valid appends.
+
+    One null activates _has_nulls and sets capacity to 64.
+    100 subsequent valid appends must grow capacity to stay in sync.
+    Before the fix, _ensure_capacity was never called in the valid branch,
+    so _capacity stayed at 64 while _length grew to 101.
+    """
+    var mask = NullMask()
+    mask.append_null()
+    for i in range(100):
+        mask.append_valid()
+    assert_true(mask._length <= mask._capacity)
+    assert_true(mask.is_null(0))
+    for i in range(1, 101):
+        assert_true(mask.is_valid(i))
 
 
 def main() raises:

--- a/tests/test_window.mojo
+++ b/tests/test_window.mojo
@@ -321,5 +321,21 @@ def test_rolling_window_1() raises:
     _assert_frame_close(result, expected)
 
 
+def test_series_rolling_large_window_no_false_nan() raises:
+    """rolling(200).min() on 1000 elements must not produce false NaN.
+
+    The initial NullMask capacity is 64 bits; the rolling result has 800
+    valid entries. Before the fix, null_mask_copy() left bits beyond
+    capacity uninitialized, causing false NaN at index ~519 and beyond.
+    """
+    var pd = Python.import_module("pandas")
+    var vals = Python.evaluate("[float(i % 17) for i in range(1000)]")
+    var pd_s = pd.Series(vals, name="x")
+    var s = Series(pd_s, "x")
+    var result = s.rolling(200).min().to_pandas()
+    var expected = pd_s.rolling(200).min()
+    _assert_series_close(result, expected)
+
+
 def main() raises:
     TestSuite.discover_tests[__functions_in_module()]().run()


### PR DESCRIPTION
## Summary

- `NullMask.append` was not calling `_ensure_capacity` in the `elif self._has_nulls` branch, leaving `_capacity` behind `_length` and bits beyond the allocated bitmap uninitialized
- False NaN values appeared in `to_pandas()` output for any Series/DataFrame with rolling windows large enough to exceed the initial 64-bit bitmap (e.g. `rolling(200).min()` on 1000 elements failed at index 519)
- Fix: add `self._ensure_capacity(self._length)` before `unsafe_clear` in the valid-append branch, matching the pattern already used in the null-append branch

## Test Plan

- [ ] `test_null_mask_append_valid_grows_capacity` in `test_missing.mojo` — asserts `_length <= _capacity` invariant is maintained after 1 null + 100 valid appends (was failing before fix)
- [ ] `test_series_rolling_large_window_no_false_nan` in `test_window.mojo` — exact repro from the issue: `Series.rolling(200).min().to_pandas()` on 1000 elements matches pandas (was failing at index 519 before fix)
- [ ] Full test suite passes: `pixi run test`

Closes #756