### PR TITLE
fix(ci): make the nightly job actually detect drift

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -38,6 +38,9 @@ jobs:
       - name: Run tests
         run: pixi run test
 
+      - name: DELIBERATE TEST FAILURE (temporary, will be reverted)
+        run: exit 1
+
       - name: File or update tracking issue on failure
         if: failure()
         uses: actions/github-script@v7

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -15,16 +15,17 @@ jobs:
     timeout-minutes: 30
     permissions:
       contents: read
+      issues: write
 
     steps:
       - uses: actions/checkout@v6
         with:
           submodules: true
 
-      - name: Switch to Mojo nightly channel
+      - name: Float to latest nightly MAX build
         run: |
           sed -i \
-            's|https://conda.modular.com/max"|https://conda.modular.com/max-nightly"|g' \
+            -E 's|max = "==[^"]+"|max = "*"|; s|mblack = "==[^"]+"|mblack = "*"|' \
             pixi.toml
 
       - uses: prefix-dev/setup-pixi@v0.9.5
@@ -36,3 +37,34 @@ jobs:
 
       - name: Run tests
         run: pixi run test
+
+      - name: File or update tracking issue on failure
+        if: failure()
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const label = 'nightly-broken';
+            const title = 'Nightly build is broken against latest Mojo/MAX';
+            const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+            const { data: issues } = await github.rest.issues.listForRepo({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: 'open',
+              labels: label,
+            });
+            if (issues.length > 0) {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issues[0].number,
+                body: `Still failing: ${runUrl}`,
+              });
+            } else {
+              await github.rest.issues.create({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                title,
+                labels: [label],
+                body: `The scheduled nightly build failed against the latest MAX nightly.\n\nRun: ${runUrl}`,
+              });
+            }

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -38,9 +38,6 @@ jobs:
       - name: Run tests
         run: pixi run test
 
-      - name: DELIBERATE TEST FAILURE (temporary, will be reverted)
-        run: exit 1
-
       - name: File or update tracking issue on failure
         if: failure()
         uses: actions/github-script@v7


### PR DESCRIPTION
## Summary
- The nightly workflow's channel-switch sed was a no-op (pixi.toml already points at max-nightly), and the exact `==` version pin meant the job silently re-tested the same committed build every day instead of catching drift. This is why months of incompatibility went unnoticed before this project's Mojo/MAX toolchain was revived.
- Floats the nightly job's max/mblack pins to `*` instead of re-testing the committed version, so the daily job actually resolves against whatever's newest in the channel.
- Files/updates a `nightly-broken`-labeled tracking issue on failure so drift produces a durable, visible signal instead of only a red X in the Actions tab.

## Test plan
- [x] Manually triggered the workflow on this branch — confirmed via the job log that pixi performs a real solve (not a cached/pinned re-read) against the max-nightly channel. The solved build matched the currently pinned version, since no newer nightly has been published since it landed a few days ago — this reflects the state of the channel, not the fix.
- [x] Confirmed the failure path: pushed a deliberate `exit 1` step, re-ran the workflow, verified it filed a `nightly-broken`-labeled tracking issue (#767) with the correct title/body/run link, then closed that test issue and reverted the deliberate-failure scaffolding — final diff matches only the intended nightly.yml changes.